### PR TITLE
docs: add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,7 @@ git push -u origin <YOUR_BRANCH>
   - PR 只包括测试用例的变更；
 - 在 48 小时之内，没有 Collaborator 要求更改；
 - 所有关于新特性与缺陷修复的 PR 都必须包含对应测试用例；
+- 如果在 `packages/design` 下面添加新的组件，需要包含一个 storybook 作为组件文档；
 
 ## 如何成为 Collaborator
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,8 @@
 
 ## 开始
 
-- 通过右上角的 Fork 按钮将这个 [repo](https://github.com/bangumi/frontend) fork 到自己的账号下面。
+- 通过右上角的 Fork 按钮或者点击[这个链接](https://github.com/bangumi/frontend)
+  将 [repo](https://github.com/bangumi/frontend) fork 到自己的账号下面。
 - 通过 SSH，GitHub CLI 或者 HTTP clone 你的 fork。
 
 ```bash
@@ -38,8 +39,8 @@ pnpm test
 pnpm lint
 ```
 
-- Commit 你的工作，commit message 需要遵守 [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) 规范
-- Push 到你的分支上
+- Commit 你的工作
+- 开发完成后，Push 到你的分支上
 
 ```bash
 git push -u origin <YOUR_BRANCH>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,8 +87,3 @@ By making a contribution to this project, I certify that:
   a record of the contribution (including all personal information I submit with it,
   including my sign-off) is maintained indefinitely and may be redistributed consistent
   with this project or the open source license(s) involved.
-
-[Storybook]: https://storybook.js.org/
-[`squash`]: https://help.github.com/en/articles/about-pull-request-merges#squash-and-merge-your-pull-request-commits
-[conventional commits]: https://www.conventionalcommits.org/
-[nodejs.dev repo]: https://github.com/nodejs/nodejs.dev

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,94 @@
+# Bangumi Frontend 项目贡献指南
+
+首先欢迎为新 Bangumi 的前端项目添砖加瓦。
+
+## 开始
+
+- 通过右上角的 Fork 按钮将这个 [repo](https://github.com/bangumi/frontend) fork 到自己的账号下面。
+- 通过 SSH，GitHub CLI 或者 HTTP clone 你的 fork。
+
+```bash
+git clone git@github.com:<GITHUB_ID>/frontend # SSH
+gh repo clone <GITHUB_ID>/frontend # GitHub CLI
+git clone https://github.com/<GITHUB_ID>/frontend # HTTPS
+```
+
+- 进入项目目录
+
+```bash
+cd frontend
+```
+
+- 将 bangumi/frontend 添加为 `upstream`
+
+```bash
+git remote add upstream https://github.com/bangumi/frontend.git
+```
+
+- 为你的工作创建一个新的分支
+
+```bash
+git checkout -b <BRANCH_NAME>
+```
+
+- 提交前确认所有的测试、lint 通过；
+
+```bash
+pnpm test
+pnpm lint
+```
+
+- Commit 你的工作，commit message 需要遵守 [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) 规范
+- Push 到你的分支上
+
+```bash
+git push -u origin <YOUR_BRANCH>
+```
+
+- 开一个新的 Pull Request，详细参见 [PR 规则](#pr-规则)。
+
+## PR 规则
+
+- PR 的标题需要满足 [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) 规范的要求
+
+### 在合并之前
+
+- 每一个 PR 都将会被打开至少 48 小时，以便所有 Collaborator 都有机会看到 PR，
+  提出建议。以下情况除外：
+  - PR 只包含 typo 的修复；
+  - PR 只关于项目架构的维护（如 Github Action 的维护）；
+  - PR 只包括测试用例的变更；
+- 在 48 小时之内，没有 Collaborator 要求更改；
+- 所有关于新特性与缺陷修复的 PR 都必须包含对应测试用例；
+
+## 如何成为 Collaborator
+
+- Collaborator 需要对项目作出活跃的贡献；
+- 想要成为 Collaborator 的话，需要向 `README.md` 文件的 Collaborator 小节提起 PR，
+  将自己添加到 Collaborator 列表中（注意列表以 GitHub ID 的字典序排列）；
+- PR 需要被至少一名 Collaborator approve；
+- PR 在打开 48 小时之后没有反对意见；
+- 当上述条件满足，PR 将会被合并，然后邀请新同学成为 @bangumi/frontend 组的成员；
+
+## Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+- (a) The contribution was created in whole or in part by me and I have the right to
+  submit it under the open source license indicated in the file; or
+- (b) The contribution is based upon previous work that, to the best of my knowledge,
+  is covered under an appropriate open source license and I have the right under that
+  license to submit that work with modifications, whether created in whole or in part
+  by me, under the same open source license (unless I am permitted to submit under a
+  different license), as indicated in the file; or
+- (c) The contribution was provided directly to me by some other person who certified
+  (a), (b) or (c) and I have not modified it.
+- (d) I understand and agree that this project and the contribution are public and that
+  a record of the contribution (including all personal information I submit with it,
+  including my sign-off) is maintained indefinitely and may be redistributed consistent
+  with this project or the open source license(s) involved.
+
+[Storybook]: https://storybook.js.org/
+[`squash`]: https://help.github.com/en/articles/about-pull-request-merges#squash-and-merge-your-pull-request-commits
+[conventional commits]: https://www.conventionalcommits.org/
+[nodejs.dev repo]: https://github.com/nodejs/nodejs.dev

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Bangumi Front-end Project
+# Bangumi Frontend Project
 
 Bangumi 新前端项目，基于 React/TypeScript/Vite。
 
@@ -30,3 +30,9 @@ pnpm lint
 由于 pnpm 对 exFAT 格式的硬盘支持不佳，见 [issue](https://github.com/pnpm/pnpm/issues/3952)，
 在 exFAT 格式的分区上启动项目可能报 `ENOENT: no such file or directory` 错误。
 在上游修复之前，建议在 NTFS 格式的硬盘上存储本项目。
+
+## 项目成员
+
+### Collaborators
+
+- [Ayase-252](https://github.com/Ayase-252)<<i@ayase-lab.com>>

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ pnpm lint
 在 exFAT 格式的分区上启动项目可能报 `ENOENT: no such file or directory` 错误。
 在上游修复之前，建议在 NTFS 格式的硬盘上存储本项目。
 
+## 如何参与开发
+
+见[贡献指南](./CONTRIBUTING.md)。
+
 ## 项目成员
 
 ### Collaborators


### PR DESCRIPTION
仿照 nodejs/nodejs.dev 那边的做法写了个贡献指南。

为了防止 PR 长时间没人 review，也仿照 nodejs/nodejs.dev 组的做法，添加了个自愿申请 Collaborator 的程序，看看可不可行？ 👀 