### PR TITLE
feat: add subject type, convert api to camelcase

### DIFF
--- a/packages/website/src/App.test.tsx
+++ b/packages/website/src/App.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import App from './App'
-import { render } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
 
 describe('App', () => {
   it('should increase counter by 1 after clicking count button', () => {
@@ -11,5 +12,16 @@ describe('App', () => {
     countButton.click()
 
     expect(getByText('1'))
+  })
+  it('should load character and subject', async () => {
+    const { getByText } = render(<App />)
+    const characterName = 'うずまきボルト'
+    await waitFor(() => getByText(characterName), { timeout: 6000 })
+
+    expect(getByText(characterName))
+
+    const subjectName = 'BLACK WOLVES SAGA -Bloody Nightmare-'
+    await waitFor(() => getByText(subjectName), { timeout: 6000 })
+    expect(getByText(subjectName)).toBeInTheDocument()
   })
 })

--- a/packages/website/src/App.tsx
+++ b/packages/website/src/App.tsx
@@ -2,13 +2,20 @@ import React, { useState, FC, useEffect } from 'react'
 import { Button, Typography } from '@bangumi/design'
 import style from './App.module.css'
 import { getCharacterDetail } from './api/character'
-import { CharacterDetail } from './types/common'
+import { getSubject } from './api/subject'
+import { CharacterDetail, Subject } from './types/common'
 const App: FC = () => {
   const [count, setCount] = useState(0)
   const [detail, setDetail] = useState<CharacterDetail|null>(null)
+  const [subjectDetail, setSubjectDetail] = useState<Subject|null>(null)
   useEffect(() => {
     getCharacterDetail('39115').then(res => {
       setDetail(res.data)
+    })
+  }, [])
+  useEffect(() => {
+    getSubject('39115').then(res => {
+      setSubjectDetail(res.data)
     })
   }, [])
   return (
@@ -39,6 +46,24 @@ const App: FC = () => {
               )
             }
         <p>{detail.summary}</p>
+        </div>
+        : <div>loading</div>}
+      { subjectDetail
+        ? <div>
+        <Typography.Link href="https://bgm.tv/subject/39115"><h1>{subjectDetail.name}</h1></Typography.Link>
+            {
+              subjectDetail.infobox.map(el =>
+                <tr key={el.key}>
+                  <td>{el.key}</td>
+                  <tr>
+                    { Array.isArray(el.value)
+                      ? el.value.map(val => <p key={val.k}>{`${val.k}:${val.v}`}</p>)
+                      : el.value }
+                  </tr>
+                </tr>
+              )
+            }
+        <p>{subjectDetail.summary}</p>
         </div>
         : <div>loading</div>}
     </div>

--- a/packages/website/src/api/api.test.ts
+++ b/packages/website/src/api/api.test.ts
@@ -1,0 +1,14 @@
+import { getCharacterDetail } from './character'
+import { getSubject } from './subject'
+
+it('get CharacterDetail correctly', async () => {
+  const res = await getCharacterDetail('39115')
+  expect(res.data.birthDay).toBe(27)
+  expect(res.data.birthMon).toBe(3)
+})
+
+it('get Subject correctly', async () => {
+  const res = await getSubject('39115')
+  expect(res.data.totalEpisodes).toBe(0)
+  expect(res.data.date).toBe('2012-04-26')
+})

--- a/packages/website/src/api/api.test.ts
+++ b/packages/website/src/api/api.test.ts
@@ -1,5 +1,6 @@
 import { getCharacterDetail } from './character'
 import { getSubject } from './subject'
+import { request } from './request'
 
 it('get CharacterDetail correctly', async () => {
   const res = await getCharacterDetail('39115')
@@ -11,4 +12,10 @@ it('get Subject correctly', async () => {
   const res = await getSubject('39115')
   expect(res.data.totalEpisodes).toBe(0)
   expect(res.data.date).toBe('2012-04-26')
+})
+
+// test object in an array
+it('underscodeToCamelcase correctly', async () => {
+  const res = await request('/v0/persons/123/characters')
+  expect(res.data[0].subjectNameCn).toBe('美少女战士')
 })

--- a/packages/website/src/api/request.ts
+++ b/packages/website/src/api/request.ts
@@ -15,16 +15,29 @@ const errorHandler = (error:any) => {
   return Promise.reject(error)
 }
 
-const underscodeToCamelcase = (data:{ [k: string]: any }) => {
-  const newData: { [k: string]: any } = {}
-  for (const key in data) {
-    const newKey = key.replace(/_[a-z]/, (str):string => {
+const underscodeToCamelcase = (data:any) => {
+  if (Array.isArray(data)) {
+    data.forEach((value) => {
+      value = underscodeToCamelcase(value)
+    })
+  } else if (data !== null && typeof data === 'object') {
+    for (const key in data) {
+      if (typeof key === 'string') {
+        const newKey = underscodeToCamelcase(key)
+        if (key !== newKey) {
+          data[newKey] = data[key]
+          delete data[key]
+        }
+      }
+      if (typeof data[key] === 'object') data[key] = underscodeToCamelcase(data[key])
+    }
+  } else if (typeof data === 'string') {
+    data = data.replace(/_[a-z]/g, (str:string):string => {
       const char = str[1]
       return char.toUpperCase()
     })
-    newData[newKey] = data[key]
   }
-  return newData
+  return data
 }
 
 request.interceptors.request.use(config => {
@@ -33,6 +46,5 @@ request.interceptors.request.use(config => {
 
 request.interceptors.response.use((response) => {
   response.data = underscodeToCamelcase(response.data)
-  console.log(response)
   return response
 }, errorHandler)

--- a/packages/website/src/api/request.ts
+++ b/packages/website/src/api/request.ts
@@ -15,10 +15,24 @@ const errorHandler = (error:any) => {
   return Promise.reject(error)
 }
 
+const underscodeToCamelcase = (data:{ [k: string]: any }) => {
+  const newData: { [k: string]: any } = {}
+  for (const key in data) {
+    const newKey = key.replace(/_[a-z]/, (str):string => {
+      const char = str[1]
+      return char.toUpperCase()
+    })
+    newData[newKey] = data[key]
+  }
+  return newData
+}
+
 request.interceptors.request.use(config => {
   return config
 }, errorHandler)
 
 request.interceptors.response.use((response) => {
+  response.data = underscodeToCamelcase(response.data)
+  console.log(response)
   return response
 }, errorHandler)

--- a/packages/website/src/api/subject.ts
+++ b/packages/website/src/api/subject.ts
@@ -1,0 +1,9 @@
+import { request } from './request'
+import { Subject } from '../types/common'
+import { AxiosPromise } from 'axios'
+
+type SubjectId = string;
+
+export const getSubject = (subjectId:SubjectId):AxiosPromise<Subject> => {
+  return request(`/v0/subjects/${subjectId}`)
+}

--- a/packages/website/src/types/common.ts
+++ b/packages/website/src/types/common.ts
@@ -2,7 +2,7 @@
 type infoBox = {
   key:string,
   value:string | {
-    k:string // this can be undefined, see https://api.bgm.tv/v0/characters/321
+    k?: string
     v:string
   }[]
 }[]
@@ -48,7 +48,7 @@ type tag = {
   count: number
 }
 
-export type CharacterDetail={
+export type CharacterDetail = {
   id: number
   name: string
   type: number
@@ -72,7 +72,7 @@ export type CharacterDetail={
   }
 }
 
-export type Subject={
+export type Subject = {
   id: number
   name: string
   type: number

--- a/packages/website/src/types/common.ts
+++ b/packages/website/src/types/common.ts
@@ -1,10 +1,52 @@
+// using camelcase api
 type infoBox = {
   key:string,
   value:string | {
-    k:string
+    k:string // this can be undefined, see https://api.bgm.tv/v0/characters/321
     v:string
   }[]
 }[]
+
+type images = {
+  large: string
+  common: string
+  medium: string
+  small: string
+  grid: string
+}
+
+type count = {
+  '1': number
+  '2': number
+  '3': number
+  '4': number
+  '5': number
+  '6': number
+  '7': number
+  '8': number
+  '9': number
+  '10': number
+}
+
+type rating = {
+  rank: number
+  total: number
+  count: count
+  score: number
+}
+
+type collection = {
+  wish: number
+  collect: number
+  doing: number
+  onHold: number
+  dropped: number
+}
+
+type tag = {
+  name: string
+  count: number
+}
 
 export type CharacterDetail={
   id: number
@@ -28,4 +70,24 @@ export type CharacterDetail={
     comments: number
     collects: number
   }
+}
+
+export type Subject={
+  id: number
+  name: string
+  type: number
+  nameCn: string
+  summary: string
+  nsfw: boolean
+  locked: boolean
+  date: string // YYYY-MM-DD format
+  platform: string
+  images: images
+  infobox: infoBox
+  volumes: number
+  eps: number
+  totalEpisodes: number
+  rating: rating
+  collection: collection
+  tags: tag[]
 }


### PR DESCRIPTION
添加了Subject 类型, 并由 #31 ，将请求到的数据的键全部进行驼峰处理。（也许之后可以放到 utils 里？）