### PR TITLE
refactor: refactor api `baseURL`

### DIFF
--- a/packages/website/src/api/request.ts
+++ b/packages/website/src/api/request.ts
@@ -1,9 +1,8 @@
 import axios from 'axios'
 
-const baseURL = 'https://api.bgm.tv'
+const baseURL = (import.meta.env.VITE_APP_ROOT as string) ?? 'https://api.bgm.tv'
+
 export const request = axios.create({
-  // baseURL: import.meta.env.VITE_APP_ROOT as string,
-  // import.meta无法通过jest https://github.com/facebook/jest/issues/4842 可能需要改一下jest配置
   baseURL,
   timeout: 6000 // 请求超时时间
 })
@@ -15,19 +14,19 @@ const errorHandler = async (error: any): Promise<never> => {
   return await Promise.reject(error)
 }
 
-const underscodeToCamelcase = (data: any): string | any[] => {
+const underscoreToCamelcase = (data: any): string | any[] => {
   if (Array.isArray(data)) {
     data.forEach((value) => {
-      value = underscodeToCamelcase(value)
+      value = underscoreToCamelcase(value)
     })
   } else if (data !== null && typeof data === 'object') {
     for (const key in data) {
-      const newKey = underscodeToCamelcase(key) as string
+      const newKey = underscoreToCamelcase(key) as string
       if (key !== newKey) {
         data[newKey] = data[key]
         delete data?.key
       }
-      if (typeof data[key] === 'object') data[key] = underscodeToCamelcase(data[key])
+      if (typeof data[key] === 'object') data[key] = underscoreToCamelcase(data[key])
     }
   } else if (typeof data === 'string') {
     data = data.replace(/_[a-z]/g, (str: string): string => {
@@ -43,6 +42,6 @@ request.interceptors.request.use(config => {
 }, errorHandler)
 
 request.interceptors.response.use((response) => {
-  response.data = underscodeToCamelcase(response.data)
+  response.data = underscoreToCamelcase(response.data)
   return response
 }, errorHandler)

--- a/packages/website/src/mocks/handlers.ts
+++ b/packages/website/src/mocks/handlers.ts
@@ -1,6 +1,6 @@
 import { mockAPI } from './utils'
 
-const BASE_URL = 'https://api.bgm.tv'
+const BASE_URL = (import.meta.env.VITE_APP_ROOT as string) ?? 'https://api.bgm.tv'
 
 function buildAPIURL (path: string): string {
   return `${BASE_URL}${path}`

--- a/packages/website/src/mocks/utils.ts
+++ b/packages/website/src/mocks/utils.ts
@@ -1,4 +1,4 @@
-import { rest } from 'msw'
+import { rest, RequestHandler } from 'msw'
 import fsp from 'fs/promises'
 import path from 'path'
 
@@ -12,7 +12,7 @@ async function isFileExist (filePath: string): Promise<boolean> {
   return true
 }
 
-async function loadFixture (pathname: string, requestMethod: string): Promise<string> {
+async function loadFixture (pathname: string, requestMethod: string): Promise<Record<string, any> | any[]> {
   const fixturePath = path.join(__dirname, './fixtures', `${pathname}-GET.json`)
 
   if (!(await isFileExist(fixturePath))) {
@@ -26,7 +26,7 @@ async function loadFixture (pathname: string, requestMethod: string): Promise<st
 
 type HTTPMethods = 'get' | 'post' | 'put' | 'delete' | 'options'
 
-export function mockAPI (url: string, method: HTTPMethods): any {
+export function mockAPI (url: string, method: HTTPMethods): RequestHandler {
   return rest[method](url, (req, res, ctx) =>
     loadFixture(req.url.pathname, req.method).then(data => res(
       ctx.status(200),


### PR DESCRIPTION
- refactor api `baseURL`
- fix typo: `underscodeToCamelcase` -> `underscoreToCamelcase`
- fix msw types

`underscoreToCamelcase` 是否有存在的必要？我觉得对数据的操作应该和 API 接口返回的格式相同。前端每一次请求接口都会调用 `underscoreToCamelcase` 也是额外的性能损失 @Ayase-252 

目前用公共 API 的话也可以用 https://www.npmjs.com/package/bgm-types 减少手写 TS 接口的麻烦操作（