### PR TITLE
refactor: fix image render in Chrome

### DIFF
--- a/packages/design/components/Image/style/index.less
+++ b/packages/design/components/Image/style/index.less
@@ -8,6 +8,8 @@
   background: @loadingColor;
   object-fit: cover;
   object-position: top left;
+  /* stylelint-disable-next-line value-no-vendor-prefix */
+  image-rendering: -webkit-optimize-contrast;
 
   &:hover {
     outline: 2px solid @outlineColor;

--- a/packages/design/components/Image/style/index.less
+++ b/packages/design/components/Image/style/index.less
@@ -8,6 +8,7 @@
   background: @loadingColor;
   object-fit: cover;
   object-position: top left;
+  // https://github.com/bangumi/frontend/pull/77
   /* stylelint-disable-next-line value-no-vendor-prefix */
   image-rendering: -webkit-optimize-contrast;
 


### PR DESCRIPTION
image-rendering: auto;
在 Chrome 下缩放渲染有明显的模糊现象。Firefox 表现还不错。
在 Chrome 下使用 image-render: crisp-edges; 有明显改善。
但是 Firefox 使用会有明显的锯齿感。

不知道其它系统其他版本浏览器渲染效果怎么样（

![U9rrQ3S.png](https://i.imgur.com/U9rrQ3S.png)