### PR TITLE
ci: adjust codecov requirement

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -5,3 +5,17 @@ coverage:
   precision: 2
   round: down
   range: "80...100"
+  status:
+    default_rules:
+      flag_coverage_not_uploaded_behavior: exclude
+    project:
+      design:
+        target: auto
+        threshold: 0
+        paths:
+          - "packages/design"
+      website:
+        target: auto
+        threshold: 5
+        paths:
+          - "packages/website"


### PR DESCRIPTION
现在 CI 的状态是有点问题的。有时会有因为测试覆盖率下降产生的错误。

分开对组件库测试覆盖与网站业务代码测试覆盖率的要求。