### PR TITLE
fix: nav spacing

### DIFF
--- a/packages/website/src/components/Header/style.module.less
+++ b/packages/website/src/components/Header/style.module.less
@@ -182,7 +182,7 @@
   }
 
   .nav {
-    margin: auto;
+    margin: auto 20px;
 
     .divider {
       margin: 0 20px;

--- a/packages/website/vite.config.ts
+++ b/packages/website/vite.config.ts
@@ -36,11 +36,7 @@ export default defineConfig(({ mode }) => {
                 proxyRes.headers['set-cookie'] = setCookies.map((sc) => {
                   return sc
                     .split(';')
-                    .filter(
-                      (v) =>
-                        v.trim().toLowerCase() !== 'secure' &&
-                        v.trim().toLowerCase() !== 'samesite=none',
-                    )
+                    .filter((v) => v.trim().toLowerCase() !== 'secure')
                     .join('; ');
                 });
               }

--- a/packages/website/vite.config.ts
+++ b/packages/website/vite.config.ts
@@ -29,14 +29,18 @@ export default defineConfig(({ mode }) => {
               proxyReq.setHeader('Referer', apiDomain);
             });
             proxy.on('proxyRes', (proxyRes) => {
-              // 本地开发环境没有 https 带有 secure attribute 的 set-cookies 无效，
-              // 所以在本地开发时移除 secure attribute
+              // 本地开发环境没有 https 带有 secure 和 samesite attribute 的 set-cookies 无效，
+              // 所以在本地开发时移除 secure 和 samesite attribute
               const setCookies = proxyRes.headers['set-cookie'];
               if (Array.isArray(setCookies)) {
                 proxyRes.headers['set-cookie'] = setCookies.map((sc) => {
                   return sc
                     .split(';')
-                    .filter((v) => v.trim().toLowerCase() !== 'secure')
+                    .filter(
+                      (v) =>
+                        v.trim().toLowerCase() !== 'secure' &&
+                        v.trim().toLowerCase() !== 'samesite=none',
+                    )
                     .join('; ');
                 });
               }

--- a/packages/website/vite.config.ts
+++ b/packages/website/vite.config.ts
@@ -29,8 +29,8 @@ export default defineConfig(({ mode }) => {
               proxyReq.setHeader('Referer', apiDomain);
             });
             proxy.on('proxyRes', (proxyRes) => {
-              // 本地开发环境没有 https 带有 secure 和 samesite attribute 的 set-cookies 无效，
-              // 所以在本地开发时移除 secure 和 samesite attribute
+              // 本地开发环境没有 https 带有 secure attribute 的 set-cookies 无效，
+              // 所以在本地开发时移除 secure attribute
               const setCookies = proxyRes.headers['set-cookie'];
               if (Array.isArray(setCookies)) {
                 proxyRes.headers['set-cookie'] = setCookies.map((sc) => {


### PR DESCRIPTION
删除 samesite 以正确设置 stage 模式下的 cookie，导航栏在 1440px 宽度下会和 logo 挤在一起，一起修了。
![telegram-cloud-photo-size-1-4904716463370250851-y](https://user-images.githubusercontent.com/33192552/204091507-6e9791b5-eb17-4584-9063-8763719eb2aa.jpg)
