### PR TITLE
fix(design): test type and `include` of tsconfig

### DIFF
--- a/packages/design/components/Avatar/__test__/Avatar.test.tsx
+++ b/packages/design/components/Avatar/__test__/Avatar.test.tsx
@@ -7,7 +7,7 @@ it('Render a Avatar', () => {
   const { container } = render(<Avatar src='urlLink' />);
   const img = container.children[0];
   expect(img).toBeInTheDocument();
-  expect(img.children[0]).toHaveAttribute('src', 'urlLink');
+  expect(img?.children[0]).toHaveAttribute('src', 'urlLink');
 });
 
 it('Avatar Size', () => {

--- a/packages/design/components/Button/__test__/Button.test.tsx
+++ b/packages/design/components/Button/__test__/Button.test.tsx
@@ -3,12 +3,12 @@ import React from 'react';
 
 import Button from '../index';
 
-it.each(['primary', 'secondary', 'text'])('should render button of type %s', (type) => {
+it.each(['primary', 'secondary', 'text'] as const)('should render button of type %s', (type) => {
   const { container } = render(<Button type={type}>hello world</Button>);
   expect(container.firstChild).toMatchSnapshot();
 });
 
-it.each(['square', 'rounded'])('should render button of shape %s', (shape) => {
+it.each(['square', 'rounded'] as const)('should render button of shape %s', (shape) => {
   const { container } = render(
     <Button type='primary' shape={shape}>
       hello world

--- a/packages/design/components/Typography/__test__/Texts.spec.tsx
+++ b/packages/design/components/Typography/__test__/Texts.spec.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import Text from '../Text';
 
-it.each([undefined, 'default', 'secondary'])('should render %s text', (type) => {
+it.each([undefined, 'default', 'secondary'] as const)('should render %s text', (type) => {
   const { container } = render(<Text type={type}>hello world</Text>);
   expect(container.firstChild).toMatchSnapshot();
 });

--- a/packages/website/tsconfig.json
+++ b/packages/website/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["./src"]
+  "include": ["./src", "vite.config.ts", "jest-setup.ts"]
 }


### PR DESCRIPTION
修复三个组件的测试文件内的类型报错。
website 的 tsconfig 应该包含 `vite.config.ts` 和 `jest-setup.ts`。