### PR TITLE
ci: adjust codecov requirement

### DIFF
--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -10,12 +10,12 @@ coverage:
       flag_coverage_not_uploaded_behavior: exclude
     project:
       design:
-        target: '80%'
-        threshold: 0
+        target: auto
+        threshold: 2
         paths:
           - 'packages/design'
       website:
-        target: '80%'
+        target: auto
         threshold: 5
         paths:
           - 'packages/website'

--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -11,7 +11,7 @@ coverage:
     project:
       design:
         target: auto
-        threshold: 2
+        threshold: 1
         paths:
           - 'packages/design'
       website:

--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -11,7 +11,7 @@ coverage:
     project:
       design:
         target: auto
-        threshold: 1
+        threshold: '1%'
         paths:
           - 'packages/design'
       website:

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -10,12 +10,12 @@ coverage:
       flag_coverage_not_uploaded_behavior: exclude
     project:
       design:
-        target: auto
+        target: '80%'
         threshold: 0
         paths:
           - 'packages/design'
       website:
-        target: auto
+        target: '80%'
         threshold: 5
         paths:
           - 'packages/website'


### PR DESCRIPTION
> 现在 CI 的状态是有点问题的。有时会有因为测试覆盖率下降产生的错误。
>
> 分开对组件库测试覆盖与网站业务代码测试覆盖率的要求。

之前设置是的 auto，所以一旦下降就会失败。

手动指定一个数字作为最低要求。

我应该没理解错 https://github.com/bangumi/frontend/pull/95 的意思吧？