### PR TITLE
fix: storybook typo & doc

### DIFF
--- a/packages/design/components/Avatar/index.tsx
+++ b/packages/design/components/Avatar/index.tsx
@@ -5,15 +5,15 @@ import type { FC } from 'react';
 import React from 'react';
 
 export interface AvatarProps {
-  /* 头像大小 */
+  /** 头像大小 */
   size?: 'small' | 'medium' | 'large';
-  /* 头像的 URL */
+  /** 头像的 URL */
   src: string;
-  /* 替代文本 */
+  /** 替代文本 */
   alt?: string;
-  /* 自定义最外层类名 */
+  /** 自定义最外层类名 */
   wrapperClass?: string;
-  /* 自定义最外层样式 */
+  /** 自定义最外层样式 */
   wrapperStyle?: React.CSSProperties;
 }
 

--- a/packages/design/components/Divider/index.tsx
+++ b/packages/design/components/Divider/index.tsx
@@ -5,11 +5,11 @@ import type { FC } from 'react';
 import React from 'react';
 
 export interface DividerProps {
-  /* 朝向：水平或竖直 */
+  /** 朝向：水平或竖直 */
   orientation?: 'horizontal' | 'vertical';
-  /* 是否属于列表子项 , 在 `ul` 中使用 */
+  /** 是否属于列表子项 , 在 `ul` 中使用 */
   isListItem?: boolean;
-  /* 自定义类名 */
+  /** 自定义类名 */
   className?: string;
 }
 

--- a/packages/design/components/Image/index.tsx
+++ b/packages/design/components/Image/index.tsx
@@ -5,13 +5,13 @@ import type { FC, ImgHTMLAttributes } from 'react';
 import React from 'react';
 
 export interface ImageProps extends Omit<ImgHTMLAttributes<HTMLImageElement>, 'src' | 'alt'> {
-  /* 图像的 URL */
+  /** 图像的 URL */
   src: string;
-  /* 图像的备用文本描述 */
+  /** 图像的备用文本描述 */
   alt?: string;
-  /* 是否增加 box-shadow */
+  /** 是否增加 box-shadow */
   withBoxShadow?: boolean;
-  /* 形状, 矩形或圆形, 默认为矩形 */
+  /** 形状, 矩形或圆形, 默认为矩形 */
   shape?: 'rect' | 'circle';
 }
 

--- a/packages/design/components/Input/index.tsx
+++ b/packages/design/components/Input/index.tsx
@@ -4,17 +4,17 @@ import classnames from 'classnames';
 import React, { forwardRef } from 'react';
 
 export interface InputProps {
-  /* 同原生 input 标签 `type` */
+  /** 同原生 input 标签 `type` */
   type?: string;
-  /* 同原生 `placeholder` */
+  /** 同原生 `placeholder` */
   placeholder?: string;
-  /* 外层 wrapper 的样式 */
+  /** 外层 wrapper 的样式 */
   wrapperStyle?: React.CSSProperties;
-  /* 外层 wrapper 的自定义类名 */
+  /** 外层 wrapper 的自定义类名 */
   wrapperClass?: string;
-  /* 前缀 */
+  /** 前缀 */
   prefix?: React.ReactNode;
-  /* 后缀 */
+  /** 后缀 */
   suffix?: React.ReactNode;
 }
 

--- a/packages/design/components/Menu/MenuItem.tsx
+++ b/packages/design/components/Menu/MenuItem.tsx
@@ -5,13 +5,13 @@ import React from 'react';
 import { useMenuContext } from '.';
 
 export interface MenuItemProps {
-  /* 唯一标识，不应该直接设置它 */
+  /** 唯一标识，不应该直接设置它 */
   id: string;
-  /* 菜单标题 */
+  /** 菜单标题 */
   label: string;
-  /* 自定义类名 */
+  /** 自定义类名 */
   className?: string;
-  /* 子菜单，鼠标悬浮时显示 */
+  /** 子菜单，鼠标悬浮时显示 */
   subMenu?: JSX.Element;
 }
 

--- a/packages/design/components/Menu/index.tsx
+++ b/packages/design/components/Menu/index.tsx
@@ -10,19 +10,19 @@ import MenuItem from './MenuItem';
 export type MenuItemType = Omit<MenuItemProps, 'id'> & { key: string };
 
 export interface MenuProps {
-  /* 点击事件，对每一个 MenuItem 都生效 */
+  /** 点击事件，对每一个 MenuItem 都生效 */
   onClick?: (key: string, e: React.MouseEvent<HTMLElement>) => void;
-  /* 自定义最外层类名 */
+  /** 自定义最外层类名 */
   wrapperClass?: string;
-  /* 菜单类型，支持水平、垂直。在 Bangumi 设计中，垂直菜单多用于子菜单 */
+  /** 菜单类型，支持水平、垂直。在 Bangumi 设计中，垂直菜单多用于子菜单 */
   mode?: 'vertical' | 'horizontal';
-  /* 最外层节点样式 */
+  /** 最外层节点样式 */
   style?: React.CSSProperties;
-  /* 选中节点的 Key */
+  /** 选中节点的 Key */
   activeKey?: string;
-  /* 节点数组，设置可以自动设置 MenuItem 节点 */
+  /** 节点数组，设置可以自动设置 MenuItem 节点 */
   items: MenuItemType[];
-  /* Render Props, 你可以使用自定义的 Item 组件 */
+  /** Render Props, 你可以使用自定义的 Item 组件 */
   children?: (items: MenuItemType) => React.ReactElement;
 }
 

--- a/packages/design/components/Pagination/index.tsx
+++ b/packages/design/components/Pagination/index.tsx
@@ -9,16 +9,16 @@ import { VerticalLeft, VerticalRight } from '@bangumi/icons';
 import Pager from './Pager';
 
 export interface PaginationProps {
-  /* 当前偏移 */
+  /** 当前偏移 */
   currentPage?: number;
-  /* 单页的数据条数 */
+  /** 单页的数据条数 */
   pageSize?: number;
-  /* 数据的总条数 */
+  /** 数据的总条数 */
   total?: number;
-  /* 页码改变的回调 */
+  /** 页码改变的回调 */
   onChange?: (offset: number) => void;
 
-  /* 自定义 classname */
+  /** 自定义 classname */
   wrapperClass?: string;
 }
 

--- a/packages/design/components/Rate/index.tsx
+++ b/packages/design/components/Rate/index.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { FilledStar, HalfStar, EmptyStar } from '@bangumi/icons';
 
 export interface RateProps {
-  /* 评分的分值 , 范围 0 ~ 10 */
+  /** 评分的分值, 范围 0 ~ 10 */
   value: number;
 }
 

--- a/packages/design/components/Tab/index.tsx
+++ b/packages/design/components/Tab/index.tsx
@@ -28,13 +28,13 @@ interface ItemType {
 }
 
 export interface TabProps<T extends ItemType = ItemType> {
-  /* 节点数组 */
+  /** 节点数组 */
   items: T[];
-  /* 选中节点的 Key */
+  /** 选中节点的 Key */
   activeKey: string;
-  /* 点击切换事件回调，对每一个 Item 都生效 */
+  /** 点击切换事件回调，对每一个 Item 都生效 */
   onChange?: (key: string, value: T) => void;
-  /* 样式类型 */
+  /** 样式类型 */
   type?: 'default' | 'borderless';
 }
 

--- a/packages/design/components/Typography/Link.stories.tsx
+++ b/packages/design/components/Typography/Link.stories.tsx
@@ -6,7 +6,7 @@ import type { LinkProps } from './Link';
 import Link from './Link';
 
 const componentMeta: ComponentMeta<typeof Link> = {
-  title: 'modern/Topology/Link',
+  title: 'modern/Typography/Link',
   component: Link,
 };
 

--- a/packages/design/components/Typography/Typography.stories.tsx
+++ b/packages/design/components/Typography/Typography.stories.tsx
@@ -5,7 +5,7 @@ import type { TextProps } from './Text';
 import Text from './Text';
 
 export default {
-  title: 'modern/Topology/Text',
+  title: 'modern/Typography/Text',
   component: Text,
 };
 


### PR DESCRIPTION
- Topology -> Typography
- 把普通注释换成文档注释，不然Storybook不会显示在文档里，IDE也没有提示
  - Before:
  <img width="362" alt="image" src="https://user-images.githubusercontent.com/17172063/209768518-7dfcdfa6-08eb-46fc-b8d6-b20a9a9028c0.png">

  - After:
  <img width="364" alt="image" src="https://user-images.githubusercontent.com/17172063/209768451-c2bcc2c5-9516-4510-8a3d-b051f01e3925.png">
