### PR TITLE
chore: remove data-testid in prod

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -29,6 +29,7 @@
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.10",
     "@vitejs/plugin-react": "^3.0.0",
+    "babel-plugin-jsx-remove-data-test-id": "^3.0.0",
     "msw": "^0.49.2",
     "openapi-types": "^12.1.0",
     "timezone-mock": "^1.3.6",

--- a/packages/website/vite.config.ts
+++ b/packages/website/vite.config.ts
@@ -55,7 +55,15 @@ export default defineConfig(({ mode }) => {
       },
     },
     plugins: [
-      react(),
+      react(
+        mode === 'production'
+          ? {
+              babel: {
+                plugins: ['babel-plugin-jsx-remove-data-test-id'],
+              },
+            }
+          : undefined,
+      ),
       svgr({
         svgrOptions: {
           titleProp: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,6 +213,7 @@ importers:
       '@types/react': ^18.0.26
       '@types/react-dom': ^18.0.10
       '@vitejs/plugin-react': ^3.0.0
+      babel-plugin-jsx-remove-data-test-id: ^3.0.0
       classnames: ^2.3.2
       dayjs: ^1.11.7
       msw: ^0.49.2
@@ -251,6 +252,7 @@ importers:
       '@types/react': 18.0.26
       '@types/react-dom': 18.0.10
       '@vitejs/plugin-react': 3.0.0_vite@4.0.3
+      babel-plugin-jsx-remove-data-test-id: 3.0.0
       msw: 0.49.2_typescript@4.9.4
       openapi-types: 12.1.0
       timezone-mock: 1.3.6
@@ -7421,6 +7423,15 @@ packages:
       '@babel/types': 7.20.7
       '@types/babel__core': 7.1.20
       '@types/babel__traverse': 7.18.3
+    dev: true
+
+  /babel-plugin-jsx-remove-data-test-id/3.0.0:
+    resolution: {integrity: sha512-E4uM/LIUizjy2Z5tVAfa8pSXsYgoKWJ97kzuEMfsIxSLSNDWsAhgFVPkgNuakViX5dkNjw1DKIi0VpWP6djqbw==}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
     dev: true
 
   /babel-plugin-macros/3.1.0:
@@ -17449,7 +17460,7 @@ packages:
     dependencies:
       '@rollup/pluginutils': 5.0.2
       '@svgr/core': 6.5.1
-      vite: 4.0.3_less@4.1.3
+      vite: 4.0.3
     transitivePeerDependencies:
       - rollup
       - supports-color


### PR DESCRIPTION
在构建时移除 `data-testid` 这种自定义的数据属性，因为其只在测试环境中有用