### PR TITLE
fix: BBCode rendering line breaks & react key

### DIFF
--- a/packages/utils/bbcode/__test__/__snapshots__/react.test.tsx.snap
+++ b/packages/utils/bbcode/__test__/__snapshots__/react.test.tsx.snap
@@ -59,9 +59,9 @@ exports[`html render bbcode string render code 1`] = `
     <React.Fragment>
       <React.Fragment>
         <React.Fragment />
-        <br />
         ss[b]加粗
       </React.Fragment>
+      <br />
       换行了[/b](bgm38) [/fafa [code]
     </React.Fragment>
   </pre>,
@@ -73,9 +73,9 @@ exports[`html render bbcode string render color 1`] = `
   <React.Fragment>
     <React.Fragment>
       <React.Fragment />
-      <br />
       我是
     </React.Fragment>
+    <br />
     
   </React.Fragment>,
   <span
@@ -144,9 +144,9 @@ exports[`html render bbcode string render color size 1`] = `
       <React.Fragment>
         <React.Fragment>
           <React.Fragment />
-          <br />
           
         </React.Fragment>
+        <br />
            
       </React.Fragment>
       <span
@@ -168,9 +168,9 @@ exports[`html render bbcode string render img 1`] = `
   <React.Fragment>
     <React.Fragment>
       <React.Fragment />
-      <br />
       存放于其他网络服务器的图片：
     </React.Fragment>
+    <br />
     
   </React.Fragment>,
   <img
@@ -295,9 +295,9 @@ exports[`html render bbcode string render url 2`] = `
   <React.Fragment>
     <React.Fragment>
       <React.Fragment />
-      <br />
       带文字说明的网站链接：
     </React.Fragment>
+    <br />
     
   </React.Fragment>,
   <a
@@ -318,7 +318,6 @@ exports[`html render bbcode string should render br 1`] = `
         <React.Fragment>
           <React.Fragment>
             <React.Fragment />
-            <br />
             
           </React.Fragment>
           <br />
@@ -330,6 +329,7 @@ exports[`html render bbcode string should render br 1`] = `
       <br />
           1.上班的时候想要回家的。
     </React.Fragment>
+    <br />
         2.学校课上打瞌睡的。
   </React.Fragment>,
   <img
@@ -341,9 +341,9 @@ exports[`html render bbcode string should render br 1`] = `
   <React.Fragment>
     <React.Fragment>
       <React.Fragment />
-      <br />
       
     </React.Fragment>
+    <br />
         2.学校课上打瞌睡的。
   </React.Fragment>,
   <img
@@ -355,9 +355,9 @@ exports[`html render bbcode string should render br 1`] = `
   <React.Fragment>
     <React.Fragment>
       <React.Fragment />
-      <br />
       
     </React.Fragment>
+    <br />
         2.学校课上打瞌睡的。
   </React.Fragment>,
   <img
@@ -371,7 +371,6 @@ exports[`html render bbcode string should render br 1`] = `
       <React.Fragment>
         <React.Fragment>
           <React.Fragment />
-          <br />
           
         </React.Fragment>
         <br />
@@ -380,6 +379,7 @@ exports[`html render bbcode string should render br 1`] = `
       <br />
       
     </React.Fragment>
+    <br />
         
   </React.Fragment>,
 ]
@@ -450,9 +450,9 @@ exports[`react render vnode render mask 1`] = `
   <React.Fragment>
     <React.Fragment>
       <React.Fragment />
-      <br />
       文字
     </React.Fragment>
+    <br />
     换行
   </React.Fragment>
 </span>
@@ -471,9 +471,9 @@ exports[`react render vnode render multi style 1`] = `
   <React.Fragment>
     <React.Fragment>
       <React.Fragment />
-      <br />
       文字
     </React.Fragment>
+    <br />
     换行了
   </React.Fragment>
 </span>
@@ -526,9 +526,9 @@ exports[`react render vnode render pre children 1`] = `
   <React.Fragment>
     <React.Fragment>
       <React.Fragment />
-      <br />
       文字
     </React.Fragment>
+    <br />
     换行
   </React.Fragment>
 </pre>

--- a/packages/utils/bbcode/react.tsx
+++ b/packages/utils/bbcode/react.tsx
@@ -14,7 +14,7 @@ const joinClassName = (cls: string | string[]) => {
   return cls;
 };
 
-const convertToReactProps = (node: VNode, key?: string) => {
+const convertToReactProps = (node: VNode, key?: React.Key) => {
   const { props, style, className } = node;
 
   const transformedStyle: Record<string, string> = style
@@ -38,7 +38,7 @@ const convertToReactProps = (node: VNode, key?: string) => {
   return reactProps;
 };
 
-export const renderNode = (node: NodeTypes, key?: string): React.ReactElement | string => {
+export const renderNode = (node: NodeTypes, key?: React.Key): React.ReactElement | string => {
   if (typeof node === 'string') {
     const splittedStr: Array<string | React.ReactElement> = node.split(/\n/g);
 
@@ -46,17 +46,17 @@ export const renderNode = (node: NodeTypes, key?: string): React.ReactElement | 
       return splittedStr[0] ?? '';
     }
     return splittedStr.reduce((pre, curr, idx) => {
-      if (idx < splittedStr.length - 1) {
+      if (idx > 0) {
         return React.createElement(
           React.Fragment,
-          null,
+          { key: idx },
           pre,
           React.createElement('br', null),
           curr,
         );
       }
-      return React.createElement(React.Fragment, null, pre, curr);
-    }, React.createElement(React.Fragment, null));
+      return React.createElement(React.Fragment, { key: idx }, pre, curr);
+    }, React.createElement(React.Fragment, { key }));
   }
 
   const { type, children } = node;
@@ -65,14 +65,14 @@ export const renderNode = (node: NodeTypes, key?: string): React.ReactElement | 
     return React.createElement(
       type,
       convertToReactProps(node, key),
-      ...children.map((child, idx) => renderNode(child, `${idx}`)),
+      ...children.map((child, idx) => renderNode(child, idx)),
     );
   }
-  return React.createElement(type, convertToReactProps(node));
+  return React.createElement(type, convertToReactProps(node, key));
 };
 
 export const render = (rawStr: string): Array<React.ReactElement | string> => {
   const nodes: CodeNodeTypes[] = new Parser(rawStr).parse();
 
-  return nodes.map((node) => renderNode(convert(node, {})));
+  return nodes.map((node, idx) => renderNode(convert(node, {}), idx));
 };


### PR DESCRIPTION
- 循环渲染的时候有一部分子元素没有指定 Key:
<img width="719" alt="屏幕截图 2023-01-28 115849" src="https://user-images.githubusercontent.com/17172063/215242485-7922e1de-cedc-4ea3-95b4-b4f9697f0617.png">

- 换行符应该加在第一个子元素后面而不是前面：
```react
    <React.Fragment>
      <React.Fragment>
        <React.Fragment />
        <br /> <------ 这里
        ss[b]加粗
      </React.Fragment>
      换行了[/b](bgm38) [/fafa [code]
    </React.Fragment>
```
