### PR TITLE
fix(Editor): pass down extra props, fix font size & padding

### DIFF
--- a/packages/design/components/EditorForm/Editor.tsx
+++ b/packages/design/components/EditorForm/Editor.tsx
@@ -9,7 +9,7 @@ import React, {
 
 import Toolbox from './Toolbox';
 
-export type EditorProps = Omit<JSX.IntrinsicElements['textarea'], 'ref' | 'onChange'> & {
+export interface EditorProps {
   placeholder?: string;
   /** 是否显示工具栏 */
   showToolbox?: boolean;
@@ -23,7 +23,9 @@ export type EditorProps = Omit<JSX.IntrinsicElements['textarea'], 'ref' | 'onCha
   onChange?: (content: string) => void;
   /** 在被渲染时是否自动获取焦点 */
   autoFocus?: boolean;
-};
+  /** 文本域初始行数 */
+  rows?: number;
+}
 
 const keyToEvent: Record<string, string> = {
   b: 'bold',
@@ -40,7 +42,7 @@ export interface EditorRef {
 
 const Editor = forwardRef<EditorRef, EditorProps>(
   (
-    { placeholder, showToolbox = true, onConfirm, content = '', onChange, autoFocus, ...props },
+    { placeholder, showToolbox = true, onConfirm, content = '', onChange, autoFocus, rows },
     ref,
   ) => {
     const [selection, setSelection] = useState<[number, number]>();
@@ -179,7 +181,7 @@ const Editor = forwardRef<EditorRef, EditorProps>(
           autoFocus={autoFocus}
           onChange={(e) => updateContent(e.target.value)}
           onKeyDown={handleKeyDown}
-          {...props}
+          rows={rows}
         />
       </div>
     );

--- a/packages/design/components/EditorForm/Editor.tsx
+++ b/packages/design/components/EditorForm/Editor.tsx
@@ -9,7 +9,7 @@ import React, {
 
 import Toolbox from './Toolbox';
 
-export interface EditorProps {
+export type EditorProps = Omit<JSX.IntrinsicElements['textarea'], 'ref' | 'onChange'> & {
   placeholder?: string;
   /** 是否显示工具栏 */
   showToolbox?: boolean;
@@ -23,7 +23,7 @@ export interface EditorProps {
   onChange?: (content: string) => void;
   /** 在被渲染时是否自动获取焦点 */
   autoFocus?: boolean;
-}
+};
 
 const keyToEvent: Record<string, string> = {
   b: 'bold',
@@ -39,7 +39,10 @@ export interface EditorRef {
 }
 
 const Editor = forwardRef<EditorRef, EditorProps>(
-  ({ placeholder, showToolbox = true, onConfirm, content = '', onChange, autoFocus }, ref) => {
+  (
+    { placeholder, showToolbox = true, onConfirm, content = '', onChange, autoFocus, ...props },
+    ref,
+  ) => {
     const [selection, setSelection] = useState<[number, number]>();
     const innerRef = useRef<HTMLTextAreaElement>(null);
 
@@ -176,6 +179,7 @@ const Editor = forwardRef<EditorRef, EditorProps>(
           autoFocus={autoFocus}
           onChange={(e) => updateContent(e.target.value)}
           onKeyDown={handleKeyDown}
+          {...props}
         />
       </div>
     );

--- a/packages/design/components/EditorForm/style/index.less
+++ b/packages/design/components/EditorForm/style/index.less
@@ -10,7 +10,7 @@
     min-height: 162px;
     border: 2px solid @gray-10;
     border-radius: 12px;
-    padding: 8px 0 0 10px;
+    padding: 8px 6px 6px;
     z-index: 9999;
   }
 
@@ -20,7 +20,7 @@
     align-items: center;
     height: 26px;
     width: @toolbox-width;
-    padding: 0 4px;
+    padding: 0 8px;
     margin-bottom: 10px;
 
     > svg {
@@ -30,7 +30,7 @@
 
   &__text {
     flex: 1 0 auto;
-    padding: 0;
+    padding: 0 6px;
     min-width: @toolbox-width;
     width: @text-width;
     border: none;

--- a/packages/design/components/EditorForm/style/index.less
+++ b/packages/design/components/EditorForm/style/index.less
@@ -37,6 +37,7 @@
     outline: none;
     color: @gray-100;
     line-height: 26px;
+    font-size: 16px;
 
     &::placeholder {
       color: @gray-60;


### PR DESCRIPTION
- 将额外参数传递给 textarea
- 根据设计稿将文字大小改为 16px
- 文本域右侧也应有 padding

**Before:**
<img width="528" alt="image" src="https://user-images.githubusercontent.com/17172063/215329093-ed6d0d82-5735-4857-950c-cb6950e9efac.png">

**After:**
<img width="528" alt="image" src="https://user-images.githubusercontent.com/17172063/215329104-5b302fc4-3f3a-4a9d-b47b-dd1160acd573.png">
