### PR TITLE
refactor: update button design system

### DIFF
--- a/packages/design/components/Button/__test__/Button.test.tsx
+++ b/packages/design/components/Button/__test__/Button.test.tsx
@@ -3,9 +3,55 @@ import React from 'react';
 
 import Button from '../index';
 
-it.each(['primary', 'secondary', 'text'] as const)('should render button of type %s', (type) => {
-  const { container } = render(<Button type={type}>hello world</Button>);
-  expect(container.firstChild).toMatchSnapshot();
+describe('Primary Button', () => {
+  it.each(['large', 'medium', 'small'] as const)('should render button of size %s', (size) => {
+    const { container } = render(
+      <Button type='primary' size={size}>
+        hello world
+      </Button>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it.each(['blue', 'gray'] as const)('should render button of color %s', (color) => {
+    const { container } = render(
+      <Button type='primary' color={color}>
+        hello world
+      </Button>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});
+
+describe('Secondary Button', () => {
+  it.each(['large', 'medium', 'small'] as const)('should render button of size %s', (size) => {
+    const { container } = render(
+      <Button type='secondary' size={size}>
+        hello world
+      </Button>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it.each(['blue'] as const)('should render button of color %s', (color) => {
+    const { container } = render(
+      <Button type='secondary' color={color}>
+        hello world
+      </Button>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});
+
+describe('Text Button', () => {
+  it.each(['large', 'medium', 'small'] as const)('should render button of size %s', (size) => {
+    const { container } = render(
+      <Button type='text' size={size}>
+        hello world
+      </Button>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
 });
 
 it.each(['square', 'rounded'] as const)('should render button of shape %s', (shape) => {

--- a/packages/design/components/Button/__test__/__snapshots__/Button.test.tsx.snap
+++ b/packages/design/components/Button/__test__/__snapshots__/Button.test.tsx.snap
@@ -1,8 +1,104 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Primary Button should render button of color blue 1`] = `
+<button
+  class="bgm-button bgm-button--primary bgm-button--color-blue"
+>
+  hello world
+</button>
+`;
+
+exports[`Primary Button should render button of color gray 1`] = `
+<button
+  class="bgm-button bgm-button--primary bgm-button--color-gray"
+>
+  hello world
+</button>
+`;
+
+exports[`Primary Button should render button of size large 1`] = `
+<button
+  class="bgm-button bgm-button--primary"
+>
+  hello world
+</button>
+`;
+
+exports[`Primary Button should render button of size medium 1`] = `
+<button
+  class="bgm-button bgm-button--primary bgm-button--size-medium"
+>
+  hello world
+</button>
+`;
+
+exports[`Primary Button should render button of size small 1`] = `
+<button
+  class="bgm-button bgm-button--primary bgm-button--size-small"
+>
+  hello world
+</button>
+`;
+
+exports[`Secondary Button should render button of color blue 1`] = `
+<button
+  class="bgm-button bgm-button--secondary bgm-button--color-blue"
+>
+  hello world
+</button>
+`;
+
+exports[`Secondary Button should render button of size large 1`] = `
+<button
+  class="bgm-button bgm-button--secondary"
+>
+  hello world
+</button>
+`;
+
+exports[`Secondary Button should render button of size medium 1`] = `
+<button
+  class="bgm-button bgm-button--secondary bgm-button--size-medium"
+>
+  hello world
+</button>
+`;
+
+exports[`Secondary Button should render button of size small 1`] = `
+<button
+  class="bgm-button bgm-button--secondary bgm-button--size-small"
+>
+  hello world
+</button>
+`;
+
+exports[`Text Button should render button of size large 1`] = `
+<button
+  class="bgm-button bgm-button--text"
+>
+  hello world
+</button>
+`;
+
+exports[`Text Button should render button of size medium 1`] = `
+<button
+  class="bgm-button bgm-button--text bgm-button--size-medium"
+>
+  hello world
+</button>
+`;
+
+exports[`Text Button should render button of size small 1`] = `
+<button
+  class="bgm-button bgm-button--text bgm-button--size-small"
+>
+  hello world
+</button>
+`;
+
 exports[`should render button of shape rounded 1`] = `
 <button
-  class="bgm-button bgm-button__primary bgm-button__rounded bgm-button__normal"
+  class="bgm-button bgm-button--primary"
 >
   hello world
 </button>
@@ -10,31 +106,7 @@ exports[`should render button of shape rounded 1`] = `
 
 exports[`should render button of shape square 1`] = `
 <button
-  class="bgm-button bgm-button__primary bgm-button__square bgm-button__normal"
->
-  hello world
-</button>
-`;
-
-exports[`should render button of type primary 1`] = `
-<button
-  class="bgm-button bgm-button__primary bgm-button__square bgm-button__normal"
->
-  hello world
-</button>
-`;
-
-exports[`should render button of type secondary 1`] = `
-<button
-  class="bgm-button bgm-button__secondary bgm-button__square bgm-button__normal"
->
-  hello world
-</button>
-`;
-
-exports[`should render button of type text 1`] = `
-<button
-  class="bgm-button bgm-button__text bgm-button__square bgm-button__normal"
+  class="bgm-button bgm-button--primary bgm-button--shape-square"
 >
   hello world
 </button>

--- a/packages/design/components/Button/button.stories.tsx
+++ b/packages/design/components/Button/button.stories.tsx
@@ -7,35 +7,97 @@ import Button from '.';
 const storyMeta: ComponentMeta<typeof Button> = {
   title: 'modern/Button',
   component: Button,
+  argTypes: {
+    disabled: { control: 'boolean' },
+    color: { control: 'select', options: ['default', 'blue', 'gray'] },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          '主类型按钮，全圆角，有颜色填充，为默认类型。默认为粉色，另有蓝色和灰色两种颜色可选。',
+      },
+    },
+  },
 };
 
 export default storyMeta;
 
 const Template: Story<ButtonProps> = (args) => {
-  return <Button {...args}>Click Me!</Button>;
+  return <Button {...args}>{args.children ?? 'Click Me!'}</Button>;
 };
 
-export const PrimaryButton = Template.bind({});
-PrimaryButton.args = {
+export const Primary = Template.bind({});
+Primary.args = {
   type: 'primary',
+  children: '登录',
 };
 
-export const SecondaryButton = Template.bind({});
-SecondaryButton.args = {
+export const Secondary = Template.bind({});
+Secondary.args = {
   type: 'secondary',
+  children: '小组概览',
+  size: 'medium',
+};
+Secondary.parameters = {
+  docs: {
+    description: {
+      story:
+        '次级按钮，全圆角，有边框，无颜色填充。默认为灰色，另有蓝色变种可选，此处为 `medium` 大小。',
+    },
+  },
 };
 
-export const TextButton = Template.bind({});
-TextButton.args = {
+export const Text = Template.bind({});
+Text.args = {
   type: 'text',
+  children: '编辑',
+  size: 'small',
+};
+Text.parameters = {
+  docs: {
+    description: {
+      story: '纯文字按钮，无边框，无颜色填充。默认为灰色，无其他颜色变种，此处为 `small` 大小。',
+    },
+  },
 };
 
-export const SquareButton = Template.bind({});
-SquareButton.args = {
+export const Blue = Template.bind({});
+Blue.args = {
+  type: 'primary',
+  children: '发表新主题',
+  color: 'blue',
+};
+Blue.parameters = {
+  docs: {
+    description: {
+      story: '主类型按钮的蓝色变种，为默认的 `large` 大小。',
+    },
+  },
+};
+
+export const Small = Template.bind({});
+Small.args = {
+  type: 'secondary',
+  children: '评论',
+  size: 'small',
+};
+Small.parameters = {
+  docs: {
+    description: {
+      story: '所有类型的按钮均提供 `large`、`medium`、`small` 三种尺寸。默认为 `large`。',
+    },
+  },
+};
+
+export const Square = Template.bind({});
+Square.args = {
   shape: 'square',
 };
 
-export const RoundedButton = Template.bind({});
-RoundedButton.args = {
-  shape: 'rounded',
+export const Disabled = Template.bind({});
+Disabled.args = {
+  type: 'primary',
+  disabled: true,
+  children: 'Disabled',
 };

--- a/packages/design/components/Button/index.tsx
+++ b/packages/design/components/Button/index.tsx
@@ -8,7 +8,8 @@ export type ButtonProps = Omit<JSX.IntrinsicElements['button'], 'type' | 'onClic
   onClick?: MouseEventHandler; // desserts for story book
   type?: 'primary' | 'secondary' | 'text';
   shape?: 'square' | 'rounded';
-  size?: 'normal';
+  size?: 'large' | 'medium' | 'small';
+  color?: 'default' | 'blue' | 'gray';
   htmlType?: JSX.IntrinsicElements['button']['type'];
 };
 
@@ -16,8 +17,9 @@ const Button: FC<ButtonProps> = ({
   disabled = false,
   className,
   type = 'primary',
-  shape = 'square',
-  size = 'normal',
+  shape = 'rounded',
+  size = 'large',
+  color = 'default',
   children,
   htmlType,
   ...rest
@@ -27,10 +29,11 @@ const Button: FC<ButtonProps> = ({
       className={classNames(
         'bgm-button',
         className,
-        disabled && 'bgm-button__disabled',
-        `bgm-button__${type}`,
-        `bgm-button__${shape}`,
-        `bgm-button__${size}`,
+        disabled && 'bgm-button--disabled',
+        `bgm-button--${type}`,
+        shape !== 'rounded' && `bgm-button--shape-${shape}`,
+        size !== 'large' && `bgm-button--size-${size}`,
+        color !== 'default' && `bgm-button--color-${color}`,
       )}
       type={htmlType}
       disabled={disabled}

--- a/packages/design/components/Button/style/index.less
+++ b/packages/design/components/Button/style/index.less
@@ -91,4 +91,9 @@
   &--disabled {
     cursor: default;
   }
+
+  a {
+    color: inherit !important;
+    text-decoration: none !important;
+  }
 }

--- a/packages/design/components/Button/style/index.less
+++ b/packages/design/components/Button/style/index.less
@@ -91,6 +91,7 @@
     cursor: default;
   }
 
+  // 强制覆盖.bgm-link的样式
   a {
     color: inherit !important;
     text-decoration: none !important;

--- a/packages/design/components/Button/style/index.less
+++ b/packages/design/components/Button/style/index.less
@@ -12,6 +12,7 @@
   display: flex;
   align-items: center;
   text-align: center;
+  justify-content: center;
   height: var(--height);
   border-radius: calc(var(--height) / 2);
   padding: 0 var(--padding);

--- a/packages/design/components/Button/style/index.less
+++ b/packages/design/components/Button/style/index.less
@@ -3,33 +3,92 @@
 .bgm-button {
   border: 0;
   cursor: pointer;
+  user-select: none;
+  font-size: 14px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  text-align: center;
+  height: var(--height);
+  border-radius: calc(var(--height) / 2);
+  padding: 0 var(--padding);
 
-  &__normal {
-    height: 38px;
-    font-size: 14px;
-    line-height: 20px;
-  }
+  // 默认大小：large
+  --height: 38px;
+  --padding: 32px;
 
-  &__primary {
+  line-height: 20px;
+
+  &--primary {
     background-color: @primary-color;
     color: #fff;
+
+    &.bgm-button--color {
+      &-blue {
+        background-color: @blue-100;
+      }
+
+      &-gray {
+        background-color: @gray-10;
+        color: @gray-80;
+      }
+    }
   }
 
-  &__secondary {
-    background-color: @gray-10;
-    color: @gray-80;
+  &--secondary {
+    background-color: transparent;
+    border: 2px solid @gray-10;
+    color: @gray-60;
+    // 为了使不同类型的按钮宽度一致，将secondary类型的内边距减去2px的边框宽度
+    padding: 0 calc(var(--padding) - 2px);
+
+    &:hover {
+      background-color: @gray-10;
+      color: @gray-80;
+    }
+
+    &.bgm-button--color {
+      &-blue {
+        border-color: @blue-100;
+        color: @blue-100;
+
+        &:hover {
+          background-color: @blue-100;
+          color: #fff;
+        }
+      }
+    }
   }
 
-  &__text {
+  &--text {
     background-color: transparent;
     color: @gray-60;
   }
 
-  &__normal&__rounded {
-    border-radius: 19px;
-  }
-}
+  &--size {
+    &-medium {
+      --height: 30px;
+      --padding: 13px;
 
-.bgm-button__disabled {
-  cursor: default;
+      line-height: 24px;
+    }
+
+    &-small {
+      --height: 24px;
+      --padding: 17px;
+
+      line-height: 24px;
+    }
+  }
+
+  &--shape-square {
+    border-radius: 0;
+  }
+
+  &--disabled {
+    cursor: default;
+  }
 }

--- a/packages/design/components/Button/style/index.less
+++ b/packages/design/components/Button/style/index.less
@@ -1,7 +1,6 @@
 @import '../../../theme/base';
 
 .bgm-button {
-  border: 0;
   cursor: pointer;
   user-select: none;
   font-size: 14px;
@@ -13,14 +12,15 @@
   align-items: center;
   text-align: center;
   justify-content: center;
+  box-sizing: border-box;
+  border: 2px transparent solid;
   height: var(--height);
   border-radius: calc(var(--height) / 2);
-  padding: 0 var(--padding);
 
   // 默认大小：large
   --height: 38px;
-  --padding: 32px;
 
+  padding: 0 32px;
   line-height: 20px;
 
   &--primary {
@@ -41,10 +41,8 @@
 
   &--secondary {
     background-color: transparent;
-    border: 2px solid @gray-10;
+    border-color: @gray-10;
     color: @gray-60;
-    // 为了使不同类型的按钮宽度一致，将secondary类型的内边距减去2px的边框宽度
-    padding: 0 calc(var(--padding) - 2px);
 
     &:hover {
       background-color: @gray-10;
@@ -72,15 +70,15 @@
   &--size {
     &-medium {
       --height: 30px;
-      --padding: 13px;
 
+      padding: 0 13px;
       line-height: 24px;
     }
 
     &-small {
       --height: 24px;
-      --padding: 17px;
 
+      padding: 0 17px;
       line-height: 24px;
     }
   }

--- a/packages/design/components/EditorForm/__test__/__snapshots__/EditorForm.test.tsx.snap
+++ b/packages/design/components/EditorForm/__test__/__snapshots__/EditorForm.test.tsx.snap
@@ -45,12 +45,12 @@ exports[`<EditorForm /> render correctly with props 1`] = `
       class="bgm-editor__submit"
     >
       <button
-        class="bgm-button bgm-editor__button bgm-editor__button--confirm bgm-button__primary bgm-button__rounded bgm-button__normal"
+        class="bgm-button bgm-editor__button bgm-editor__button--confirm bgm-button--primary bgm-button--size-small bgm-button--color-blue"
       >
         Confirm
       </button>
       <button
-        class="bgm-button bgm-editor__button bgm-button__text bgm-button__square bgm-button__normal"
+        class="bgm-button bgm-editor__button bgm-button--text bgm-button--size-small"
       >
         取消
       </button>

--- a/packages/design/components/EditorForm/index.tsx
+++ b/packages/design/components/EditorForm/index.tsx
@@ -49,14 +49,15 @@ const EditorForm = forwardRef<EditorRef, EditorFormProps>(
         <Editor ref={ref} onConfirm={onConfirm} {...props} />
         <div className='bgm-editor__submit'>
           <Button
-            shape='rounded'
+            size='small'
+            color='blue'
             className='bgm-editor__button bgm-editor__button--confirm'
             onClick={() => onConfirm?.(props.content ?? '')}
           >
             {confirmText}
           </Button>
           {!hideCancel && (
-            <Button type='text' className='bgm-editor__button' onClick={onCancel}>
+            <Button type='text' size='small' className='bgm-editor__button' onClick={onCancel}>
               {cancelText}
             </Button>
           )}

--- a/packages/design/components/EditorForm/style/index.less
+++ b/packages/design/components/EditorForm/style/index.less
@@ -60,16 +60,7 @@
     justify-content: center;
 
     .bgm-editor__button {
-      font-weight: 600;
-      font-size: 14px;
-      height: 24px;
-      line-height: 24px;
-      padding: 0 16px;
       margin-right: 10px;
-
-      &--confirm {
-        background-color: @blue-100;
-      }
     }
 
     .bgm-editor__bbcode-tip {

--- a/packages/design/components/EditorForm/style/index.less
+++ b/packages/design/components/EditorForm/style/index.less
@@ -58,10 +58,7 @@
     height: 24px;
     align-items: center;
     justify-content: center;
-
-    .bgm-editor__button {
-      margin-right: 10px;
-    }
+    gap: 10px;
 
     .bgm-editor__bbcode-tip {
       color: @gray-60;

--- a/packages/design/components/Form/Form.stories.tsx
+++ b/packages/design/components/Form/Form.stories.tsx
@@ -83,9 +83,7 @@ const Template: ComponentStory<typeof Form> = (args) => {
         </Input.Group>
       </Form.Item>
 
-      <Button htmlType='submit' shape='rounded'>
-        提交修改
-      </Button>
+      <Button htmlType='submit'>提交修改</Button>
     </Form>
   );
 };

--- a/packages/design/components/Topic/Comment.tsx
+++ b/packages/design/components/Topic/Comment.tsx
@@ -179,17 +179,21 @@ const Comment: FC<CommentProps> = ({
                 />
               ) : (
                 <>
-                  <Button type='secondary' shape='rounded' onClick={startReply}>
+                  <Button type='secondary' size='small' onClick={startReply}>
                     回复
                   </Button>
-                  <Button type='secondary' shape='rounded'>
+                  <Button type='secondary' size='small'>
                     +1
                   </Button>
                   {user.id === creator.id ? (
                     <>
                       {/* TODO */}
-                      <Button type='text'>编辑</Button>
-                      <Button type='text'>删除</Button>
+                      <Button type='text' size='small'>
+                        编辑
+                      </Button>
+                      <Button type='text' size='small'>
+                        删除
+                      </Button>
                     </>
                   ) : null}
                 </>

--- a/packages/design/components/Topic/__test__/__snapshots__/Comment.spec.tsx.snap
+++ b/packages/design/components/Topic/__test__/__snapshots__/Comment.spec.tsx.snap
@@ -132,12 +132,12 @@ exports[`Normal Comment should highlight comment corresponding to hash 1`] = `
           class="bgm-comment__opinions"
         >
           <button
-            class="bgm-button bgm-button__secondary bgm-button__rounded bgm-button__normal"
+            class="bgm-button bgm-button--secondary bgm-button--size-small"
           >
             回复
           </button>
           <button
-            class="bgm-button bgm-button__secondary bgm-button__rounded bgm-button__normal"
+            class="bgm-button bgm-button--secondary bgm-button--size-small"
           >
             +1
           </button>
@@ -204,12 +204,12 @@ exports[`Normal Comment should highlight comment corresponding to hash 1`] = `
             class="bgm-comment__opinions"
           >
             <button
-              class="bgm-button bgm-button__secondary bgm-button__rounded bgm-button__normal"
+              class="bgm-button bgm-button--secondary bgm-button--size-small"
             >
               回复
             </button>
             <button
-              class="bgm-button bgm-button__secondary bgm-button__rounded bgm-button__normal"
+              class="bgm-button bgm-button--secondary bgm-button--size-small"
             >
               +1
             </button>
@@ -286,12 +286,12 @@ exports[`Normal Comment should render 0 1`] = `
           class="bgm-comment__opinions"
         >
           <button
-            class="bgm-button bgm-button__secondary bgm-button__rounded bgm-button__normal"
+            class="bgm-button bgm-button--secondary bgm-button--size-small"
           >
             回复
           </button>
           <button
-            class="bgm-button bgm-button__secondary bgm-button__rounded bgm-button__normal"
+            class="bgm-button bgm-button--secondary bgm-button--size-small"
           >
             +1
           </button>
@@ -367,12 +367,12 @@ exports[`Normal Comment should render 6 1`] = `
           class="bgm-comment__opinions"
         >
           <button
-            class="bgm-button bgm-button__secondary bgm-button__rounded bgm-button__normal"
+            class="bgm-button bgm-button--secondary bgm-button--size-small"
           >
             回复
           </button>
           <button
-            class="bgm-button bgm-button__secondary bgm-button__rounded bgm-button__normal"
+            class="bgm-button bgm-button--secondary bgm-button--size-small"
           >
             +1
           </button>
@@ -455,12 +455,12 @@ exports[`Normal Comment should render 7 1`] = `
           class="bgm-comment__opinions"
         >
           <button
-            class="bgm-button bgm-button__secondary bgm-button__rounded bgm-button__normal"
+            class="bgm-button bgm-button--secondary bgm-button--size-small"
           >
             回复
           </button>
           <button
-            class="bgm-button bgm-button__secondary bgm-button__rounded bgm-button__normal"
+            class="bgm-button bgm-button--secondary bgm-button--size-small"
           >
             +1
           </button>
@@ -536,12 +536,12 @@ exports[`Normal Comment should render with reply 1`] = `
           class="bgm-comment__opinions"
         >
           <button
-            class="bgm-button bgm-button__secondary bgm-button__rounded bgm-button__normal"
+            class="bgm-button bgm-button--secondary bgm-button--size-small"
           >
             回复
           </button>
           <button
-            class="bgm-button bgm-button__secondary bgm-button__rounded bgm-button__normal"
+            class="bgm-button bgm-button--secondary bgm-button--size-small"
           >
             +1
           </button>
@@ -608,12 +608,12 @@ exports[`Normal Comment should render with reply 1`] = `
             class="bgm-comment__opinions"
           >
             <button
-              class="bgm-button bgm-button__secondary bgm-button__rounded bgm-button__normal"
+              class="bgm-button bgm-button--secondary bgm-button--size-small"
             >
               回复
             </button>
             <button
-              class="bgm-button bgm-button__secondary bgm-button__rounded bgm-button__normal"
+              class="bgm-button bgm-button--secondary bgm-button--size-small"
             >
               +1
             </button>

--- a/packages/design/components/Topic/style/Comment.less
+++ b/packages/design/components/Topic/style/Comment.less
@@ -63,18 +63,10 @@
 
   &__opinions {
     margin-top: 12px;
+    display: flex;
 
     > .bgm-button {
-      height: 24px;
-      line-height: 22px;
       margin-right: 10px;
-    }
-
-    > .bgm-button__secondary {
-      background-color: #fff;
-      border: 2px solid @gray-10;
-      border-radius: 12px;
-      padding: 0 15px;
     }
   }
 

--- a/packages/design/components/Topic/style/Comment.less
+++ b/packages/design/components/Topic/style/Comment.less
@@ -64,10 +64,7 @@
   &__opinions {
     margin-top: 12px;
     display: flex;
-
-    > .bgm-button {
-      margin-right: 10px;
-    }
+    gap: 10px;
   }
 
   &__content {

--- a/packages/website/src/components/Header/index.tsx
+++ b/packages/website/src/components/Header/index.tsx
@@ -104,8 +104,7 @@ const Header: FC = () => {
           {/* Mobile Menu Toggle Button */}
           <Button
             className={style.mobileMenuToggle}
-            shape='rounded'
-            type={showMobileMenu ? 'primary' : 'secondary'}
+            color={showMobileMenu ? 'default' : 'gray'}
             onClick={() => setShowMobileMenu((show) => !show)}
           >
             {showMobileMenu ? '关闭' : '菜单'}

--- a/packages/website/src/components/Header/style.module.less
+++ b/packages/website/src/components/Header/style.module.less
@@ -51,7 +51,6 @@
 .mobileMenuToggle {
   padding: 0 15px;
   margin-left: 16px;
-  font-weight: bold;
   display: none;
 }
 

--- a/packages/website/src/pages/index/group/topic/[id]/index.module.less
+++ b/packages/website/src/pages/index/group/topic/[id]/index.module.less
@@ -53,24 +53,6 @@
   margin-top: 20px;
 
   > :global(.bgm-button) {
-    border: 2px solid @gray-10;
-    border-radius: 15px;
-    height: 30px;
-    line-height: 24px;
     padding: 0 32px;
-
-    a {
-      font-weight: 600;
-      color: @gray-60;
-      text-decoration: none;
-    }
-
-    &:hover {
-      background-color: @gray-10;
-
-      a {
-        color: @gray-80;
-      }
-    }
   }
 }

--- a/packages/website/src/pages/index/group/topic/[id]/index.tsx
+++ b/packages/website/src/pages/index/group/topic/[id]/index.tsx
@@ -34,13 +34,13 @@ const GroupInfo = memo(({ group }: { group: Group }) => (
       isClamped
     />
     <div className={styles.groupOpinions}>
-      <Button type='text'>
+      <Button type='secondary' size='medium'>
         <Link to={`/group/${group.name}`}>小组概览</Link>
       </Button>
-      <Button type='text'>
+      <Button type='secondary' size='medium'>
         <Link to={`/group/${group.name}/forum`}>组内讨论</Link>
       </Button>
-      <Button type='text'>
+      <Button type='secondary' size='medium'>
         <Link to={`/group/${group.name}/members`}>小组成员</Link>
       </Button>
     </div>

--- a/packages/website/src/pages/index/subject/[id]/wiki/common.module.less
+++ b/packages/website/src/pages/index/subject/[id]/wiki/common.module.less
@@ -80,8 +80,6 @@
 
   &Button {
     width: 120px;
-    background: @blue-100;
-    font-weight: 600;
   }
 
   .Tips {

--- a/packages/website/src/pages/index/subject/[id]/wiki/edit_detail.tsx
+++ b/packages/website/src/pages/index/subject/[id]/wiki/edit_detail.tsx
@@ -589,7 +589,7 @@ const WikiEditDetailDetailPage: React.FC = () => {
               </Input.Group>
             </Form.Item>
 
-            <Button htmlType='submit' shape='rounded' className={style.formButton}>
+            <Button htmlType='submit' color='blue' className={style.formButton}>
               提交修改
             </Button>
           </Form>

--- a/packages/website/src/pages/login/index.module.less
+++ b/packages/website/src/pages/login/index.module.less
@@ -36,8 +36,6 @@
 
 .button {
   width: 150px;
-  // height: 38px;
-  font-weight: 600;
 }
 
 .icon {

--- a/packages/website/src/pages/login/index.tsx
+++ b/packages/website/src/pages/login/index.tsx
@@ -114,10 +114,10 @@ const Login: React.FC = () => {
           />
         </div>
         <div className={style.buttonGroup}>
-          <Button className={style.button} type='secondary' shape='rounded' disabled>
+          <Button className={style.button} color='gray' disabled>
             注册新用户
           </Button>
-          <Button className={style.button} type='primary' shape='rounded' onClick={handleLogin}>
+          <Button className={style.button} onClick={handleLogin}>
             登录
           </Button>
         </div>


### PR DESCRIPTION
此前 design 包里提供的按钮类型不能完全满足要求，导致各个地方都重复用了自定义样式，与设计师[讨论](https://bangumiworkspace.slack.com/archives/C02RY7CKGAW/p1675045471609809?thread_ts=1674896271.461799&cid=C02RY7CKGAW)后更新了一下设计系统，整理了按钮类型，增加了对不同大小和颜色的支持，并对不符合设计稿的地方进行了修正，清理了样式表。

https://pr-324-storybook--bangumi-next.netlify.app/?path=/docs/modern-button--primary
