### PR TITLE
refactor(Editor): forward textarea ref & props

### DIFF
--- a/packages/design/components/EditorForm/Editor.tsx
+++ b/packages/design/components/EditorForm/Editor.tsx
@@ -1,3 +1,4 @@
+import type { FocusEventHandler } from 'react';
 import React, {
   forwardRef,
   useCallback,
@@ -25,6 +26,8 @@ export interface EditorProps {
   autoFocus?: boolean;
   /** 文本域初始行数 */
   rows?: number;
+  name?: string;
+  onBlur?: FocusEventHandler<HTMLTextAreaElement>;
 }
 
 const keyToEvent: Record<string, string> = {
@@ -37,7 +40,20 @@ const keyToEvent: Record<string, string> = {
 } as const;
 
 const Editor = forwardRef<HTMLTextAreaElement, EditorProps>(
-  ({ placeholder, showToolbox = true, onConfirm, value = '', onChange, autoFocus, rows }, ref) => {
+  (
+    {
+      placeholder,
+      showToolbox = true,
+      onConfirm,
+      value = '',
+      onChange,
+      autoFocus,
+      rows,
+      name,
+      onBlur,
+    },
+    ref,
+  ) => {
     const [selection, setSelection] = useState<[number, number]>();
     const innerRef = useRef<HTMLTextAreaElement>(null);
 
@@ -176,6 +192,8 @@ const Editor = forwardRef<HTMLTextAreaElement, EditorProps>(
           onChange={(e) => updateContent(e.target.value)}
           onKeyDown={handleKeyDown}
           rows={rows}
+          name={name}
+          onBlur={onBlur}
         />
       </div>
     );

--- a/packages/design/components/EditorForm/Editor.tsx
+++ b/packages/design/components/EditorForm/Editor.tsx
@@ -36,11 +36,7 @@ const keyToEvent: Record<string, string> = {
   p: 'image',
 } as const;
 
-export interface EditorRef {
-  textArea: HTMLTextAreaElement;
-}
-
-const Editor = forwardRef<EditorRef, EditorProps>(
+const Editor = forwardRef<HTMLTextAreaElement, EditorProps>(
   (
     { placeholder, showToolbox = true, onConfirm, content = '', onChange, autoFocus, rows },
     ref,
@@ -48,9 +44,10 @@ const Editor = forwardRef<EditorRef, EditorProps>(
     const [selection, setSelection] = useState<[number, number]>();
     const innerRef = useRef<HTMLTextAreaElement>(null);
 
-    useImperativeHandle(ref, () => ({
-      textArea: innerRef.current!,
-    }));
+    useImperativeHandle<HTMLTextAreaElement | null, HTMLTextAreaElement | null>(
+      ref,
+      () => innerRef.current,
+    );
 
     useEffect(() => {
       // 用来确保输入光标在自动插入的quote内容之后。

--- a/packages/design/components/EditorForm/Editor.tsx
+++ b/packages/design/components/EditorForm/Editor.tsx
@@ -14,13 +14,13 @@ export interface EditorProps {
   /** 是否显示工具栏 */
   showToolbox?: boolean;
   /** textarea 通过键盘按下提交触发事件 */
-  onConfirm?: (content: string) => void;
+  onConfirm?: (value: string) => void;
   /**
    * @default empty string
    */
-  content?: string;
+  value?: string;
   /** 内容改变时的回调函数 */
-  onChange?: (content: string) => void;
+  onChange?: (value: string) => void;
   /** 在被渲染时是否自动获取焦点 */
   autoFocus?: boolean;
   /** 文本域初始行数 */
@@ -37,10 +37,7 @@ const keyToEvent: Record<string, string> = {
 } as const;
 
 const Editor = forwardRef<HTMLTextAreaElement, EditorProps>(
-  (
-    { placeholder, showToolbox = true, onConfirm, content = '', onChange, autoFocus, rows },
-    ref,
-  ) => {
+  ({ placeholder, showToolbox = true, onConfirm, value = '', onChange, autoFocus, rows }, ref) => {
     const [selection, setSelection] = useState<[number, number]>();
     const innerRef = useRef<HTMLTextAreaElement>(null);
 
@@ -174,7 +171,7 @@ const Editor = forwardRef<HTMLTextAreaElement, EditorProps>(
           className='bgm-editor__text'
           placeholder={placeholder}
           ref={innerRef}
-          value={content}
+          value={value}
           autoFocus={autoFocus}
           onChange={(e) => updateContent(e.target.value)}
           onKeyDown={handleKeyDown}

--- a/packages/design/components/EditorForm/EditorForm.stories.tsx
+++ b/packages/design/components/EditorForm/EditorForm.stories.tsx
@@ -17,8 +17,8 @@ const componentMeta: ComponentMeta<typeof EditorForm> = {
 export default componentMeta;
 
 const Template: ComponentStory<typeof EditorForm> = (args) => {
-  const [content, setContent] = useState(args.content);
-  return <EditorForm {...args} content={content} onChange={setContent} />;
+  const [value, setValue] = useState(args.value);
+  return <EditorForm {...args} value={value} onChange={setValue} />;
 };
 
 export const Usage = Template.bind({});

--- a/packages/design/components/EditorForm/__test__/Editor.spec.tsx
+++ b/packages/design/components/EditorForm/__test__/Editor.spec.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import React, { useState } from 'react';
 
-import type { EditorProps, EditorRef } from '../Editor';
+import type { EditorProps } from '../Editor';
 import Editor from '../Editor';
 
 const TestEditor = (props: EditorProps) => {
@@ -121,9 +121,9 @@ describe('EditorForm > Editor', () => {
   });
 
   it('ref should forward to textarea tag', () => {
-    const ref = React.createRef<HTMLTextAreaElement & EditorRef>();
+    const ref = React.createRef<HTMLTextAreaElement>();
     render(<Editor ref={ref} />);
-    expect(ref.current?.textArea.tagName).toBe('TEXTAREA');
+    expect(ref.current?.tagName).toBe('TEXTAREA');
   });
 
   it('placeholder props', () => {

--- a/packages/design/components/EditorForm/__test__/Editor.spec.tsx
+++ b/packages/design/components/EditorForm/__test__/Editor.spec.tsx
@@ -5,8 +5,8 @@ import type { EditorProps } from '../Editor';
 import Editor from '../Editor';
 
 const TestEditor = (props: EditorProps) => {
-  const [content, setContent] = useState('');
-  return <Editor content={content} onChange={setContent} {...props} />;
+  const [value, setValue] = useState('');
+  return <Editor value={value} onChange={setValue} {...props} />;
 };
 
 const initTextareaTest = (

--- a/packages/design/components/EditorForm/__test__/EditorForm.test.tsx
+++ b/packages/design/components/EditorForm/__test__/EditorForm.test.tsx
@@ -5,8 +5,8 @@ import type { EditorFormProps } from '..';
 import EditorForm from '..';
 
 const TestEditorForm = (props: EditorFormProps) => {
-  const [content, setContent] = useState('');
-  return <EditorForm content={content} onChange={setContent} {...props} />;
+  const [value, setValue] = useState('');
+  return <EditorForm value={value} onChange={setValue} {...props} />;
 };
 
 describe('<EditorForm />', () => {

--- a/packages/design/components/EditorForm/index.tsx
+++ b/packages/design/components/EditorForm/index.tsx
@@ -5,7 +5,7 @@ import React, { forwardRef } from 'react';
 
 import Button from '../Button';
 import Link from '../Typography/Link';
-import type { EditorProps, EditorRef } from './Editor';
+import type { EditorProps } from './Editor';
 import Editor from './Editor';
 
 export interface EditorFormProps extends EditorProps {
@@ -28,7 +28,7 @@ export interface EditorFormProps extends EditorProps {
   hideCancel?: boolean;
 }
 
-const EditorForm = forwardRef<EditorRef, EditorFormProps>(
+const EditorForm = forwardRef<HTMLTextAreaElement, EditorFormProps>(
   (
     {
       className,

--- a/packages/design/components/EditorForm/index.tsx
+++ b/packages/design/components/EditorForm/index.tsx
@@ -51,7 +51,7 @@ const EditorForm = forwardRef<HTMLTextAreaElement, EditorFormProps>(
           <Button
             shape='rounded'
             className='bgm-editor__button bgm-editor__button--confirm'
-            onClick={() => onConfirm?.(props.content ?? '')}
+            onClick={() => onConfirm?.(props.value ?? '')}
           >
             {confirmText}
           </Button>

--- a/packages/design/components/Topic/ReplyForm.tsx
+++ b/packages/design/components/Topic/ReplyForm.tsx
@@ -56,7 +56,7 @@ const ReplyForm = ({
     <EditorForm
       onCancel={onCancel}
       placeholder={placeholder}
-      content={content}
+      value={content}
       // TODO: use loading state
       confirmText={sending ? '...' : undefined}
       onChange={onChange}


### PR DESCRIPTION
为了更方便地配合 react-hook-form 使用：
- 让 Editor 直接暴露 textarea 的 ref，在校验不通过时能够自动聚焦输入框
- 将 content 参数重命名为 value，与 react-hook-form 匹配，在 render 函数中可以直接使用 `{...field}`
- 向下传递 react-hook-form 要求的两个参数 `name` 和 `onBlur`

使用方法：
```javascript
          <Controller
            name='content'
            control={control}
            render={({ field }) => (
              <EditorForm
                onConfirm={() => {
                  handleSubmit(onSubmit)();
                }}
                {...field}
              />
            )}
          />
```
