### PR TITLE
fix: enter key not working in form

### DIFF
--- a/packages/design/components/Form/index.tsx
+++ b/packages/design/components/Form/index.tsx
@@ -35,16 +35,7 @@ type FormProps = PropsWithChildren<{
 const Form = ({ children, labelWidth, className, onKeyDown, ...rest }: FormProps) => {
   return (
     <FormContext.Provider value={{ labelWidth: labelWidth ?? 12 }}>
-      <form
-        className={cn('bgm-form', className)}
-        onKeyDown={(e) => {
-          onKeyDown?.(e);
-          if (e.key === 'Enter') {
-            e.preventDefault();
-          }
-        }}
-        {...rest}
-      >
+      <form className={cn('bgm-form', className)} onKeyDown={onKeyDown} {...rest}>
         {children}
       </form>
     </FormContext.Provider>

--- a/packages/website/src/pages/index/subject/[id]/wiki/edit_detail.tsx
+++ b/packages/website/src/pages/index/subject/[id]/wiki/edit_detail.tsx
@@ -111,6 +111,12 @@ const WikiInfoItem = ({
     >
       <Input.Group
         className={cn(style.formInputGroup, level === 2 && style.formInputGroupSecondary)}
+        onKeyDown={(e) => {
+          // 阻止回车提交表单
+          if (e.key === 'Enter') {
+            e.preventDefault();
+          }
+        }}
       >
         <Input
           tabIndex={1} // 帮助在按 Tab 时能保证获取下一个 Input，不然下一个会 focus 到 <Cursor/>

--- a/packages/website/src/pages/index/subject/[id]/wiki/edit_detail.tsx
+++ b/packages/website/src/pages/index/subject/[id]/wiki/edit_detail.tsx
@@ -245,7 +245,9 @@ const WikiEditDetailDetailPage: React.FC = () => {
     wikiRef.current = parseWiki(subjectWikiInfo.infobox);
     monoEditorInstanceRef.current?.setValue(subjectWikiInfo.infobox);
     setWikiElement(toWikiElement(wikiRef.current));
-  }, [subjectWikiInfo.infobox]);
+    // https://github.com/bangumi/frontend/pull/312#discussion_r1086401410
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const onSubmit = useCallback(
     ({ commitMessage, subject }: FormData) => {

--- a/packages/website/src/pages/index/subject/[id]/wiki/edit_detail.tsx
+++ b/packages/website/src/pages/index/subject/[id]/wiki/edit_detail.tsx
@@ -100,7 +100,6 @@ const WikiInfoItem = ({
     <div
       className={cn(style.formDetailInfoItem, isArray(item.value) && style.draggableBox)}
       onKeyDown={(e) => {
-        console.log(e);
         if (e.ctrlKey && e.key === 'Enter') {
           level === 1 && switchWikiElementToArray?.(index); /** 只对一级菜单有效 */
         }
@@ -246,7 +245,7 @@ const WikiEditDetailDetailPage: React.FC = () => {
     wikiRef.current = parseWiki(subjectWikiInfo.infobox);
     monoEditorInstanceRef.current?.setValue(subjectWikiInfo.infobox);
     setWikiElement(toWikiElement(wikiRef.current));
-  }, []);
+  }, [subjectWikiInfo.infobox]);
 
   const onSubmit = useCallback(
     ({ commitMessage, subject }: FormData) => {
@@ -293,7 +292,7 @@ const WikiEditDetailDetailPage: React.FC = () => {
           toast('提交失败，请稍后再试');
         });
     },
-    [wikiElement, editorType, mutateHistory],
+    [wikiElement, editorType, mutateHistory, subjectId],
   );
 
   const handleSetEditorType = (type: EditorType) => {
@@ -453,7 +452,7 @@ const WikiEditDetailDetailPage: React.FC = () => {
         setValue('subject.platform', prePlatform);
       }
     },
-    [editorType, prePlatform],
+    [editorType, prePlatform, setValue, subjectWikiInfo.typeID],
   );
 
   return (


### PR DESCRIPTION
e.g. [wiki edit page](http://localhost:5173/subject/363612/wiki/edit_detail) 的 monaco-editor 和 textarea 无法使用 enter 键换行

@FoundTheWOUT 原来的这个 `preventDefault` 是有何用意？