### PR TITLE
feat: button link

### DIFF
--- a/packages/design/components/Button/__test__/Button.test.tsx
+++ b/packages/design/components/Button/__test__/Button.test.tsx
@@ -54,6 +54,15 @@ describe('Text Button', () => {
   });
 });
 
+it('should render button link', () => {
+  const { container } = render(
+    <Button.Link to='https://bgm.tv' isExternal>
+      Bangumi
+    </Button.Link>,
+  );
+  expect(container.firstChild).toMatchSnapshot();
+});
+
 it.each(['square', 'rounded'] as const)('should render button of shape %s', (shape) => {
   const { container } = render(
     <Button type='primary' shape={shape}>

--- a/packages/design/components/Button/__test__/__snapshots__/Button.test.tsx.snap
+++ b/packages/design/components/Button/__test__/__snapshots__/Button.test.tsx.snap
@@ -98,7 +98,7 @@ exports[`Text Button should render button of size small 1`] = `
 
 exports[`should render button link 1`] = `
 <a
-  class="bgm-link bgm-button bgm-button--link bgm-button--primary"
+  class="bgm-button bgm-button--link bgm-button--primary"
   href="https://bgm.tv"
 >
   Bangumi

--- a/packages/design/components/Button/__test__/__snapshots__/Button.test.tsx.snap
+++ b/packages/design/components/Button/__test__/__snapshots__/Button.test.tsx.snap
@@ -96,6 +96,15 @@ exports[`Text Button should render button of size small 1`] = `
 </button>
 `;
 
+exports[`should render button link 1`] = `
+<a
+  class="bgm-link bgm-button bgm-button--link bgm-button--primary"
+  href="https://bgm.tv"
+>
+  Bangumi
+</a>
+`;
+
 exports[`should render button of shape rounded 1`] = `
 <button
   class="bgm-button bgm-button--primary"

--- a/packages/design/components/Button/button.stories.tsx
+++ b/packages/design/components/Button/button.stories.tsx
@@ -1,12 +1,14 @@
 import type { ComponentMeta, Story } from '@storybook/react';
 import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
 
-import type { ButtonProps } from '.';
+import type { ButtonLinkProps, ButtonProps } from '.';
 import Button from '.';
 
 const storyMeta: ComponentMeta<typeof Button> = {
   title: 'modern/Button',
   component: Button,
+  subcomponents: { 'Button.Link': Button.Link },
   argTypes: {
     disabled: { control: 'boolean' },
     color: { control: 'select', options: ['default', 'blue', 'gray'] },
@@ -100,4 +102,27 @@ Disabled.args = {
   type: 'primary',
   disabled: true,
   children: 'Disabled',
+};
+
+const ButtonLinkTemplate: Story<ButtonLinkProps> = (args) => {
+  return (
+    <MemoryRouter>
+      <Button.Link {...args}>{args.children}</Button.Link>
+    </MemoryRouter>
+  );
+};
+
+export const Link = ButtonLinkTemplate.bind({});
+Link.args = {
+  to: 'https://bgm.tv',
+  isExternal: true,
+  target: '_blank',
+  children: 'Bangumi 番组计划',
+};
+Link.parameters = {
+  docs: {
+    description: {
+      story: '按钮的链接版本，使用方法与 `Typography.Link` 相同。',
+    },
+  },
 };

--- a/packages/design/components/Button/index.tsx
+++ b/packages/design/components/Button/index.tsx
@@ -1,19 +1,26 @@
 import './style';
 
 import classNames from 'classnames';
-import type { FC, MouseEventHandler } from 'react';
+import type { MouseEventHandler } from 'react';
 import React from 'react';
 
-export type ButtonProps = Omit<JSX.IntrinsicElements['button'], 'type' | 'onClick'> & {
-  onClick?: MouseEventHandler; // desserts for story book
+import type { LinkProps } from '../Typography';
+import Typography from '../Typography';
+
+export interface ButtonCommonProps {
   type?: 'primary' | 'secondary' | 'text';
   shape?: 'square' | 'rounded';
   size?: 'large' | 'medium' | 'small';
   color?: 'default' | 'blue' | 'gray';
-  htmlType?: JSX.IntrinsicElements['button']['type'];
-};
+}
 
-const Button: FC<ButtonProps> = ({
+export type ButtonProps = Omit<JSX.IntrinsicElements['button'], 'type' | 'onClick'> &
+  ButtonCommonProps & {
+    onClick?: MouseEventHandler; // desserts for story book
+    htmlType?: JSX.IntrinsicElements['button']['type'];
+  };
+
+const Button = ({
   disabled = false,
   className,
   type = 'primary',
@@ -23,17 +30,19 @@ const Button: FC<ButtonProps> = ({
   children,
   htmlType,
   ...rest
-}) => {
+}: ButtonProps) => {
   return (
     <button
       className={classNames(
         'bgm-button',
         className,
-        disabled && 'bgm-button--disabled',
+        { 'bgm-button--disabled': disabled },
         `bgm-button--${type}`,
-        shape !== 'rounded' && `bgm-button--shape-${shape}`,
-        size !== 'large' && `bgm-button--size-${size}`,
-        color !== 'default' && `bgm-button--color-${color}`,
+        {
+          [`bgm-button--shape-${shape}`]: shape !== 'rounded',
+          [`bgm-button--size-${size}`]: size !== 'large',
+          [`bgm-button--color-${color}`]: color !== 'default',
+        },
       )}
       type={htmlType}
       disabled={disabled}
@@ -43,5 +52,32 @@ const Button: FC<ButtonProps> = ({
     </button>
   );
 };
+
+export type ButtonLinkProps = LinkProps & ButtonCommonProps;
+
+export const ButtonLink = ({
+  children,
+  className,
+  type = 'primary',
+  shape = 'rounded',
+  size = 'large',
+  color = 'default',
+  ...props
+}: ButtonLinkProps) => {
+  return (
+    <Typography.Link
+      className={classNames('bgm-button', className, 'bgm-button--link', `bgm-button--${type}`, {
+        [`bgm-button--shape-${shape}`]: shape !== 'rounded',
+        [`bgm-button--size-${size}`]: size !== 'large',
+        [`bgm-button--color-${color}`]: color !== 'default',
+      })}
+      {...props}
+    >
+      {children}
+    </Typography.Link>
+  );
+};
+
+Button.Link = ButtonLink;
 
 export default Button;

--- a/packages/design/components/Button/index.tsx
+++ b/packages/design/components/Button/index.tsx
@@ -71,6 +71,7 @@ export const ButtonLink = ({
         [`bgm-button--size-${size}`]: size !== 'large',
         [`bgm-button--color-${color}`]: color !== 'default',
       })}
+      noStyle
       {...props}
     >
       {children}

--- a/packages/design/components/Button/style/index.less
+++ b/packages/design/components/Button/style/index.less
@@ -91,9 +91,8 @@
     cursor: default;
   }
 
-  // 强制覆盖.bgm-link的样式
-  a {
-    color: inherit !important;
-    text-decoration: none !important;
+  &--link {
+    display: inline-flex;
+    text-decoration: none;
   }
 }

--- a/packages/design/components/Typography/Link.tsx
+++ b/packages/design/components/Typography/Link.tsx
@@ -6,6 +6,7 @@ import { Link as RouterLink } from 'react-router-dom';
 export interface LinkProps extends RouterLinkProps {
   isExternal?: boolean;
   fontWeight?: 'bold';
+  noStyle?: boolean;
 }
 
 const Link: React.FC<LinkProps> = ({
@@ -14,15 +15,18 @@ const Link: React.FC<LinkProps> = ({
   children,
   fontWeight,
   isExternal = false,
+  noStyle = false,
   ...rest
 }) => {
-  const resolvedClassnames = classNames(
-    'bgm-link',
-    {
-      'bgm-link--bold': fontWeight === 'bold',
-    },
-    className,
-  );
+  const resolvedClassnames = noStyle
+    ? className
+    : classNames(
+        'bgm-link',
+        {
+          'bgm-link--bold': fontWeight === 'bold',
+        },
+        className,
+      );
 
   if (isExternal && typeof to === 'string') {
     return (

--- a/packages/design/components/Typography/__test__/Link.spec.tsx
+++ b/packages/design/components/Typography/__test__/Link.spec.tsx
@@ -22,3 +22,9 @@ it('should render external link', () => {
 
   expect(asFragment()).toMatchSnapshot();
 });
+
+it('should render no-style link', () => {
+  const { asFragment } = render(<Link to='/a' noStyle />, { wrapper: LinkTestWrapper });
+
+  expect(asFragment()).toMatchSnapshot();
+});

--- a/packages/design/components/Typography/__test__/__snapshots__/Link.spec.tsx.snap
+++ b/packages/design/components/Typography/__test__/__snapshots__/Link.spec.tsx.snap
@@ -17,3 +17,11 @@ exports[`should render internal link 1`] = `
   />
 </DocumentFragment>
 `;
+
+exports[`should render no-style link 1`] = `
+<DocumentFragment>
+  <a
+    href="/a"
+  />
+</DocumentFragment>
+`;

--- a/packages/design/components/Typography/style/Link.less
+++ b/packages/design/components/Typography/style/Link.less
@@ -1,6 +1,6 @@
 @import (reference) '../../../theme/base';
 
-:not(.bgm-button).bgm-link {
+.bgm-link {
   &:link,
   &:visited,
   &:active {

--- a/packages/design/components/Typography/style/Link.less
+++ b/packages/design/components/Typography/style/Link.less
@@ -1,6 +1,6 @@
 @import (reference) '../../../theme/base';
 
-.bgm-link {
+:not(.bgm-button).bgm-link {
   &:link,
   &:visited,
   &:active {

--- a/packages/website/src/pages/index/group/components/GroupInfo.tsx
+++ b/packages/website/src/pages/index/group/components/GroupInfo.tsx
@@ -25,15 +25,15 @@ const GroupInfo = memo(({ group }: { group: Group }) => (
       isClamped
     />
     <div className={styles.groupOpinions}>
-      <Button type='secondary' size='medium'>
-        <Link to={`/group/${group.name}`}>小组概览</Link>
-      </Button>
-      <Button type='secondary' size='medium'>
-        <Link to={`/group/${group.name}/forum`}>组内讨论</Link>
-      </Button>
-      <Button type='secondary' size='medium'>
-        <Link to={`/group/${group.name}/members`}>小组成员</Link>
-      </Button>
+      <Button.Link type='secondary' size='medium' to={`/group/${group.name}`}>
+        小组概览
+      </Button.Link>
+      <Button.Link type='secondary' size='medium' to={`/group/${group.name}/forum`}>
+        组内讨论
+      </Button.Link>
+      <Button.Link type='secondary' size='medium' to={`/group/${group.name}/members`}>
+        小组成员
+      </Button.Link>
     </div>
   </Section>
 ));


### PR DESCRIPTION
close #329

由于 Less 编译的缘故，`.bgm-link` 的样式会覆盖 `.bgm-button` 的样式，本来可以将 `.bgm-button` 细化为 `a.bgm-button` 和 `button.bgm-button` 提高优先级，但这样又会影响在 Button 上加的 class，所以还是在 `.bgm-link` 做了改动