### PR TITLE
feat: BBcode editor disable horizontal resizing

### DIFF
--- a/packages/design/components/EditorForm/__test__/__snapshots__/EditorForm.test.tsx.snap
+++ b/packages/design/components/EditorForm/__test__/__snapshots__/EditorForm.test.tsx.snap
@@ -57,7 +57,11 @@ exports[`<EditorForm /> render correctly with props 1`] = `
       <span
         class="bgm-editor__bbcode-tip"
       >
-        使用 Ctrl+Enter 或 Alt+S 快速提交 | 
+        <span
+          class="desktop-only"
+        >
+          使用 Ctrl+Enter 或 Alt+S 快速提交 |
+        </span>
         <a
           class="bgm-link"
           href="https://bgm.tv/help/bbcode"

--- a/packages/design/components/EditorForm/__test__/__snapshots__/EditorForm.test.tsx.snap
+++ b/packages/design/components/EditorForm/__test__/__snapshots__/EditorForm.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`<EditorForm /> render correctly with props 1`] = `
         <span
           class="desktop-only"
         >
-          使用 Ctrl+Enter 或 Alt+S 快速提交 |
+          使用 Ctrl+Enter 或 Alt+S 快速提交 | 
         </span>
         <a
           class="bgm-link"

--- a/packages/design/components/EditorForm/__test__/__snapshots__/EditorForm.test.tsx.snap
+++ b/packages/design/components/EditorForm/__test__/__snapshots__/EditorForm.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`<EditorForm /> render correctly with props 1`] = `
         class="bgm-editor__bbcode-tip"
       >
         <span
-          class="sm-screen-hidden"
+          class="bgm-editor__bbcode-tip__left"
         >
           使用 Ctrl+Enter 或 Alt+S 快速提交 | 
         </span>

--- a/packages/design/components/EditorForm/__test__/__snapshots__/EditorForm.test.tsx.snap
+++ b/packages/design/components/EditorForm/__test__/__snapshots__/EditorForm.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`<EditorForm /> render correctly with props 1`] = `
         class="bgm-editor__bbcode-tip"
       >
         <span
-          class="desktop-only"
+          class="sm-screen-hidden"
         >
           使用 Ctrl+Enter 或 Alt+S 快速提交 | 
         </span>

--- a/packages/design/components/EditorForm/index.tsx
+++ b/packages/design/components/EditorForm/index.tsx
@@ -64,7 +64,7 @@ const EditorForm = forwardRef<HTMLTextAreaElement, EditorFormProps>(
             </Button>
           )}
           <span className='bgm-editor__bbcode-tip'>
-            使用 Ctrl+Enter 或 Alt+S 快速提交 |{' '}
+            <span className='desktop-only'>使用 Ctrl+Enter 或 Alt+S 快速提交 |</span>
             <Link isExternal to='https://bgm.tv/help/bbcode'>
               BBCode指南
             </Link>

--- a/packages/design/components/EditorForm/index.tsx
+++ b/packages/design/components/EditorForm/index.tsx
@@ -64,7 +64,7 @@ const EditorForm = forwardRef<HTMLTextAreaElement, EditorFormProps>(
             </Button>
           )}
           <span className='bgm-editor__bbcode-tip'>
-            <span className='desktop-only'>使用 Ctrl+Enter 或 Alt+S 快速提交 | </span>
+            <span className='sm-screen-hidden'>使用 Ctrl+Enter 或 Alt+S 快速提交 | </span>
             <Link isExternal to='https://bgm.tv/help/bbcode'>
               BBCode指南
             </Link>

--- a/packages/design/components/EditorForm/index.tsx
+++ b/packages/design/components/EditorForm/index.tsx
@@ -42,10 +42,8 @@ const EditorForm = forwardRef<HTMLTextAreaElement, EditorFormProps>(
     },
     ref,
   ) => {
-    const classNames = classnames('bgm-editor__form', className);
-
     return (
-      <div className={classNames} style={style}>
+      <div className={classnames('bgm-editor__form', className)} style={style}>
         <Editor ref={ref} onConfirm={onConfirm} {...props} />
         <div className='bgm-editor__submit'>
           <Button

--- a/packages/design/components/EditorForm/index.tsx
+++ b/packages/design/components/EditorForm/index.tsx
@@ -60,7 +60,9 @@ const EditorForm = forwardRef<HTMLTextAreaElement, EditorFormProps>(
             </Button>
           )}
           <span className='bgm-editor__bbcode-tip'>
-            <span className='sm-screen-hidden'>使用 Ctrl+Enter 或 Alt+S 快速提交 | </span>
+            <span className='bgm-editor__bbcode-tip__left'>
+              使用 Ctrl+Enter 或 Alt+S 快速提交 |{' '}
+            </span>
             <Link isExternal to='https://bgm.tv/help/bbcode'>
               BBCode指南
             </Link>

--- a/packages/design/components/EditorForm/index.tsx
+++ b/packages/design/components/EditorForm/index.tsx
@@ -64,7 +64,7 @@ const EditorForm = forwardRef<HTMLTextAreaElement, EditorFormProps>(
             </Button>
           )}
           <span className='bgm-editor__bbcode-tip'>
-            <span className='desktop-only'>使用 Ctrl+Enter 或 Alt+S 快速提交 |</span>
+            <span className='desktop-only'>使用 Ctrl+Enter 或 Alt+S 快速提交 | </span>
             <Link isExternal to='https://bgm.tv/help/bbcode'>
               BBCode指南
             </Link>

--- a/packages/design/components/EditorForm/style/index.less
+++ b/packages/design/components/EditorForm/style/index.less
@@ -2,7 +2,6 @@
 @import (reference) '../../../components/Form/style/index';
 
 @toolbox-width: 215px;
-@text-width: 500px; //TODO: fix-me:breaking on mobile style
 
 .bgm-editor {
   &__container {
@@ -13,7 +12,7 @@
     border-radius: 12px;
     padding: 8px 6px 6px;
     box-sizing: border-box;
-    max-width: 100%;
+    width: 100%;
   }
 
   &__toolbar {
@@ -47,8 +46,7 @@
   &__text {
     flex: 1 0 auto;
     padding: 0 6px;
-    max-width: calc(100% - 12px); // max width fit __container
-    min-width: @text-width;
+    resize: vertical;
     border: none;
     outline: none;
     color: @gray-100;
@@ -65,13 +63,6 @@
     flex-direction: column;
     align-items: flex-start;
     justify-content: flex-start;
-    // https://stackoverflow.com/questions/43809612/prevent-a-child-element-from-overflowing-its-parent-in-flexbox
-    // bgm-editor__form 将有可能作为 flex item 使用！
-    // flex item 会初始 min-width: auto。
-    // min-width: auto 时，flex item 可以自由 expand 和 shrink。
-    // 我们不想该 item(bgm-editor__form) 被自由伸缩，顾有此选项
-    // * 注意：为了避免混淆，真实的 min width 我们在 __text 中控制
-    min-width: 0;
   }
 
   &__submit {

--- a/packages/design/components/EditorForm/style/index.less
+++ b/packages/design/components/EditorForm/style/index.less
@@ -77,6 +77,10 @@
     .bgm-editor__bbcode-tip {
       color: @gray-60;
       line-height: 24px;
+
+      &__left {
+        .sm-screen-hidden();
+      }
     }
   }
 

--- a/packages/design/components/EditorForm/style/index.less
+++ b/packages/design/components/EditorForm/style/index.less
@@ -32,7 +32,7 @@
     flex: 1 0 auto;
     padding: 0;
     max-width: 100%; // max width fit __container
-    min-width: calc(@text-width + 12px);
+    min-width: calc(@text-width + 12px); // 12px is __container width
     border: none;
     outline: none;
     color: @gray-100;
@@ -53,7 +53,13 @@
     flex-direction: column;
     align-items: flex-start;
     justify-content: flex-start;
-    min-width: @text-width;
+    // https://stackoverflow.com/questions/43809612/prevent-a-child-element-from-overflowing-its-parent-in-flexbox
+    // bgm-editor__form 将有可能作为 flex item 使用！
+    // flex item 会初始 min-width: auto。
+    // min-width: auto 时，flex item 可以自由 expand 和 shrink。
+    // 我们不想该 item(bgm-editor__form) 被自由伸缩，顾有此选项
+    // * 注意：为了避免混淆，真实的 min width 我们在 __text 中控制
+    min-width: 0;
   }
 
   &__submit {

--- a/packages/design/components/EditorForm/style/index.less
+++ b/packages/design/components/EditorForm/style/index.less
@@ -10,7 +10,7 @@
     min-height: 162px;
     border: 2px solid @gray-10;
     border-radius: 12px;
-    padding: 10px 0 0 12px;
+    padding: 8px 6px 6px;
     box-sizing: border-box;
     max-width: 100%;
   }
@@ -21,6 +21,7 @@
     align-items: center;
     height: 26px;
     width: @toolbox-width;
+    padding: 0 8px;
     margin-bottom: 10px;
 
     > svg {
@@ -30,9 +31,9 @@
 
   &__text {
     flex: 1 0 auto;
-    padding: 0;
-    max-width: 100%; // max width fit __container
-    min-width: calc(@text-width + 12px); // 12px is __container width
+    padding: 0 6px;
+    max-width: calc(100% - 12px); // max width fit __container
+    min-width: @text-width;
     border: none;
     outline: none;
     color: @gray-100;

--- a/packages/design/components/EditorForm/style/index.less
+++ b/packages/design/components/EditorForm/style/index.less
@@ -1,7 +1,7 @@
 @import '../../../theme/base';
 
 @toolbox-width: 215px;
-@text-width: 682px;
+@text-width: 500px; //TODO: fix-me:breaking on mobile style
 
 .bgm-editor {
   &__container {
@@ -10,8 +10,9 @@
     min-height: 162px;
     border: 2px solid @gray-10;
     border-radius: 12px;
-    padding: 8px 6px 6px;
-    z-index: 9999;
+    padding: 10px 0 0 12px;
+    box-sizing: border-box;
+    max-width: 100%;
   }
 
   &__toolbox {
@@ -20,7 +21,6 @@
     align-items: center;
     height: 26px;
     width: @toolbox-width;
-    padding: 0 8px;
     margin-bottom: 10px;
 
     > svg {
@@ -30,9 +30,9 @@
 
   &__text {
     flex: 1 0 auto;
-    padding: 0 6px;
-    min-width: @toolbox-width;
-    width: @text-width;
+    padding: 0;
+    max-width: 100%; // max width fit __container
+    min-width: calc(@text-width + 12px);
     border: none;
     outline: none;
     color: @gray-100;
@@ -53,7 +53,7 @@
     flex-direction: column;
     align-items: flex-start;
     justify-content: flex-start;
-    width: @text-width;
+    min-width: @text-width;
   }
 
   &__submit {

--- a/packages/design/components/Form/Form.stories.tsx
+++ b/packages/design/components/Form/Form.stories.tsx
@@ -107,3 +107,39 @@ export const Compact: ComponentStory<typeof Form> = (args) => {
     </Form>
   );
 };
+
+export const CompactWithInputGroup = () => {
+  return (
+    <Form compact style={{ maxWidth: 675 }}>
+      <Form.Item>
+        <Input type='text' placeholder='给新帖取一个标题' />
+      </Form.Item>
+      <Form.Item>
+        <Input.Group>
+          <Input
+            placeholder='项目名'
+            wrapperStyle={{
+              width: '20%',
+            }}
+          />
+          <Input />
+          <Input />
+        </Input.Group>
+      </Form.Item>
+      <Form.Item>
+        <Input type='text' placeholder='给新帖取一个标题' />
+      </Form.Item>
+      <Form.Item>
+        <Input.Group>
+          <Input
+            placeholder='项目名'
+            wrapperStyle={{
+              width: '20%',
+            }}
+          />
+          <Input />
+        </Input.Group>
+      </Form.Item>
+    </Form>
+  );
+};

--- a/packages/design/components/Form/Form.stories.tsx
+++ b/packages/design/components/Form/Form.stories.tsx
@@ -89,7 +89,10 @@ export const Compact: ComponentStory<typeof Form> = (args) => {
   const [content, setContent] = useState('');
 
   return (
-    <Form compact style={{ width: 675 }} {...args}>
+    <Form compact style={{ maxWidth: 675 }} {...args}>
+      <Form.Item>
+        <Input type='text' placeholder='给新帖取一个标题' />
+      </Form.Item>
       <Form.Item>
         <Input type='text' placeholder='给新帖取一个标题' />
       </Form.Item>

--- a/packages/design/components/Form/__test__/__snapshots__/Form.spec.tsx.snap
+++ b/packages/design/components/Form/__test__/__snapshots__/Form.spec.tsx.snap
@@ -146,7 +146,7 @@ exports[`Form Components render compact layout properly 1`] = `
             <span
               class="desktop-only"
             >
-              使用 Ctrl+Enter 或 Alt+S 快速提交 |
+              使用 Ctrl+Enter 或 Alt+S 快速提交 | 
             </span>
             <a
               class="bgm-link"

--- a/packages/design/components/Form/__test__/__snapshots__/Form.spec.tsx.snap
+++ b/packages/design/components/Form/__test__/__snapshots__/Form.spec.tsx.snap
@@ -143,8 +143,11 @@ exports[`Form Components render compact layout properly 1`] = `
           <span
             class="bgm-editor__bbcode-tip"
           >
-            使用 Ctrl+Enter 或 Alt+S 快速提交 |
-             
+            <span
+              class="desktop-only"
+            >
+              使用 Ctrl+Enter 或 Alt+S 快速提交 |
+            </span>
             <a
               class="bgm-link"
               href="https://bgm.tv/help/bbcode"

--- a/packages/design/components/Form/__test__/__snapshots__/Form.spec.tsx.snap
+++ b/packages/design/components/Form/__test__/__snapshots__/Form.spec.tsx.snap
@@ -137,9 +137,10 @@ exports[`Form Components render compact layout properly 1`] = `
           class="bgm-editor__bbcode-tip"
         >
           <span
-            class="sm-screen-hidden"
+            class="bgm-editor__bbcode-tip__left"
           >
-            使用 Ctrl+Enter 或 Alt+S 快速提交 | 
+            使用 Ctrl+Enter 或 Alt+S 快速提交 |
+             
           </span>
           <a
             class="bgm-link"

--- a/packages/design/components/Form/__test__/__snapshots__/Form.spec.tsx.snap
+++ b/packages/design/components/Form/__test__/__snapshots__/Form.spec.tsx.snap
@@ -136,8 +136,11 @@ exports[`Form Components render compact layout properly 1`] = `
         <span
           class="bgm-editor__bbcode-tip"
         >
-          使用 Ctrl+Enter 或 Alt+S 快速提交 |
-           
+          <span
+            class="sm-screen-hidden"
+          >
+            使用 Ctrl+Enter 或 Alt+S 快速提交 | 
+          </span>
           <a
             class="bgm-link"
             href="https://bgm.tv/help/bbcode"

--- a/packages/design/components/Form/style/index.less
+++ b/packages/design/components/Form/style/index.less
@@ -1,7 +1,7 @@
 @import '../../../theme/base';
 
 .bgm-form {
-  display: flex;
+  display: inline-flex;
   flex-direction: column;
   gap: 1rem;
 
@@ -64,12 +64,6 @@
 
     .bgm-form__input {
       padding: 0.75rem;
-    }
-
-    .bgm-form__editor {
-      align-items: stretch;
-      width: auto;
-      flex: 1;
     }
   }
 }

--- a/packages/design/components/Topic/style/Comment.less
+++ b/packages/design/components/Topic/style/Comment.less
@@ -32,7 +32,9 @@
 
   &__box {
     margin-left: 12px;
-    width: 100%;
+    flex: 1;
+    // this trick is same to EditorForm
+    min-width: 0;
   }
 
   &__main {

--- a/packages/design/theme/base.less
+++ b/packages/design/theme/base.less
@@ -3,3 +3,9 @@
 @sm: 640px;
 @md: 768px;
 @lg: 1024px;
+
+.desktop-only {
+  @media (max-width: @sm) {
+    display: none;
+  }
+}

--- a/packages/design/theme/base.less
+++ b/packages/design/theme/base.less
@@ -3,9 +3,3 @@
 @sm: 640px;
 @md: 768px;
 @lg: 1024px;
-
-.desktop-only {
-  @media (max-width: @sm) {
-    display: none;
-  }
-}

--- a/packages/design/theme/base.less
+++ b/packages/design/theme/base.less
@@ -1,17 +1,2 @@
-@import './variables';
-
-@sm: 640px;
-@md: 768px;
-@lg: 1024px;
-
-.no-top-border {
-  border-top: none;
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
-}
-
-.no-bottom-border {
-  border-bottom: none;
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
-}
+@import './variables.less';
+@import './mixins.less';

--- a/packages/design/theme/mixins.less
+++ b/packages/design/theme/mixins.less
@@ -1,0 +1,5 @@
+.sm-screen-hidden {
+  @media (max-width: @sm) {
+    display: none;
+  }
+}

--- a/packages/design/theme/mixins.less
+++ b/packages/design/theme/mixins.less
@@ -1,5 +1,19 @@
+@import './variables.less';
+
 .sm-screen-hidden {
   @media (max-width: @sm) {
     display: none;
   }
+}
+
+.no-top-border {
+  border-top: none;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.no-bottom-border {
+  border-bottom: none;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 }

--- a/packages/design/theme/variables.less
+++ b/packages/design/theme/variables.less
@@ -17,3 +17,8 @@
 @blue-100: #54b5df;
 @blue-doing: #8fcaec;
 @blue-collect: #3db3f5;
+
+/* Response */
+@sm: 640px;
+@md: 768px;
+@lg: 1024px;

--- a/packages/website/src/pages/index/group/[name]/components/NewTopicForm.module.less
+++ b/packages/website/src/pages/index/group/[name]/components/NewTopicForm.module.less
@@ -19,20 +19,13 @@
 
 .contentEditor {
   grid-column: 1;
-
-  :global(.bgm-editor) {
-    &__form,
-    &__text {
-      width: auto;
-    }
-
-    &__container {
-      align-self: stretch;
-    }
-  }
 }
 
 .quickPostForm {
+  @media (max-width: @md) {
+    width: 100%;
+  }
+
+  width: 75%;
   margin-top: 40px;
-  max-width: 100%;
 }

--- a/packages/website/src/pages/index/group/[name]/components/NewTopicForm.module.less
+++ b/packages/website/src/pages/index/group/[name]/components/NewTopicForm.module.less
@@ -34,5 +34,5 @@
 
 .quickPostForm {
   margin-top: 40px;
-  max-width: 682px;
+  max-width: 100%;
 }

--- a/packages/website/src/pages/index/group/[name]/components/NewTopicForm.tsx
+++ b/packages/website/src/pages/index/group/[name]/components/NewTopicForm.tsx
@@ -77,12 +77,8 @@ const NewTopicForm = ({ quickPost = false }: { quickPost?: boolean }) => {
         // 统一由 EditorForm 的 onConfirm 处理
         onSubmit={(e) => e.preventDefault()}
       >
-        <Form.Item>
-          <FormInput quickPost />
-        </Form.Item>
-        <Form.Item>
-          <FormEditor quickPost />
-        </Form.Item>
+        <FormInput quickPost />
+        <FormEditor quickPost />
       </Form>
     );
   }

--- a/packages/website/src/pages/index/group/topic/[id]/index.module.less
+++ b/packages/website/src/pages/index/group/topic/[id]/index.module.less
@@ -12,6 +12,11 @@
   margin-top: 20px;
 
   .replyForm {
+    @media (max-width: @md) {
+      flex-basis: 100%;
+    }
+
+    flex-basis: 75%;
     margin-left: 12px;
   }
 }


### PR DESCRIPTION
ref: https://github.com/bangumi/frontend/pull/320#issuecomment-1427472398
close #361
禁用水平调宽，Editor 不设宽度（最小宽度为 EditorForm 宽度），最大宽度在 website 控制，如可以使用 `width:100%` ，`flex: 1` ，`flex-basis` 等