### PR TITLE
ci: require 2 approval to auto-merging

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -48,7 +48,7 @@ pull_request_rules:
         toggle:
           - waiting-reviewer-approval
 
-  - name: label 48h
+  - name: label waiting 48h
     conditions:
       - '#approved-reviews-by>=2'
       - '#changes-requested-reviews-by=0'

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -5,6 +5,7 @@ pull_request_rules:
       - -conflict
       - base=master
       - '#review-threads-unresolved=0'
+      - -title~=(?i)wip
       - or:
           - check-success=storybook-build
           - check-skipped=storybook-build
@@ -21,15 +22,14 @@ pull_request_rules:
       merge:
         method: squash
 
-  - name: request review
+  - name: label 'waiting-review'
     conditions:
-      - '#approved-reviews-by=0'
-      - '#review-threads-unresolved=0'
-      - '#changes-requested-reviews-by=0'
+      - '#approved-reviews-by<2'
       - -conflict
       - -draft
       - base=master
       - label!=waiting-review
+      - -title~=(?i)wip
       - or:
           - check-success=storybook-build
           - check-skipped=storybook-build
@@ -44,12 +44,12 @@ pull_request_rules:
           - check-skipped=build
     actions:
       label:
-        add:
+        toggle:
           - waiting-review
 
-  - name: add 48h label
+  - name: label 48h
     conditions:
-      - '#approved-reviews-by>=1'
+      - '#approved-reviews-by>=2'
       - -conflict
       - base=master
       - -draft
@@ -68,10 +68,8 @@ pull_request_rules:
           - check-skipped=build
     actions:
       label:
-        remove:
-          - waiting-review
         toggle:
-          - waiting-opened-48h
+          - waiting-opened-48h-before-merge
 
   - name: warn on conflicts
     conditions:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -54,6 +54,7 @@ pull_request_rules:
       - base=master
       - -draft
       - '#review-threads-unresolved=0'
+      - -title~=(?i)wip
       - or:
           - check-success=storybook-build
           - check-skipped=storybook-build

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -23,7 +23,7 @@ pull_request_rules:
       merge:
         method: squash
 
-  - name: label 'waiting-review'
+  - name: label 'waiting-reviewer-approval'
     conditions:
       - '#approved-reviews-by<2'
       - -conflict
@@ -46,7 +46,7 @@ pull_request_rules:
     actions:
       label:
         toggle:
-          - waiting-review
+          - waiting-reviewer-approval
 
   - name: label 48h
     conditions:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -5,7 +5,7 @@ pull_request_rules:
       - -conflict
       - base=master
       - '#review-threads-unresolved=0'
-      - -title~=(?i)wip
+      - -title~=(?i)\[wip\]
       - or:
           - check-success=storybook-build
           - check-skipped=storybook-build
@@ -29,7 +29,7 @@ pull_request_rules:
       - -draft
       - base=master
       - label!=waiting-review
-      - -title~=(?i)wip
+      - -title~=(?i)\[wip\]
       - or:
           - check-success=storybook-build
           - check-skipped=storybook-build
@@ -54,7 +54,7 @@ pull_request_rules:
       - base=master
       - -draft
       - '#review-threads-unresolved=0'
-      - -title~=(?i)wip
+      - -title~=(?i)\[wip\]
       - or:
           - check-success=storybook-build
           - check-skipped=storybook-build

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,6 +1,7 @@
 pull_request_rules:
   - name: Automatic merge on approval
     conditions:
+      - '#approved-reviews-by>=2'
       - 'created-at<=48:00 ago'
       - -conflict
       - base=master

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,7 @@ git push -u origin <YOUR_BRANCH>
 ## PR 规则
 
 - PR 的标题需要满足 [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) 规范的要求
+- 尚未完成的 PR 请在标题中添加 `[WIP]`，或者以 draft 状态。
 
 ### 在合并之前
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ git push -u origin <YOUR_BRANCH>
 ## PR 规则
 
 - PR 的标题需要满足 [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) 规范的要求
-- 尚未完成的 PR 请在标题中添加 `[WIP]`，或者以 draft 状态。
+- 尚未完成的 PR 请在标题中添加 `[WIP]`，或者设置为 draft 状态。
 
 ### 在合并之前
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,21 +83,20 @@ git push -u origin <YOUR_BRANCH>
   - PR 只包含 typo 的修复；
   - PR 只关于项目架构的维护（如 Github Action 的维护）；
   - PR 只包括测试用例的变更；
-- 在 48 小时之内，没有 Collaborator 要求更改；
 - 所有关于新特性与缺陷修复的 PR 都必须包含对应测试用例；
 - 如果在 `packages/design` 下面添加新的组件，需要包含一个 storybook 作为组件文档；
 - test/lint/build 等 ci 应该通过。
 
-在 PR 打开 48 小时并被任意一位 collaborator approve 之后会被 bot 自动合并。
+在 PR 打开 48 小时并被任意两位 collaborator approve 之后会被 bot 自动合并。
 
 ## 如何成为 Collaborator
 
 - Collaborator 需要对项目作出活跃的贡献；
 - 想要成为 Collaborator 的话，需要向 `README.md` 文件的 Collaborator 小节提起 PR，
   将自己添加到 Collaborator 列表中（注意列表以 GitHub ID 的字典序排列）；
-- PR 需要被至少一名 Collaborator approve；
+- PR 需要被至少两名 Collaborator approve；
 - PR 在打开 48 小时之后没有反对意见；
-- 当上述条件满足，PR 将会被合并，然后邀请新同学成为 @bangumi/frontend 组的成员；
+- 当上述条件满足，PR 将会被合并，然后邀请新同学成为 @bangumi/frontend-collaborators 组的成员；
 
 ## Developer's Certificate of Origin 1.1
 


### PR DESCRIPTION
GitHub branch protection rule 没有修改，仍然是 1 个approval，只是修改了 bot 的自动合并条件。

避免 https://github.com/bangumi/frontend/pull/320#issuecomment-1427847872