### PR TITLE
fix: duplicate key rendering `(bgm23)\n(bgm13)`

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -7,10 +7,11 @@ pull_request_rules:
       - base=master
       - '#review-threads-unresolved=0'
       - -title~=(?i)\[wip\]
-      - -check-failure=lint
-      - -check-failure=build
-      - -check-failure=test
-      - -check-failure=storybook-build
+      - and: &ci
+          - -check-failure=lint
+          - -check-failure=build
+          - -check-failure=test
+          - -check-failure=storybook-build
     actions:
       merge:
         method: squash
@@ -23,10 +24,7 @@ pull_request_rules:
       - base=master
       - -title~=(?i)\[wip\]
       - 'created-at<=00:10 ago' # label after PR is created after 10 min
-      - -check-failure=lint
-      - -check-failure=build
-      - -check-failure=test
-      - -check-failure=storybook-build
+      - and: *ci
     actions:
       label:
         toggle:
@@ -42,10 +40,7 @@ pull_request_rules:
       - -draft
       - '#review-threads-unresolved=0'
       - -title~=(?i)\[wip\]
-      - -check-failure=lint
-      - -check-failure=build
-      - -check-failure=test
-      - -check-failure=storybook-build
+      - and: *ci
     actions:
       label:
         toggle:

--- a/packages/utils/bbcode/__test__/__snapshots__/react.test.tsx.snap
+++ b/packages/utils/bbcode/__test__/__snapshots__/react.test.tsx.snap
@@ -57,10 +57,7 @@ exports[`html render bbcode string render code 1`] = `
     style={{}}
   >
     <React.Fragment>
-      <React.Fragment>
-        <React.Fragment />
-        ss[b]加粗
-      </React.Fragment>
+      ss[b]加粗
       <br />
       换行了[/b](bgm38) [/fafa [code]
     </React.Fragment>
@@ -71,10 +68,7 @@ exports[`html render bbcode string render code 1`] = `
 exports[`html render bbcode string render color 1`] = `
 [
   <React.Fragment>
-    <React.Fragment>
-      <React.Fragment />
-      我是
-    </React.Fragment>
+    我是
     <br />
     
   </React.Fragment>,
@@ -142,10 +136,7 @@ exports[`html render bbcode string render color size 1`] = `
         粗
       </strong>
       <React.Fragment>
-        <React.Fragment>
-          <React.Fragment />
-          
-        </React.Fragment>
+        
         <br />
            
       </React.Fragment>
@@ -166,10 +157,7 @@ exports[`html render bbcode string render color size 1`] = `
 exports[`html render bbcode string render img 1`] = `
 [
   <React.Fragment>
-    <React.Fragment>
-      <React.Fragment />
-      存放于其他网络服务器的图片：
-    </React.Fragment>
+    存放于其他网络服务器的图片：
     <br />
     
   </React.Fragment>,
@@ -293,10 +281,7 @@ exports[`html render bbcode string render url 1`] = `
 exports[`html render bbcode string render url 2`] = `
 [
   <React.Fragment>
-    <React.Fragment>
-      <React.Fragment />
-      带文字说明的网站链接：
-    </React.Fragment>
+    带文字说明的网站链接：
     <br />
     
   </React.Fragment>,
@@ -313,22 +298,13 @@ exports[`html render bbcode string render url 2`] = `
 exports[`html render bbcode string should render br 1`] = `
 [
   <React.Fragment>
-    <React.Fragment>
-      <React.Fragment>
-        <React.Fragment>
-          <React.Fragment>
-            <React.Fragment />
-            
-          </React.Fragment>
-          <br />
-              又名：CUP人生茶话会
-        </React.Fragment>
-        <br />
-        
-      </React.Fragment>
-      <br />
-          1.上班的时候想要回家的。
-    </React.Fragment>
+    
+    <br />
+        又名：CUP人生茶话会
+    <br />
+    
+    <br />
+        1.上班的时候想要回家的。
     <br />
         2.学校课上打瞌睡的。
   </React.Fragment>,
@@ -339,10 +315,7 @@ exports[`html render bbcode string should render br 1`] = `
     style={{}}
   />,
   <React.Fragment>
-    <React.Fragment>
-      <React.Fragment />
-      
-    </React.Fragment>
+    
     <br />
         2.学校课上打瞌睡的。
   </React.Fragment>,
@@ -353,10 +326,7 @@ exports[`html render bbcode string should render br 1`] = `
     style={{}}
   />,
   <React.Fragment>
-    <React.Fragment>
-      <React.Fragment />
-      
-    </React.Fragment>
+    
     <br />
         2.学校课上打瞌睡的。
   </React.Fragment>,
@@ -367,18 +337,11 @@ exports[`html render bbcode string should render br 1`] = `
     style={{}}
   />,
   <React.Fragment>
-    <React.Fragment>
-      <React.Fragment>
-        <React.Fragment>
-          <React.Fragment />
-          
-        </React.Fragment>
-        <br />
-        
-      </React.Fragment>
-      <br />
-      
-    </React.Fragment>
+    
+    <br />
+    
+    <br />
+    
     <br />
         
   </React.Fragment>,
@@ -448,10 +411,7 @@ exports[`react render vnode render mask 1`] = `
   }
 >
   <React.Fragment>
-    <React.Fragment>
-      <React.Fragment />
-      文字
-    </React.Fragment>
+    文字
     <br />
     换行
   </React.Fragment>
@@ -469,10 +429,7 @@ exports[`react render vnode render multi style 1`] = `
   }
 >
   <React.Fragment>
-    <React.Fragment>
-      <React.Fragment />
-      文字
-    </React.Fragment>
+    文字
     <br />
     换行了
   </React.Fragment>
@@ -524,10 +481,7 @@ exports[`react render vnode render pre children 1`] = `
   style={{}}
 >
   <React.Fragment>
-    <React.Fragment>
-      <React.Fragment />
-      文字
-    </React.Fragment>
+    文字
     <br />
     换行
   </React.Fragment>

--- a/packages/utils/bbcode/__test__/react.test.tsx
+++ b/packages/utils/bbcode/__test__/react.test.tsx
@@ -1,6 +1,3 @@
-/* eslint-disable unused-imports/no-unused-imports */
-import React from 'react';
-
 import { render, renderNode } from '../react';
 import type { VNode } from '../types';
 
@@ -170,5 +167,27 @@ describe('html render bbcode string', () => {
     `;
 
     expect(render(input)).toMatchSnapshot();
+  });
+  test('should produce unique react keys', () => {
+    const checkUniqueKeys = (item: Array<string | React.ReactElement>) => {
+      const keys = new Set<React.Key>();
+      item.forEach((i) => {
+        if (typeof i === 'string') {
+          return;
+        }
+        if (i.key !== null) {
+          expect(keys.has(i.key)).toBe(false);
+          keys.add(i.key);
+        }
+        const props = i.props as Record<string, any>;
+        if (typeof props.children === 'object') {
+          checkUniqueKeys(i.props.children);
+        }
+      });
+    };
+
+    const input = '(bgm38)\n(bgm38)\n';
+    const result = render(input);
+    checkUniqueKeys(result);
   });
 });

--- a/packages/utils/bbcode/react.tsx
+++ b/packages/utils/bbcode/react.tsx
@@ -45,18 +45,13 @@ export const renderNode = (node: NodeTypes, key?: React.Key): React.ReactElement
     if (splittedStr.length < 2) {
       return splittedStr[0] ?? '';
     }
-    return splittedStr.reduce((pre, curr, idx) => {
+    const children = splittedStr.reduce<Array<string | React.ReactElement>>((pre, curr, idx) => {
       if (idx > 0) {
-        return React.createElement(
-          React.Fragment,
-          { key: idx },
-          pre,
-          React.createElement('br', null),
-          curr,
-        );
+        return [...pre, React.createElement('br', null), curr];
       }
-      return React.createElement(React.Fragment, { key: idx }, pre, curr);
-    }, React.createElement(React.Fragment, { key }));
+      return [...pre, curr];
+    }, []);
+    return React.createElement(React.Fragment, { key }, ...children);
   }
 
   const { type, children } = node;


### PR DESCRIPTION
测试用例：
```
(bgm23)
(bgm13)
```

**Before:**
原 59 行的初始 Fragment 会变成数组 Fragment 的 children，如果数组内只有两个元素（`\n` -> `['', '']`），则最后生成的最外层 Fragment 的 key 就是最大索引值 1

![image](https://user-images.githubusercontent.com/17172063/219947296-3d99878c-1aa5-4210-9bfb-e7077557c71a.png)
![image](https://user-images.githubusercontent.com/17172063/219947364-a7192275-8f50-4a6e-a938-545641ee2cff.png)

**After:**
![image](https://user-images.githubusercontent.com/17172063/219947544-f31fbc85-69fa-4424-9ef6-9900d5d4ddfa.png)




