### PR TITLE
fix: login redirect after captcha reset

### DIFF
--- a/packages/website/src/components/Header/index.tsx
+++ b/packages/website/src/components/Header/index.tsx
@@ -149,7 +149,10 @@ const Header: FC = () => {
             </>
           ) : (
             <span className={style.userLogin}>
-              <Link className={style.link} to={`/login?backTo=${location.pathname}`}>
+              <Link
+                className={style.link}
+                to={`/login?backTo=${encodeURIComponent(location.pathname)}`}
+              >
                 登录
               </Link>
               <Link className={style.link} to='/register'>

--- a/packages/website/src/components/Header/index.tsx
+++ b/packages/website/src/components/Header/index.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react';
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 
 import { Avatar, Button, Divider, Input, Menu } from '@bangumi/design';
 import { Notification, Search as SearchIcon, Setting } from '@bangumi/icons';
@@ -90,6 +90,7 @@ if (Musume === undefined) {
 
 const Header: FC = () => {
   const { user } = useUser();
+  const location = useLocation();
 
   const [showMobileMenu, setShowMobileMenu] = useState(false);
   return (
@@ -148,7 +149,7 @@ const Header: FC = () => {
             </>
           ) : (
             <span className={style.userLogin}>
-              <Link className={style.link} to='/login'>
+              <Link className={style.link} to={`/login?backTo=${location.pathname}`}>
                 登录
               </Link>
               <Link className={style.link} to='/register'>

--- a/packages/website/src/pages/login/index.spec.tsx
+++ b/packages/website/src/pages/login/index.spec.tsx
@@ -70,18 +70,6 @@ it('should redirect user to homepage after success login', async () => {
   });
 });
 
-it('should bring user back to last page if exists', async () => {
-  const mockedNavigate = vi.fn();
-  mockedUseNavigate.mockReturnValue(mockedNavigate);
-  mockedUseLocation.mockReturnValue({ key: 'not-default' } as any);
-  mockedUseSearchParams.mockReturnValue([new URLSearchParams(), vi.fn()] as any);
-
-  mockSuccessfulLogin();
-  await waitFor(() => {
-    expect(mockedNavigate).toBeCalledWith(-1);
-  });
-});
-
 it('should redirect user to specified page', async () => {
   const mockedNavigate = vi.fn();
   mockedUseNavigate.mockReturnValue(mockedNavigate);

--- a/packages/website/src/pages/login/index.tsx
+++ b/packages/website/src/pages/login/index.tsx
@@ -1,7 +1,7 @@
 import type { TurnstileInstance } from '@marsidev/react-turnstile';
 import { Turnstile } from '@marsidev/react-turnstile';
 import React, { useRef } from 'react';
-import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useInput } from 'rooks';
 
 import { Button, Input, Message } from '@bangumi/design';
@@ -24,7 +24,6 @@ const Login: React.FC = () => {
   const password = useInput('' as string);
   const { login } = useUser();
   const navigate = useNavigate();
-  const location = useLocation();
   const [searchParams, _] = useSearchParams();
 
   const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
@@ -42,11 +41,6 @@ const Login: React.FC = () => {
     const backTo = searchParams.get('backTo');
     if (backTo) {
       navigate(backTo.startsWith('/') ? backTo : '/', { replace: true });
-    }
-    // 如果有 history 则返回上一页
-    // https://github.com/remix-run/react-router/discussions/9788
-    else if (location.key !== 'default') {
-      navigate(-1);
     }
     // 否则跳转到首页
     else {


### PR DESCRIPTION
Fix #480 

不知为何，在 Turnstile 验证码重置后 history state 会被替换，使得无法通过 `navigate(-1)` 返回上一页，例如在输错一次密码后

看了一下并没有找到原因，所以干脆把这个逻辑去掉，只留下根据 URL 传入的 backTo 进行跳转