### PR TITLE
fix: jump out for oauth with login

### DIFF
--- a/packages/website/src/pages/login/index.spec.tsx
+++ b/packages/website/src/pages/login/index.spec.tsx
@@ -5,9 +5,14 @@ import { HelmetProvider } from 'react-helmet-async';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 
 import { UserProvider } from '@bangumi/website/hooks/use-user';
+import { redirectTo } from '@bangumi/website/utils/route';
 
 import { server as mockServer } from '../../mocks/server';
 import LoginPage from '.';
+
+vi.mock('@bangumi/website/utils/route', () => ({
+  redirectTo: vi.fn(),
+}));
 
 vi.mock('@marsidev/react-turnstile', () => {
   const Turnstile = React.forwardRef<
@@ -73,7 +78,7 @@ it('should redirect user to homepage after success login', async () => {
 
   mockSuccessfulLogin();
   await waitFor(() => {
-    expect(mockedNavigate).toBeCalledWith('/', { replace: true });
+    expect(redirectTo).toBeCalledWith('/');
   });
 });
 
@@ -88,7 +93,7 @@ it('should redirect user to specified page', async () => {
 
   mockSuccessfulLogin();
   await waitFor(() => {
-    expect(mockedNavigate).toBeCalledWith('/group/sandbox', { replace: true });
+    expect(redirectTo).toBeCalledWith('/group/sandbox');
   });
 });
 
@@ -103,7 +108,7 @@ it('should redirect user to home if specified path is invalid', async () => {
 
   mockSuccessfulLogin();
   await waitFor(() => {
-    expect(mockedNavigate).toBeCalledWith('/', { replace: true });
+    expect(redirectTo).toBeCalledWith('/');
   });
 });
 

--- a/packages/website/src/pages/login/index.tsx
+++ b/packages/website/src/pages/login/index.tsx
@@ -1,7 +1,7 @@
 import type { TurnstileInstance } from '@marsidev/react-turnstile';
 import { Turnstile } from '@marsidev/react-turnstile';
 import React, { useRef } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { useInput } from 'rooks';
 
 import { Button, Input, Message } from '@bangumi/design';
@@ -24,7 +24,6 @@ const Login: React.FC = () => {
   const email = useInput('' as string);
   const password = useInput('' as string);
   const { login } = useUser();
-  const navigate = useNavigate();
   const [searchParams, _] = useSearchParams();
 
   const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
@@ -41,15 +40,10 @@ const Login: React.FC = () => {
     // 如果有 backTo 参数，则跳转到指定的页面
     const backTo = searchParams.get('backTo');
     if (backTo) {
-      // oauth 页面在 server 端，需要特殊处理
-      if (backTo.startsWith('/oauth/')) {
-        window.location.replace(backTo);
-      } else {
-        navigate(backTo.startsWith('/') ? backTo : '/', { replace: true });
-      }
+      window.location.replace(backTo.startsWith('/') ? backTo : '/');
     } else {
       // 否则跳转到首页
-      navigate('/', { replace: true });
+      window.location.replace('/');
     }
   };
 

--- a/packages/website/src/pages/login/index.tsx
+++ b/packages/website/src/pages/login/index.tsx
@@ -1,12 +1,13 @@
 import type { TurnstileInstance } from '@marsidev/react-turnstile';
 import { Turnstile } from '@marsidev/react-turnstile';
 import React, { useRef } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useInput } from 'rooks';
 
 import { Button, Input, Message } from '@bangumi/design';
 import { Password, UserLogin } from '@bangumi/icons';
 import Helmet from '@bangumi/website/components/Helmet';
+import { redirectTo } from '@bangumi/website/utils/route';
 
 import {
   CaptureError,
@@ -24,6 +25,7 @@ const Login: React.FC = () => {
   const email = useInput('' as string);
   const password = useInput('' as string);
   const { login } = useUser();
+  const navigate = useNavigate();
   const [searchParams, _] = useSearchParams();
 
   const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
@@ -40,10 +42,10 @@ const Login: React.FC = () => {
     // 如果有 backTo 参数，则跳转到指定的页面
     const backTo = searchParams.get('backTo');
     if (backTo) {
-      window.location.replace(backTo.startsWith('/') ? backTo : '/');
+      redirectTo(backTo.startsWith('/') ? backTo : '/');
     } else {
       // 否则跳转到首页
-      window.location.replace('/');
+      redirectTo('/');
     }
   };
 

--- a/packages/website/src/pages/login/index.tsx
+++ b/packages/website/src/pages/login/index.tsx
@@ -41,10 +41,14 @@ const Login: React.FC = () => {
     // 如果有 backTo 参数，则跳转到指定的页面
     const backTo = searchParams.get('backTo');
     if (backTo) {
-      navigate(backTo.startsWith('/') ? backTo : '/', { replace: true });
-    }
-    // 否则跳转到首页
-    else {
+      // oauth 页面在 server 端，需要特殊处理
+      if (backTo.startsWith('/oauth/')) {
+        window.location.replace(backTo);
+      } else {
+        navigate(backTo.startsWith('/') ? backTo : '/', { replace: true });
+      }
+    } else {
+      // 否则跳转到首页
       navigate('/', { replace: true });
     }
   };

--- a/packages/website/src/utils/route.ts
+++ b/packages/website/src/utils/route.ts
@@ -3,3 +3,7 @@ const noLayoutRoutes = new Set(['/login']);
 export function isNoLayoutRoute(pathname: string): boolean {
   return noLayoutRoutes.has(pathname);
 }
+
+export function redirectTo(pathname: string): void {
+  window.location.replace(pathname);
+}


### PR DESCRIPTION
现在登录后的转跳会使用 `window.location.replace` ，不再使用 `history.push`，允许转跳出SPA。