### PR TITLE
feat: support passkey login

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -15,6 +15,7 @@
     "@marsidev/react-turnstile": "^1.5.2",
     "@oazapfts/runtime": "^1.2.0",
     "@remix-run/router": "^1.23.3",
+    "@simplewebauthn/browser": "^13.3.0",
     "classnames": "^2.5.1",
     "dayjs": "^1.11.21",
     "lodash-es": "^4.18.1",

--- a/packages/website/src/hooks/use-user.spec.tsx
+++ b/packages/website/src/hooks/use-user.spec.tsx
@@ -1,3 +1,5 @@
+import type { AuthenticationResponseJSON } from '@simplewebauthn/browser';
+import { startAuthentication } from '@simplewebauthn/browser';
 import { renderHook, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import type { PropsWithChildren } from 'react';
@@ -14,6 +16,24 @@ import {
   useUser,
 } from './use-user';
 
+vi.mock('@simplewebauthn/browser', () => ({
+  startAuthentication: vi.fn(),
+}));
+
+const mockedStartAuthentication = vi.mocked(startAuthentication);
+
+const fakeCredential: AuthenticationResponseJSON = {
+  id: 'fake-id',
+  rawId: 'fake-raw-id',
+  type: 'public-key',
+  response: {
+    clientDataJSON: 'fake-client-data',
+    authenticatorData: 'fake-authenticator-data',
+    signature: 'fake-signature',
+  },
+  clientExtensionResults: {},
+};
+
 function mockLogin(statusCode: number, response: Object = {}, headers: HeadersInit = {}): void {
   mockServer.use(
     http.post('http://localhost:3000/p1/login', () => {
@@ -24,6 +44,32 @@ function mockLogin(statusCode: number, response: Object = {}, headers: HeadersIn
     }),
   );
 }
+
+function mockPasskeyOptions(statusCode: number, response: Object = {}): void {
+  mockServer.use(
+    http.post('http://localhost:3000/p1/passkey/login/options', () => {
+      return HttpResponse.json(response, { status: statusCode });
+    }),
+  );
+}
+
+function mockPasskeyVerify(statusCode: number, response: Object = {}): void {
+  mockServer.use(
+    http.post('http://localhost:3000/p1/passkey/login/verify', () => {
+      return HttpResponse.json(response, { status: statusCode });
+    }),
+  );
+}
+
+function mockSuccessfulPasskeyLogin(): void {
+  mockPasskeyOptions(200, { options: {}, challenge: 'fake-challenge', rpId: 'bgm.tv' });
+  mockedStartAuthentication.mockResolvedValue(fakeCredential);
+  mockPasskeyVerify(200, { id: 1, username: 'fakeuser' });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 const wrapper = ({ children }: PropsWithChildren) => (
   <MemoryRouter>
@@ -72,5 +118,56 @@ it('should refresh me if login succeeded', async () => {
   await waitFor(async () => {
     await result.current.login('fakeuser', 'fakepassword', 'fake-token');
     expect(result.current.user).toMatchSnapshot();
+  });
+});
+
+it('should return true if passkey login succeeded', async () => {
+  const { result } = renderHook(() => useUser(), { wrapper });
+
+  mockSuccessfulPasskeyLogin();
+  await waitFor(async () => {
+    await expect(result.current.passkeyLogin()).resolves.toBe(true);
+  });
+  expect(mockedStartAuthentication).toHaveBeenCalledWith({ optionsJSON: {} });
+});
+
+it('should throw if passkey options request failed', async () => {
+  const { result } = renderHook(() => useUser(), { wrapper });
+
+  mockPasskeyOptions(500);
+  await waitFor(async () => {
+    await expect(result.current.passkeyLogin()).rejects.toThrow();
+  });
+  expect(mockedStartAuthentication).not.toHaveBeenCalled();
+});
+
+it('should throw if passkey verify request failed', async () => {
+  const { result } = renderHook(() => useUser(), { wrapper });
+
+  mockPasskeyOptions(200, { options: {}, challenge: 'fake-challenge', rpId: 'bgm.tv' });
+  mockedStartAuthentication.mockResolvedValue(fakeCredential);
+  mockPasskeyVerify(401);
+  await waitFor(async () => {
+    await expect(result.current.passkeyLogin()).rejects.toThrow();
+  });
+});
+
+it('should return false if user cancelled authentication', async () => {
+  const { result } = renderHook(() => useUser(), { wrapper });
+
+  mockPasskeyOptions(200, { options: {}, challenge: 'fake-challenge', rpId: 'bgm.tv' });
+  mockedStartAuthentication.mockRejectedValue(new DOMException('canceled', 'NotAllowedError'));
+  await waitFor(async () => {
+    await expect(result.current.passkeyLogin()).resolves.toBe(false);
+  });
+});
+
+it('should throw if authentication failed with unexpected error', async () => {
+  const { result } = renderHook(() => useUser(), { wrapper });
+
+  mockPasskeyOptions(200, { options: {}, challenge: 'fake-challenge', rpId: 'bgm.tv' });
+  mockedStartAuthentication.mockRejectedValue(new Error('browser error'));
+  await waitFor(async () => {
+    await expect(result.current.passkeyLogin()).rejects.toThrow('browser error');
   });
 });

--- a/packages/website/src/hooks/use-user.tsx
+++ b/packages/website/src/hooks/use-user.tsx
@@ -1,4 +1,9 @@
 import { ok } from '@oazapfts/runtime';
+import type {
+  AuthenticationResponseJSON,
+  PublicKeyCredentialRequestOptionsJSON,
+} from '@simplewebauthn/browser';
+import { startAuthentication } from '@simplewebauthn/browser';
 import type { PropsWithChildren } from 'react';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -11,6 +16,8 @@ interface UserContextType {
   user?: Profile;
   redirectToLogin: () => void;
   login: (username: string, password: string, captchaResp: string) => Promise<void>;
+  /** 使用 Passkey 登录，成功返回 true，用户取消返回 false */
+  passkeyLogin: () => Promise<boolean>;
 }
 
 const UserContext = React.createContext<UserContextType>(null!);
@@ -63,6 +70,13 @@ export const UserProvider: React.FC<PropsWithChildren> = ({ children }) => {
       await login(email, password, captchaResp);
       await mutate();
     },
+    passkeyLogin: async () => {
+      const ok = await passkeyLogin();
+      if (ok) {
+        await mutate();
+      }
+      return ok;
+    },
     user,
   };
 
@@ -101,4 +115,53 @@ async function login(email: string, password: string, cfCaptchaResponse: string)
   }
 
   throw new UnknownError(LoginErrorCode.E_UNKNOWN_ERROR);
+}
+
+/**
+ * Passkey 登录流程：
+ * 1. 请求 WebAuthn authentication options（usernameless 模式）
+ * 2. 调用浏览器 API 让用户验证 passkey
+ * 3. 将凭证交给服务端验证并签发 session
+ *
+ * 服务端接口为私有 API，未包含在 @bangumi/client 生成的客户端中，因此直接使用 fetch。
+ */
+async function passkeyLogin(): Promise<boolean> {
+  const optionsRes = await fetch('/p1/passkey/login/options', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({}),
+  });
+
+  if (!optionsRes.ok) {
+    throw new Error(LoginErrorCode.E_UNKNOWN_ERROR);
+  }
+
+  const { options, challenge } = (await optionsRes.json()) as {
+    options: PublicKeyCredentialRequestOptionsJSON;
+    challenge: string;
+    rpId: string;
+  };
+
+  let credential: AuthenticationResponseJSON;
+  try {
+    credential = await startAuthentication({ optionsJSON: options });
+  } catch (err) {
+    // 用户取消或选择器关闭，静默返回
+    if ((err as { name?: string } | null)?.name === 'NotAllowedError') {
+      return false;
+    }
+    throw err;
+  }
+
+  const verifyRes = await fetch('/p1/passkey/login/verify', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ challenge, credential }),
+  });
+
+  if (!verifyRes.ok) {
+    throw new Error(LoginErrorCode.E_UNKNOWN_ERROR);
+  }
+
+  return true;
 }

--- a/packages/website/src/pages/login/index.module.less
+++ b/packages/website/src/pages/login/index.module.less
@@ -42,3 +42,7 @@
 .button {
   width: 150px;
 }
+
+.passkeyButton {
+  width: 100%;
+}

--- a/packages/website/src/pages/login/index.spec.tsx
+++ b/packages/website/src/pages/login/index.spec.tsx
@@ -1,3 +1,5 @@
+import type { AuthenticationResponseJSON } from '@simplewebauthn/browser';
+import { startAuthentication } from '@simplewebauthn/browser';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import React from 'react';
@@ -9,6 +11,24 @@ import { redirectTo } from '@bangumi/website/utils/route';
 
 import { server as mockServer } from '../../mocks/server';
 import LoginPage from '.';
+
+vi.mock('@simplewebauthn/browser', () => ({
+  startAuthentication: vi.fn(),
+}));
+
+const mockedStartAuthentication = vi.mocked(startAuthentication);
+
+const fakeCredential: AuthenticationResponseJSON = {
+  id: 'fake-id',
+  rawId: 'fake-raw-id',
+  type: 'public-key',
+  response: {
+    clientDataJSON: 'fake-client-data',
+    authenticatorData: 'fake-authenticator-data',
+    signature: 'fake-signature',
+  },
+  clientExtensionResults: {},
+};
 
 vi.mock('@bangumi/website/utils/route', () => ({
   redirectTo: vi.fn(),
@@ -162,5 +182,73 @@ it('should validate user input', async () => {
 
   await waitFor(() => {
     expect(getByText('请输入密码'));
+  });
+});
+
+describe('passkey login', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('PublicKeyCredential', class PublicKeyCredential {});
+    mockServer.use(
+      http.post('http://localhost:3000/p1/passkey/login/options', () =>
+        HttpResponse.json({ options: {}, challenge: 'fake-challenge', rpId: 'bgm.tv' }),
+      ),
+      http.post('http://localhost:3000/p1/passkey/login/verify', () =>
+        HttpResponse.json({ id: 1, username: 'fakeuser' }),
+      ),
+    );
+    mockedStartAuthentication.mockResolvedValue(fakeCredential);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('should show passkey login button when WebAuthn is supported', () => {
+    const { getByText } = renderLoginPage();
+
+    expect(getByText('使用 Passkey 登录')).toBeInTheDocument();
+  });
+
+  it('should hide passkey login button when WebAuthn is not supported', () => {
+    vi.unstubAllGlobals();
+    const { queryByText } = renderLoginPage();
+
+    expect(queryByText('使用 Passkey 登录')).not.toBeInTheDocument();
+  });
+
+  it('should redirect user to homepage after passkey login succeeded', async () => {
+    const mockedNavigate = vi.fn();
+    mockedUseNavigate.mockReturnValue(mockedNavigate);
+    mockedUseLocation.mockReturnValue({ key: 'default' } as any);
+    mockedUseSearchParams.mockReturnValue([new URLSearchParams(), vi.fn()] as any);
+
+    const { getByText } = renderLoginPage();
+    fireEvent.click(getByText('使用 Passkey 登录'));
+
+    await waitFor(() => {
+      expect(redirectTo).toHaveBeenCalledWith('/');
+    });
+  });
+
+  it('should show error message when passkey login failed', async () => {
+    const mockedNavigate = vi.fn();
+    mockedUseNavigate.mockReturnValue(mockedNavigate);
+    mockedUseLocation.mockReturnValue({ key: 'default' } as any);
+    mockedUseSearchParams.mockReturnValue([new URLSearchParams(), vi.fn()] as any);
+
+    mockServer.use(
+      http.post('http://localhost:3000/p1/passkey/login/verify', () =>
+        HttpResponse.json({ message: 'passkey login failed' }, { status: 401 }),
+      ),
+    );
+
+    const { getByText } = renderLoginPage();
+    fireEvent.click(getByText('使用 Passkey 登录'));
+
+    await waitFor(() => {
+      expect(getByText('Passkey 登录失败，请稍后再试')).toBeInTheDocument();
+    });
+    expect(redirectTo).not.toHaveBeenCalled();
   });
 });

--- a/packages/website/src/pages/login/index.tsx
+++ b/packages/website/src/pages/login/index.tsx
@@ -24,9 +24,14 @@ const Login: React.FC = () => {
   const [captchaToken, setCaptchaToken] = React.useState<string | null>(null);
   const email = useInput('' as string);
   const password = useInput('' as string);
-  const { login } = useUser();
+  const { login, passkeyLogin } = useUser();
   const navigate = useNavigate();
   const [searchParams, _] = useSearchParams();
+
+  // WebAuthn 不可用时隐藏 Passkey 登录按钮
+  const [passkeySupported] = React.useState(
+    () => typeof window !== 'undefined' && window.PublicKeyCredential != null,
+  );
 
   const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
 
@@ -101,6 +106,18 @@ const Login: React.FC = () => {
     }
   };
 
+  const handlePasskeyLogin = async () => {
+    try {
+      const ok = await passkeyLogin();
+      if (ok) {
+        successRedirect();
+      }
+    } catch (error: unknown) {
+      console.error(error);
+      setErrorMessage('Passkey 登录失败，请稍后再试');
+    }
+  };
+
   return (
     <>
       <Helmet title='登录' />
@@ -127,6 +144,11 @@ const Login: React.FC = () => {
               ref={captcha}
             />
           </div>
+          {passkeySupported && (
+            <Button className={style.passkeyButton} color='gray' onClick={handlePasskeyLogin}>
+              使用 Passkey 登录
+            </Button>
+          )}
           <div className={style.buttonGroup}>
             {!shouldHideRegisterButton && (
               <Button className={style.button} color='gray' disabled>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,6 +320,9 @@ importers:
       '@remix-run/router':
         specifier: ^1.23.3
         version: 1.23.3
+      '@simplewebauthn/browser':
+        specifier: ^13.3.0
+        version: 13.3.0
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -1741,6 +1744,9 @@ packages:
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@simplewebauthn/browser@13.3.0':
+    resolution: {integrity: sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==}
 
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
@@ -6015,6 +6021,8 @@ snapshots:
     optional: true
 
   '@rtsao/scc@1.1.0': {}
+
+  '@simplewebauthn/browser@13.3.0': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
 


### PR DESCRIPTION
## Summary

Add a "Sign in with passkey" button to the login page, implementing passkey login against the private server endpoints:

- `POST /p1/passkey/login/options` (usernameless mode)
- `POST /p1/passkey/login/verify`

The passkey endpoints are part of the private API and are not included in the generated `@bangumi/client`, so the requests are made with `fetch` directly in the `use-user` hook.

## Changes

- **`packages/website`**: add `@simplewebauthn/browser@^13` dependency
- **`use-user.tsx`**: add `passkeyLogin()` to `UserContextType` — fetches authentication options, prompts the user via `startAuthentication`, verifies with the server, and refreshes the current user on success. Returns `false` when the user cancels (`NotAllowedError`), throws otherwise.
- **login page**: show the "使用 Passkey 登录" button only when WebAuthn (`window.PublicKeyCredential`) is available; on success reuse the existing redirect logic, on failure show an error message.
- **Tests**: cover success, options/verify failures, user cancel, and button visibility — with `@simplewebauthn/browser` and `PublicKeyCredential` mocked.

## Verification

- `pnpm lint` ✅
- `pnpm type-check` ✅
- `pnpm vitest run` — 37 files / 238 tests passed ✅

Note: passkey registration/management endpoints are not implemented on the server yet; this PR only covers login.