### PR TITLE
chore(types): update private API type definition

### DIFF
--- a/packages/client/api.yaml
+++ b/packages/client/api.yaml
@@ -41,6 +41,8 @@ components:
           type: string
         type:
           type: integer
+        uid:
+          type: integer
         updatedAt:
           type: integer
         user:
@@ -50,6 +52,7 @@ components:
       required:
         - id
         - type
+        - uid
         - user
         - title
         - icon
@@ -135,7 +138,7 @@ components:
         redirect:
           type: integer
         role:
-          type: integer
+          $ref: '#/components/schemas/CharacterType'
         summary:
           type: string
       required:
@@ -153,16 +156,162 @@ components:
         - nsfw
       title: Character
       type: object
+    CharacterCast:
+      properties:
+        person:
+          $ref: '#/components/schemas/SlimPerson'
+        relation:
+          $ref: '#/components/schemas/CharacterCastType'
+        summary:
+          type: string
+      required:
+        - person
+        - relation
+        - summary
+      type: object
+    CharacterCastRevisionWikiInfo:
+      items:
+        properties:
+          person:
+            properties:
+              id:
+                type: integer
+              name:
+                type: string
+              nameCN:
+                type: string
+            required:
+              - id
+              - name
+              - nameCN
+            type: object
+          subject:
+            properties:
+              id:
+                type: integer
+              name:
+                type: string
+              nameCN:
+                type: string
+              typeID:
+                $ref: '#/components/schemas/SubjectType'
+            required:
+              - id
+              - typeID
+              - name
+              - nameCN
+            type: object
+        required:
+          - subject
+          - person
+        type: object
+      type: array
+    CharacterCastType:
+      description: |-
+        Character cast relation type
+          - 0 = CV
+          - 1 = Dub
+          - 2 = Actor
+          - 3 = Chinese dub
+          - 4 = Japanese dub
+          - 5 = English dub
+          - 6 = Korean dub
+      enum:
+        - 0
+        - 2
+        - 1
+        - 3
+        - 4
+        - 5
+        - 6
+      type: integer
+      x-enum-varnames:
+        - CV
+        - Actor
+        - Dub
+        - ChineseDub
+        - JapaneseDub
+        - EnglishDub
+        - KoreanDub
+      x-ms-enum:
+        modelAsString: false
+        name: CharacterCastType
+    CharacterCreate:
+      additionalProperties: false
+      properties:
+        img:
+          description: base64 encoded raw bytes, 4mb size limit on **decoded** size
+          format: byte
+          type: string
+        infobox:
+          minLength: 1
+          type: string
+        name:
+          minLength: 1
+          type: string
+        summary:
+          type: string
+        type:
+          $ref: '#/components/schemas/CharacterType'
+      required:
+        - name
+        - infobox
+        - summary
+        - type
+      type: object
+    CharacterEdit:
+      additionalProperties: false
+      properties:
+        infobox:
+          minLength: 1
+          type: string
+        name:
+          minLength: 1
+          type: string
+        summary:
+          type: string
+      required:
+        - name
+        - infobox
+        - summary
+      type: object
     CharacterRelation:
       properties:
         character:
           $ref: '#/components/schemas/SlimCharacter'
+        comment:
+          type: string
+        ended:
+          type: boolean
         relation:
-          description: '角色关系: 任职于,从属,聘用,嫁给...'
-          type: integer
+          $ref: '#/components/schemas/PersonRelationType'
+        spoiler:
+          type: boolean
       required:
         - character
         - relation
+        - spoiler
+        - ended
+        - comment
+      type: object
+    CharacterRevisionWikiInfo:
+      properties:
+        extra:
+          properties:
+            img:
+              type: string
+          type: object
+        infobox:
+          type: string
+        name:
+          type: string
+        summary:
+          type: string
+      required:
+        - name
+        - infobox
+        - summary
+        - extra
       type: object
     CharacterSearchFilter:
       properties:
@@ -175,9 +324,9 @@ components:
       type: object
     CharacterSubject:
       properties:
-        actors:
+        casts:
           items:
-            $ref: '#/components/schemas/SlimPerson'
+            $ref: '#/components/schemas/CharacterCast'
           type: array
         subject:
           $ref: '#/components/schemas/SlimSubject'
@@ -185,7 +334,7 @@ components:
           type: integer
       required:
         - subject
-        - actors
+        - casts
         - type
       type: object
     CharacterSubjectRelation:
@@ -198,6 +347,78 @@ components:
         - subject
         - type
       type: object
+    CharacterSubjectRevisionWikiInfo:
+      items:
+        properties:
+          order:
+            type: integer
+          subject:
+            properties:
+              id:
+                type: integer
+              name:
+                type: string
+              nameCN:
+                type: string
+              typeID:
+                $ref: '#/components/schemas/SubjectType'
+            required:
+              - id
+              - typeID
+              - name
+              - nameCN
+            type: object
+          type:
+            type: integer
+        required:
+          - subject
+          - type
+          - order
+        type: object
+      type: array
+    CharacterType:
+      description: |-
+        角色类型
+          - 1 = 角色
+          - 2 = 机体
+          - 3 = 舰船
+          - 4 = 组织机构
+      enum:
+        - 1
+        - 2
+        - 3
+        - 4
+      type: integer
+      x-enum-varnames:
+        - Crt
+        - Mecha
+        - Vessel
+        - Org
+      x-ms-enum:
+        modelAsString: false
+        name: CharacterType
+    CharacterWikiInfo:
+      properties:
+        id:
+          type: integer
+        infobox:
+          type: string
+        locked:
+          type: boolean
+        name:
+          type: string
+        redirect:
+          type: integer
+        summary:
+          type: string
+      required:
+        - id
+        - name
+        - infobox
+        - summary
+        - locked
+        - redirect
+      type: object
     CollectSubject:
       properties:
         comment:
@@ -205,6 +426,12 @@ components:
           type: string
         private:
           description: 仅自己可见
+          type: boolean
+        progress:
+          description: |-
+            是否自动完成条目进度，仅在 `type` 为 `看过` 时有效，并且不会产生对应的时间线记录：
+                      - 书籍条目会检查总的话数和卷数，并更新收藏进度到最新;
+                      - 动画和三次元会标记所有正片章节为已完成，并同时更新收藏进度
           type: boolean
         rate:
           description: 评分，0 表示删除评分
@@ -262,6 +489,8 @@ components:
               type: array
             relatedID:
               type: integer
+            relatedPhotoID:
+              type: integer
             state:
               type: integer
             user:
@@ -283,7 +512,6 @@ components:
           required:
             - replies
           type: object
-      type: object
     CommentBase:
       properties:
         content:
@@ -301,6 +529,8 @@ components:
             $ref: '#/components/schemas/Reaction'
           type: array
         relatedID:
+          type: integer
+        relatedPhotoID:
           type: integer
         state:
           type: integer
@@ -323,6 +553,41 @@ components:
       required:
         - content
       type: object
+    CreateIndex:
+      properties:
+        desc:
+          description: 目录描述
+          type: string
+        private:
+          description: 仅自己可见
+          type: boolean
+        title:
+          description: 目录标题
+          maxLength: 80
+          minLength: 1
+          type: string
+      required:
+        - title
+        - desc
+      title: CreateIndex
+      type: object
+    CreateIndexRelated:
+      properties:
+        award:
+          type: string
+        cat:
+          $ref: '#/components/schemas/IndexRelatedCategory'
+        comment:
+          type: string
+        order:
+          type: integer
+        sid:
+          type: integer
+      required:
+        - cat
+        - sid
+      title: CreateIndexRelated
+      type: object
     CreateReply:
       properties:
         content:
@@ -334,6 +599,26 @@ components:
           type: integer
       required:
         - content
+      type: object
+    CreateReport:
+      properties:
+        comment:
+          description: 举报说明（可选）
+          maxLength: 2000
+          type: string
+        id:
+          description: 被举报对象的 ID
+          minimum: 1
+          type: integer
+        type:
+          $ref: '#/components/schemas/ReportType'
+        value:
+          $ref: '#/components/schemas/ReportReason'
+      required:
+        - type
+        - id
+        - value
+      title: CreateReport
       type: object
     CreateTopic:
       properties:
@@ -352,6 +637,15 @@ components:
       properties:
         airdate:
           type: string
+        collection:
+          properties:
+            status:
+              $ref: '#/components/schemas/EpisodeCollectionStatus'
+            updatedAt:
+              type: integer
+          required:
+            - status
+          type: object
         comment:
           type: integer
         desc:
@@ -368,8 +662,6 @@ components:
           type: string
         sort:
           type: number
-        status:
-          $ref: '#/components/schemas/EpisodeCollectionStatus'
         subject:
           $ref: '#/components/schemas/SlimSubject'
         subjectID:
@@ -378,6 +670,7 @@ components:
           $ref: '#/components/schemas/EpisodeType'
       required:
         - id
+        - subjectID
         - sort
         - type
         - disc
@@ -386,12 +679,12 @@ components:
         - duration
         - airdate
         - comment
-        - subjectID
+        - desc
       title: Episode
       type: object
     EpisodeCollectionStatus:
       description: |-
-        剧集收藏状态
+        章节收藏状态
           - 0 = 撤消/删除
           - 1 = 想看
           - 2 = 看过
@@ -511,11 +804,6 @@ components:
           type: array
         expectedRevision:
           items:
-            description: >-
-              a optional object to check if input is changed by others
-
-              if some key is given, and current data in database doesn't match
-              input, subject will not be changed
             properties:
               date:
                 type: string
@@ -582,6 +870,21 @@ components:
         - message
         - statusCode
       type: object
+    FilterMode:
+      description: |-
+        过滤模式
+          - all = 全站
+          - friends = 好友
+      enum:
+        - all
+        - friends
+      type: string
+      x-enum-varnames:
+        - All
+        - Friends
+      x-ms-enum:
+        modelAsString: true
+        name: FilterMode
     Friend:
       properties:
         createdAt:
@@ -619,6 +922,8 @@ components:
           type: integer
         members:
           type: integer
+        membership:
+          $ref: '#/components/schemas/GroupMember'
         name:
           type: string
         nsfw:
@@ -645,6 +950,24 @@ components:
         - createdAt
       title: Group
       type: object
+    GroupFilterMode:
+      description: |-
+        小组过滤模式
+          - all = 所有小组
+          - joined = 我加入的小组
+          - managed = 我管理的小组
+      enum:
+        - all
+        - joined
+        - managed
+      type: string
+      x-enum-varnames:
+        - All
+        - Joined
+        - Managed
+      x-ms-enum:
+        modelAsString: true
+        name: GroupFilterMode
     GroupMember:
       properties:
         joinedAt:
@@ -706,10 +1029,8 @@ components:
       type: string
     GroupTopic:
       allOf:
-        - $ref: '#/components/schemas/TopicBase'
+        - $ref: '#/components/schemas/Topic'
         - properties:
-            creator:
-              $ref: '#/components/schemas/SlimUser'
             group:
               $ref: '#/components/schemas/SlimGroup'
             replies:
@@ -717,7 +1038,6 @@ components:
                 $ref: '#/components/schemas/Reply'
               type: array
           required:
-            - creator
             - group
             - replies
           type: object
@@ -743,31 +1063,10 @@ components:
       x-ms-enum:
         modelAsString: true
         name: GroupTopicFilterMode
-    HistorySummary:
-      properties:
-        commitMessage:
-          type: string
-        createdAt:
-          description: unix timestamp seconds
-          type: integer
-        creator:
-          properties:
-            username:
-              type: string
-          required:
-            - username
-          type: object
-        type:
-          description: 修改类型。`1` 正常修改， `11` 合并，`103` 锁定/解锁 `104` 未知
-          type: integer
-      required:
-        - creator
-        - type
-        - commitMessage
-        - createdAt
-      type: object
     Index:
       properties:
+        award:
+          type: integer
         collectedAt:
           type: integer
         collects:
@@ -778,6 +1077,8 @@ components:
           type: string
         id:
           type: integer
+        private:
+          type: boolean
         replies:
           type: integer
         stats:
@@ -787,27 +1088,154 @@ components:
         total:
           type: integer
         type:
+          $ref: '#/components/schemas/IndexType'
+        uid:
           type: integer
         updatedAt:
           type: integer
+        user:
+          $ref: '#/components/schemas/SlimUser'
       required:
         - id
+        - uid
         - type
         - title
         - desc
-        - replies
+        - private
         - total
+        - replies
         - collects
         - stats
+        - award
         - createdAt
         - updatedAt
       title: Index
       type: object
+    IndexRelated:
+      properties:
+        award:
+          type: string
+        blog:
+          $ref: '#/components/schemas/SlimBlogEntry'
+        cat:
+          $ref: '#/components/schemas/IndexRelatedCategory'
+        character:
+          $ref: '#/components/schemas/SlimCharacter'
+        comment:
+          type: string
+        createdAt:
+          type: integer
+        episode:
+          $ref: '#/components/schemas/Episode'
+        groupTopic:
+          $ref: '#/components/schemas/GroupTopic'
+        id:
+          type: integer
+        order:
+          type: integer
+        person:
+          $ref: '#/components/schemas/SlimPerson'
+        rid:
+          type: integer
+        sid:
+          type: integer
+        subject:
+          $ref: '#/components/schemas/SlimSubject'
+        subjectTopic:
+          $ref: '#/components/schemas/SubjectTopic'
+        type:
+          type: integer
+      required:
+        - id
+        - cat
+        - rid
+        - type
+        - sid
+        - order
+        - comment
+        - award
+        - createdAt
+      title: IndexRelated
+      type: object
+    IndexRelatedCategory:
+      description: |-
+        目录关联类型
+          - 0 = 条目
+          - 1 = 角色
+          - 2 = 人物
+          - 3 = 章节
+          - 4 = 日志
+          - 5 = 小组话题
+          - 6 = 条目讨论
+      enum:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+      type: integer
+      x-enum-varnames:
+        - Subject
+        - Character
+        - Person
+        - Episode
+        - Blog
+        - GroupTopic
+        - SubjectTopic
+      x-ms-enum:
+        modelAsString: false
+        name: IndexRelatedCategory
     IndexStats:
-      additionalProperties:
-        type: integer
+      properties:
+        blog:
+          type: integer
+        character:
+          type: integer
+        episode:
+          type: integer
+        groupTopic:
+          type: integer
+        person:
+          type: integer
+        subject:
+          properties:
+            anime:
+              type: integer
+            book:
+              type: integer
+            game:
+              type: integer
+            music:
+              type: integer
+            real:
+              type: integer
+          type: object
+        subjectTopic:
+          type: integer
+      required:
+        - subject
       title: IndexStats
       type: object
+    IndexType:
+      description: |-
+        目录类型
+          - 0 = 用户
+          - 1 = 公共
+          - 2 = TBA
+      enum:
+        - 0
+        - 1
+        - 2
+      type: integer
+      x-enum-varnames:
+        - User
+        - Public
+        - Award
+      x-ms-enum:
+        modelAsString: false
+        name: IndexType
     Infobox:
       items:
         properties:
@@ -883,48 +1311,90 @@ components:
         - password
         - turnstileToken
       type: object
-    Notice:
+    MonoPhoto:
       properties:
+        comment:
+          type: string
         createdAt:
-          description: unix timestamp in seconds
+          type: integer
+        creatorID:
           type: integer
         id:
           type: integer
-        postID:
+        images:
+          $ref: '#/components/schemas/MonoPhotoImages'
+        lastPost:
           type: integer
-        sender:
-          properties:
-            avatar:
-              $ref: '#/components/schemas/Avatar'
-            group:
-              type: integer
-            id:
-              example: 1
-              type: integer
-            joinedAt:
-              type: integer
-            nickname:
-              example: Sai🖖
-              type: string
-            sign:
-              type: string
-            username:
-              example: sai
-              type: string
-          required:
-            - id
-            - username
-            - nickname
-            - avatar
-            - group
-            - sign
-            - joinedAt
-          title: SlimUser
-          type: object
+        mainID:
+          type: integer
+        spoiler:
+          type: boolean
+        tags:
+          items:
+            type: string
+          type: array
+        target:
+          type: string
         title:
           type: string
-        topicID:
+        type:
           type: integer
+        updatedAt:
+          type: integer
+        user:
+          $ref: '#/components/schemas/SlimUser'
+      required:
+        - id
+        - type
+        - mainID
+        - creatorID
+        - target
+        - images
+        - title
+        - comment
+        - tags
+        - spoiler
+        - createdAt
+        - updatedAt
+        - lastPost
+      title: MonoPhoto
+      type: object
+    MonoPhotoImages:
+      properties:
+        common:
+          type: string
+        grid:
+          type: string
+        large:
+          type: string
+        medium:
+          type: string
+        small:
+          type: string
+      required:
+        - large
+        - common
+        - medium
+        - small
+        - grid
+      title: MonoPhotoImages
+      type: object
+    Notice:
+      properties:
+        createdAt:
+          type: integer
+        id:
+          type: integer
+        mainID:
+          description: 对应的 topicID, episodeID, userID ...
+          type: integer
+        relatedID:
+          description: 对应的 postID ...
+          type: integer
+        sender:
+          $ref: '#/components/schemas/SlimUser'
+        title:
+          type: string
         type:
           description: 查看 `./lib/notify.ts` _settings
           type: integer
@@ -932,13 +1402,14 @@ components:
           type: boolean
       required:
         - id
-        - title
         - type
         - sender
-        - topicID
-        - postID
+        - title
+        - mainID
+        - relatedID
         - createdAt
         - unread
+      title: Notice
       type: object
     Permissions:
       properties:
@@ -983,7 +1454,7 @@ components:
         summary:
           type: string
         type:
-          type: integer
+          $ref: '#/components/schemas/PersonType'
       required:
         - id
         - name
@@ -1000,6 +1471,43 @@ components:
         - nsfw
       title: Person
       type: object
+    PersonCastRevisionWikiInfo:
+      items:
+        properties:
+          character:
+            properties:
+              id:
+                type: integer
+              name:
+                type: string
+              nameCN:
+                type: string
+            required:
+              - id
+              - name
+              - nameCN
+            type: object
+          subject:
+            properties:
+              id:
+                type: integer
+              name:
+                type: string
+              nameCN:
+                type: string
+              typeID:
+                $ref: '#/components/schemas/SubjectType'
+            required:
+              - id
+              - typeID
+              - name
+              - nameCN
+            type: object
+        required:
+          - subject
+          - character
+        type: object
+      type: array
     PersonCharacter:
       properties:
         character:
@@ -1022,6 +1530,80 @@ components:
         - user
         - createdAt
       type: object
+    PersonCreate:
+      additionalProperties: false
+      properties:
+        img:
+          description: base64 encoded raw bytes, 4mb size limit on **decoded** size
+          format: byte
+          type: string
+        infobox:
+          minLength: 1
+          type: string
+        name:
+          minLength: 1
+          type: string
+        profession:
+          properties:
+            actor:
+              type: boolean
+            artist:
+              type: boolean
+            illustrator:
+              type: boolean
+            mangaka:
+              type: boolean
+            producer:
+              type: boolean
+            seiyu:
+              type: boolean
+            writer:
+              type: boolean
+          type: object
+        summary:
+          type: string
+        type:
+          $ref: '#/components/schemas/PersonType'
+      required:
+        - name
+        - infobox
+        - summary
+        - type
+      type: object
+    PersonEdit:
+      additionalProperties: false
+      properties:
+        infobox:
+          minLength: 1
+          type: string
+        name:
+          minLength: 1
+          type: string
+        profession:
+          properties:
+            actor:
+              type: boolean
+            artist:
+              type: boolean
+            illustrator:
+              type: boolean
+            mangaka:
+              type: boolean
+            producer:
+              type: boolean
+            seiyu:
+              type: boolean
+            writer:
+              type: boolean
+          type: object
+        summary:
+          type: string
+      required:
+        - name
+        - infobox
+        - summary
+        - profession
+      type: object
     PersonImages:
       properties:
         grid:
@@ -1041,14 +1623,78 @@ components:
       type: object
     PersonRelation:
       properties:
+        comment:
+          type: string
+        ended:
+          type: boolean
         person:
           $ref: '#/components/schemas/SlimPerson'
         relation:
-          description: '人物关系: 任职于,从属,聘用,嫁给...'
-          type: integer
+          $ref: '#/components/schemas/PersonRelationType'
+        spoiler:
+          type: boolean
       required:
         - person
         - relation
+        - spoiler
+        - ended
+        - comment
+      type: object
+    PersonRelationType:
+      properties:
+        cn:
+          type: string
+        desc:
+          type: string
+        id:
+          type: integer
+        primary:
+          type: boolean
+        skipViceVersa:
+          type: boolean
+        viceVersaTo:
+          type: integer
+      required:
+        - id
+        - cn
+        - desc
+      type: object
+    PersonRevisionWikiInfo:
+      properties:
+        extra:
+          properties:
+            img:
+              type: string
+          type: object
+        infobox:
+          type: string
+        name:
+          type: string
+        profession:
+          properties:
+            actor:
+              type: boolean
+            artist:
+              type: boolean
+            illustrator:
+              type: boolean
+            mangaka:
+              type: boolean
+            producer:
+              type: boolean
+            seiyu:
+              type: boolean
+            writer:
+              type: boolean
+          type: object
+        summary:
+          type: string
+      required:
+        - name
+        - infobox
+        - summary
+        - profession
+        - extra
       type: object
     PersonSearchFilter:
       properties:
@@ -1068,24 +1714,92 @@ components:
             type: string
           type: array
       type: object
+    PersonSubjectRevisionWikiInfo:
+      items:
+        properties:
+          position:
+            type: integer
+          subject:
+            properties:
+              id:
+                type: integer
+              name:
+                type: string
+              nameCN:
+                type: string
+              typeID:
+                $ref: '#/components/schemas/SubjectType'
+            required:
+              - id
+              - typeID
+              - name
+              - nameCN
+            type: object
+        required:
+          - subject
+          - position
+        type: object
+      type: array
+    PersonType:
+      description: |-
+        人物类型
+          - 1 = 个人
+          - 2 = 公司
+          - 3 = 组合
+      enum:
+        - 1
+        - 2
+        - 3
+      type: integer
+      x-enum-varnames:
+        - Individual
+        - Company
+        - Group
+      x-ms-enum:
+        modelAsString: false
+        name: PersonType
     PersonWikiInfo:
       properties:
         id:
           type: integer
         infobox:
           type: string
+        locked:
+          type: boolean
         name:
           type: string
+        profession:
+          properties:
+            actor:
+              type: boolean
+            artist:
+              type: boolean
+            illustrator:
+              type: boolean
+            mangaka:
+              type: boolean
+            producer:
+              type: boolean
+            seiyu:
+              type: boolean
+            writer:
+              type: boolean
+          type: object
+        redirect:
+          type: integer
         summary:
           type: string
         typeID:
-          $ref: '#/components/schemas/SubjectType'
+          $ref: '#/components/schemas/PersonType'
       required:
         - id
         - name
         - typeID
         - infobox
         - summary
+        - locked
+        - redirect
+        - profession
       type: object
     PersonWork:
       properties:
@@ -1129,16 +1843,6 @@ components:
       properties:
         avatar:
           $ref: '#/components/schemas/Avatar'
-        bio:
-          type: string
-        blocklist:
-          items:
-            type: integer
-          type: array
-        friendIDs:
-          items:
-            type: integer
-          type: array
         group:
           type: integer
         id:
@@ -1167,9 +1871,6 @@ components:
         - joinedAt
         - site
         - location
-        - bio
-        - friendIDs
-        - blocklist
         - permissions
       title: Profile
       type: object
@@ -1254,6 +1955,211 @@ components:
         - state
       title: ReplyBase
       type: object
+    ReportReason:
+      description: |-
+        举报原因
+          - 1 = 辱骂、人身攻击
+          - 2 = 刷屏、无关内容
+          - 3 = 政治相关
+          - 4 = 违法信息
+          - 5 = 泄露隐私
+          - 6 = 涉嫌刷分
+          - 7 = 引战
+          - 8 = 广告
+          - 9 = 剧透
+          - 99 = 其他
+      enum:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+        - 9
+        - 99
+      type: integer
+      x-enum-varnames:
+        - Abuse
+        - Spam
+        - Political
+        - Illegal
+        - Privacy
+        - CheatScore
+        - Flame
+        - Advertisement
+        - Spoiler
+        - Other
+      x-ms-enum:
+        modelAsString: false
+        name: ReportReason
+    ReportType:
+      description: |-
+        举报类型
+          - 6 = 用户
+          - 7 = 小组话题
+          - 8 = 小组回复
+          - 9 = 条目话题
+          - 10 = 条目回复
+          - 11 = 章节回复
+          - 12 = 角色回复
+          - 13 = 人物回复
+          - 14 = 日志
+          - 15 = 日志回复
+          - 16 = 时间线
+          - 17 = 时间线回复
+          - 18 = 目录
+          - 19 = 目录回复
+      enum:
+        - 6
+        - 7
+        - 8
+        - 9
+        - 10
+        - 11
+        - 12
+        - 13
+        - 14
+        - 15
+        - 16
+        - 17
+        - 18
+        - 19
+      type: integer
+      x-enum-varnames:
+        - User
+        - GroupTopic
+        - GroupReply
+        - SubjectTopic
+        - SubjectReply
+        - EpisodeReply
+        - CharacterReply
+        - PersonReply
+        - Blog
+        - BlogReply
+        - Timeline
+        - TimelineReply
+        - Index
+        - IndexReply
+      x-ms-enum:
+        modelAsString: false
+        name: ReportType
+    RevisionHistory:
+      properties:
+        commitMessage:
+          type: string
+        createdAt:
+          description: unix timestamp seconds
+          type: integer
+        creator:
+          properties:
+            nickname:
+              type: string
+            username:
+              type: string
+          required:
+            - username
+            - nickname
+          type: object
+        id:
+          type: integer
+        type:
+          $ref: '#/components/schemas/RevisionType'
+      required:
+        - id
+        - creator
+        - type
+        - commitMessage
+        - createdAt
+      type: object
+    RevisionType:
+      description: |
+        修订类型
+          - 1 = 条目编辑
+          - 103 = 条目锁定
+          - 104 = 条目解锁
+          - 11 = 条目合体
+          - 12 = 条目删除
+          - 17 = 条目关联
+          - 5 = 条目->角色关联
+          - 6 = 条目->声优关联
+          - 10 = 条目->人物关联
+
+          - 2 = 角色编辑
+          - 13 = 角色合体
+          - 14 = 角色删除
+          - 4 = 角色->条目关联
+          - 7 = 角色->声优关联
+
+          - 3 = 人物编辑
+          - 15 = 人物合体
+          - 16 = 人物删除
+          - 8 = 人物->声优关联
+          - 9 = 人物->条目关联
+
+          - 18 = 章节编辑
+          - 181 = 章节合体
+          - 182 = 章节移动
+          - 183 = 章节锁定
+          - 184 = 章节解锁
+          - 185 = 章节删除
+      enum:
+        - 1
+        - 103
+        - 104
+        - 11
+        - 12
+        - 17
+        - 5
+        - 6
+        - 10
+        - 2
+        - 13
+        - 14
+        - 4
+        - 7
+        - 3
+        - 15
+        - 16
+        - 8
+        - 9
+        - 18
+        - 181
+        - 182
+        - 183
+        - 184
+        - 185
+      type: integer
+      x-enum-varnames:
+        - SubjectEdit
+        - SubjectLock
+        - SubjectUnlock
+        - SubjectMerge
+        - SubjectErase
+        - SubjectRelation
+        - SubjectCharacterRelation
+        - SubjectCastRelation
+        - SubjectPersonRelation
+        - CharacterEdit
+        - CharacterMerge
+        - CharacterErase
+        - CharacterSubjectRelation
+        - CharacterCastRelation
+        - PersonEdit
+        - PersonMerge
+        - PersonErase
+        - PersonCastRelation
+        - PersonSubjectRelation
+        - EpisodeEdit
+        - EpisodeMerge
+        - EpisodeMove
+        - EpisodeLock
+        - EpisodeUnlock
+        - EpisodeErase
+      x-ms-enum:
+        modelAsString: false
+        name: RevisionType
     SearchCharacter:
       properties:
         filter:
@@ -1322,10 +2228,12 @@ components:
           type: integer
         updatedAt:
           type: integer
+        user:
+          $ref: '#/components/schemas/SlimUser'
       required:
         - id
-        - uid
         - type
+        - uid
         - title
         - icon
         - summary
@@ -1404,22 +2312,42 @@ components:
           type: integer
         id:
           type: integer
+        private:
+          type: boolean
+        stats:
+          $ref: '#/components/schemas/IndexStats'
         title:
           type: string
         total:
           type: integer
         type:
+          $ref: '#/components/schemas/IndexType'
+        uid:
           type: integer
+        updatedAt:
+          type: integer
+        user:
+          $ref: '#/components/schemas/SlimUser'
       required:
         - id
+        - uid
         - type
         - title
+        - private
         - total
+        - stats
         - createdAt
+        - updatedAt
       title: SlimIndex
       type: object
     SlimPerson:
       properties:
+        career:
+          description: 职业
+          example: producer
+          items:
+            type: string
+          type: array
         comment:
           type: integer
         id:
@@ -1444,6 +2372,7 @@ components:
         - nameCN
         - type
         - info
+        - career
         - comment
         - lock
         - nsfw
@@ -1459,6 +2388,7 @@ components:
           medium: https://lain.bgm.tv/pic/cover/m/c9/f0/8_wK0z3.jpg
           small: https://lain.bgm.tv/pic/cover/s/c9/f0/8_wK0z3.jpg
         locked: false
+        metaTags: []
         name: コードギアス 反逆のルルーシュR2
         nameCN: Code Geass 反叛的鲁路修R2
         nsfw: false
@@ -1474,6 +2404,10 @@ components:
           $ref: '#/components/schemas/SlimSubjectInterest'
         locked:
           type: boolean
+        metaTags:
+          items:
+            type: string
+          type: array
         name:
           type: string
         nameCN:
@@ -1490,6 +2424,7 @@ components:
         - nameCN
         - type
         - info
+        - metaTags
         - rating
         - locked
         - nsfw
@@ -1499,6 +2434,8 @@ components:
       properties:
         comment:
           type: string
+        id:
+          type: integer
         rate:
           type: integer
         tags:
@@ -1510,6 +2447,7 @@ components:
         updatedAt:
           type: integer
       required:
+        - id
         - rate
         - type
         - comment
@@ -1591,7 +2529,7 @@ components:
           动画制作:
             - v: サンライズ
           官方网站:
-            - v: http://www.geass.jp/r2/
+            - v: https://www.geass.jp/r2/
           导演:
             - v: 谷口悟朗
           摄影监督:
@@ -1768,9 +2706,9 @@ components:
         name: SubjectBrowseSort
     SubjectCharacter:
       properties:
-        actors:
+        casts:
           items:
-            $ref: '#/components/schemas/SlimPerson'
+            $ref: '#/components/schemas/CharacterCast'
           type: array
         character:
           $ref: '#/components/schemas/SlimCharacter'
@@ -1780,9 +2718,46 @@ components:
           type: integer
       required:
         - character
-        - actors
+        - casts
         - type
         - order
+      type: object
+    SubjectCharacterRevisionWikiInfo:
+      items:
+        properties:
+          character:
+            properties:
+              id:
+                type: integer
+              name:
+                type: string
+              nameCN:
+                type: string
+            required:
+              - id
+              - name
+              - nameCN
+            type: object
+          order:
+            type: integer
+          type:
+            type: integer
+        required:
+          - character
+          - type
+          - order
+        type: object
+      type: array
+    SubjectCollect:
+      properties:
+        interest:
+          $ref: '#/components/schemas/SlimSubjectInterest'
+        user:
+          $ref: '#/components/schemas/SlimUser'
+      required:
+        - user
+        - interest
+      title: SubjectCollect
       type: object
     SubjectCollection:
       additionalProperties:
@@ -1798,13 +2773,13 @@ components:
           }
           |话数= 7
           |放送开始= 0000-10-06
-          |放送星期= 
-          |官方网站= 
-          |播放电视台= 
-          |其他电视台= 
-          |播放结束= 
-          |其他= 
-          |Copyright= 
+          |放送星期=
+          |官方网站=
+          |播放电视台=
+          |其他电视台=
+          |播放结束=
+          |其他=
+          |Copyright=
           |平台={
           [龟壳]
           [Xbox Series S]
@@ -1842,6 +2817,8 @@ components:
           type: boolean
         platform:
           type: integer
+        series:
+          type: boolean
         summary:
           type: string
       required:
@@ -1878,6 +2855,8 @@ components:
           type: string
         epStatus:
           type: integer
+        id:
+          type: integer
         private:
           type: boolean
         rate:
@@ -1893,6 +2872,7 @@ components:
         volStatus:
           type: integer
       required:
+        - id
         - rate
         - type
         - comment
@@ -1932,6 +2912,10 @@ components:
       type: object
     SubjectNew:
       properties:
+        date:
+          example: '0000-00-00'
+          pattern: ^\d{4}-\d{2}-\d{2}$
+          type: string
         infobox:
           minLength: 1
           type: string
@@ -1946,6 +2930,8 @@ components:
           type: boolean
         platform:
           type: integer
+        series:
+          type: boolean
         summary:
           type: string
         type:
@@ -1959,6 +2945,29 @@ components:
         - metaTags
         - summary
       type: object
+    SubjectPersonRevisionWikiInfo:
+      items:
+        properties:
+          person:
+            properties:
+              id:
+                type: integer
+              name:
+                type: string
+              nameCN:
+                type: string
+            required:
+              - id
+              - name
+              - nameCN
+            type: object
+          position:
+            type: integer
+        required:
+          - person
+          - position
+        type: object
+      type: array
     SubjectPlatform:
       properties:
         alias:
@@ -2059,6 +3068,35 @@ components:
         - relation
         - order
       type: object
+    SubjectRelationRevisionWikiInfo:
+      items:
+        properties:
+          order:
+            type: integer
+          subject:
+            properties:
+              id:
+                type: integer
+              name:
+                type: string
+              nameCN:
+                type: string
+              typeID:
+                $ref: '#/components/schemas/SubjectType'
+            required:
+              - id
+              - typeID
+              - name
+              - nameCN
+            type: object
+          type:
+            type: integer
+        required:
+          - subject
+          - type
+          - order
+        type: object
+      type: array
     SubjectRelationType:
       properties:
         cn:
@@ -2091,6 +3129,27 @@ components:
         - user
         - entry
       title: SubjectReview
+      type: object
+    SubjectRevisionWikiInfo:
+      properties:
+        id:
+          type: integer
+        infobox:
+          type: string
+        metaTags:
+          items:
+            type: string
+          type: array
+        name:
+          type: string
+        summary:
+          type: string
+      required:
+        - id
+        - name
+        - infobox
+        - metaTags
+        - summary
       type: object
     SubjectSearchFilter:
       properties:
@@ -2133,8 +3192,6 @@ components:
         type:
           items:
             $ref: '#/components/schemas/SubjectType'
-            description: 条目类型, 可以多次出现。多值之间为 `或` 关系。
-            example: 2
           type: array
       type: object
     SubjectSearchSort:
@@ -2213,10 +3270,8 @@ components:
       type: object
     SubjectTopic:
       allOf:
-        - $ref: '#/components/schemas/TopicBase'
+        - $ref: '#/components/schemas/Topic'
         - properties:
-            creator:
-              $ref: '#/components/schemas/SlimUser'
             replies:
               items:
                 $ref: '#/components/schemas/Reply'
@@ -2224,7 +3279,6 @@ components:
             subject:
               $ref: '#/components/schemas/SlimSubject'
           required:
-            - creator
             - subject
             - replies
           type: object
@@ -2265,6 +3319,8 @@ components:
           type: integer
         infobox:
           type: string
+        locked:
+          type: boolean
         metaTags:
           items:
             type: string
@@ -2275,6 +3331,10 @@ components:
           type: boolean
         platform:
           type: integer
+        redirect:
+          type: integer
+        series:
+          type: boolean
         summary:
           type: string
         typeID:
@@ -2284,6 +3344,8 @@ components:
         - name
         - typeID
         - infobox
+        - locked
+        - redirect
         - platform
         - availablePlatform
         - metaTags
@@ -2302,6 +3364,10 @@ components:
           type: integer
         memo:
           $ref: '#/components/schemas/TimelineMemo'
+        reactions:
+          items:
+            $ref: '#/components/schemas/Reaction'
+          type: array
         replies:
           type: integer
         source:
@@ -2360,21 +3426,6 @@ components:
       x-ms-enum:
         modelAsString: false
         name: TimelineCat
-    TimelineFilterMode:
-      description: |-
-        时间线过滤模式
-          - all = 全站
-          - friends = 好友
-      enum:
-        - all
-        - friends
-      type: string
-      x-enum-varnames:
-        - All
-        - Friends
-      x-ms-enum:
-        modelAsString: true
-        name: TimelineFilterMode
     TimelineMemo:
       properties:
         blog:
@@ -2462,16 +3513,11 @@ components:
                 type: string
               rate:
                 type: number
-              reactions:
-                items:
-                  $ref: '#/components/schemas/Reaction'
-                type: array
               subject:
                 $ref: '#/components/schemas/SlimSubject'
             required:
               - subject
               - comment
-              - rate
             type: object
           type: array
         wiki:
@@ -2482,49 +3528,22 @@ components:
       title: TimelineMemo
       type: object
     TimelineSource:
-      description: |-
-        时间线来源
-          - 0 = 网站
-          - 1 = 移动端
-          - 2 = https://bgm.tv/onair
-          - 3 = https://netaba.re/
-          - 4 = WP
-          - 5 = API
-      enum:
-        - 0
-        - 1
-        - 2
-        - 3
-        - 4
-        - 5
-      type: integer
-      x-enum-varnames:
-        - Web
-        - Mobile
-        - OnAir
-        - InTouch
-        - WP
-        - API
-      x-ms-enum:
-        modelAsString: false
-        name: TimelineSource
+      properties:
+        name:
+          type: string
+        url:
+          type: string
+      required:
+        - name
+      title: TimelineSource
+      type: object
     Topic:
-      allOf:
-        - $ref: '#/components/schemas/TopicBase'
-        - properties:
-            creator:
-              $ref: '#/components/schemas/SlimUser'
-            replies:
-              type: integer
-          required:
-            - replies
-          type: object
-      title: Topic
-    TopicBase:
       properties:
         createdAt:
           description: 发帖时间，unix time stamp in seconds
           type: integer
+        creator:
+          $ref: '#/components/schemas/SlimUser'
         creatorID:
           type: integer
         display:
@@ -2533,6 +3552,8 @@ components:
           type: integer
         parentID:
           description: 小组/条目ID
+          type: integer
+        replyCount:
           type: integer
         state:
           type: integer
@@ -2546,11 +3567,12 @@ components:
         - title
         - creatorID
         - parentID
+        - replyCount
         - createdAt
         - updatedAt
         - state
         - display
-      title: TopicBase
+      title: Topic
       type: object
     TrendingSubject:
       properties:
@@ -2591,6 +3613,32 @@ components:
           type: boolean
         type:
           $ref: '#/components/schemas/EpisodeCollectionStatus'
+      type: object
+    UpdateIndex:
+      properties:
+        desc:
+          description: 目录描述
+          type: string
+        private:
+          description: 仅自己可见
+          type: boolean
+        title:
+          description: 目录标题
+          maxLength: 80
+          minLength: 1
+          type: string
+      title: UpdateIndex
+      type: object
+    UpdateIndexRelated:
+      properties:
+        comment:
+          type: string
+        order:
+          type: integer
+      required:
+        - order
+        - comment
+      title: UpdateIndexRelated
       type: object
     UpdateSubjectProgress:
       properties:
@@ -2683,6 +3731,30 @@ components:
         - stats
       title: User
       type: object
+    UserCharacterContribution:
+      properties:
+        characterID:
+          type: integer
+        commitMessage:
+          type: string
+        createdAt:
+          description: unix timestamp seconds
+          type: integer
+        id:
+          type: integer
+        name:
+          type: string
+        type:
+          description: 2 = 角色编辑
+          type: integer
+      required:
+        - id
+        - type
+        - characterID
+        - name
+        - commitMessage
+        - createdAt
+      type: object
     UserHomepage:
       properties:
         left:
@@ -2768,6 +3840,30 @@ components:
         - account
       title: UserNetworkService
       type: object
+    UserPersonContribution:
+      properties:
+        commitMessage:
+          type: string
+        createdAt:
+          description: unix timestamp seconds
+          type: integer
+        id:
+          type: integer
+        name:
+          type: string
+        personID:
+          type: integer
+        type:
+          description: 3 = 人物编辑，15 = 合并，16 = 删除
+          type: integer
+      required:
+        - id
+        - type
+        - personID
+        - name
+        - commitMessage
+        - createdAt
+      type: object
     UserStats:
       properties:
         blog:
@@ -2797,6 +3893,30 @@ components:
           type: integer
         type: object
       title: UserSubjectCollectionStats
+      type: object
+    UserSubjectContribution:
+      properties:
+        commitMessage:
+          type: string
+        createdAt:
+          description: unix timestamp seconds
+          type: integer
+        id:
+          type: integer
+        name:
+          type: string
+        subjectID:
+          type: integer
+        type:
+          description: 修改类型。`1` 正常修改， `11` 合并，`103` 锁定/解锁 `104` 未知
+          type: integer
+      required:
+        - id
+        - type
+        - subjectID
+        - name
+        - commitMessage
+        - createdAt
       type: object
     WikiPlatform:
       properties:
@@ -2849,63 +3969,22 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
           HTTPBearer: []
-      summary: 获取绝交用户列表
+      summary: 获取当前用户的绝交用户列表
       tags:
-        - misc
-    post:
-      operationId: addToBlocklist
-      requestBody:
-        content:
-          application/json:
-            schema:
-              properties:
-                id:
-                  type: integer
-              required:
-                - id
-              type: object
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  blocklist:
-                    items:
-                      type: integer
-                    type: array
-                required:
-                  - blocklist
-                type: object
-          description: Default Response
-        '500':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
-          description: 意料之外的服务器错误
-      security:
-        - CookiesSession: []
-          HTTPBearer: []
-      summary: 将用户添加到绝交列表
-      tags:
-        - misc
-  /p1/blocklist/{id}:
+        - relationship
+  /p1/blocklist/{username}:
     delete:
-      operationId: removeFromBlocklist
+      operationId: removeUserFromBlocklist
       parameters:
         - in: path
-          name: id
+          name: username
           required: true
           schema:
-            type: integer
+            type: string
       responses:
         '200':
           content:
@@ -2920,19 +3999,64 @@ paths:
                   - blocklist
                 type: object
           description: Default Response
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
           HTTPBearer: []
-      summary: 将用户从绝交列表移出
+      summary: 取消与用户绝交
       tags:
-        - misc
+        - relationship
+    put:
+      operationId: addUserToBlocklist
+      parameters:
+        - in: path
+          name: username
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  blocklist:
+                    items:
+                      type: integer
+                    type: array
+                required:
+                  - blocklist
+                type: object
+          description: Default Response
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 与用户绝交
+      tags:
+        - relationship
   /p1/blogs/-/comments/{commentID}:
     delete:
       operationId: deleteBlogComment
@@ -2955,7 +4079,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -2976,6 +4099,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/UpdateContent'
+        required: true
       responses:
         '200':
           content:
@@ -2989,7 +4113,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -3018,10 +4141,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
-        - HTTPBearer: []
+        - CookiesSession: []
+          HTTPBearer: []
       summary: 获取日志详情
       tags:
         - blog
@@ -3058,6 +4181,8 @@ paths:
                           type: array
                         relatedID:
                           type: integer
+                        relatedPhotoID:
+                          type: integer
                         state:
                           type: integer
                         user:
@@ -3079,19 +4204,11 @@ paths:
                       required:
                         - replies
                       type: object
-                  type: object
                 type: array
           description: Default Response
         '404':
           content:
             application/json:
-              examples:
-                NOT_FOUND:
-                  value:
-                    code: NOT_FOUND
-                    error: Not Found
-                    message: blog entry not found
-                    statusCode: 404
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: default error response type
@@ -3100,7 +4217,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -3123,6 +4239,7 @@ paths:
               allOf:
                 - $ref: '#/components/schemas/CreateReply'
                 - $ref: '#/components/schemas/TurnstileToken'
+        required: true
       responses:
         '200':
           content:
@@ -3136,12 +4253,17 @@ paths:
                   - id
                 type: object
           description: Default Response
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -3198,10 +4320,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
-        - HTTPBearer: []
+        - CookiesSession: []
+          HTTPBearer: []
       summary: 获取日志的图片
       tags:
         - blog
@@ -3228,10 +4350,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
-        - HTTPBearer: []
+        - CookiesSession: []
+          HTTPBearer: []
       summary: 获取日志的关联条目
       tags:
         - blog
@@ -3250,7 +4372,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -3280,7 +4401,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -3301,6 +4421,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/UpdateContent'
+        required: true
       responses:
         '200':
           content:
@@ -3314,7 +4435,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -3341,13 +4461,6 @@ paths:
         '404':
           content:
             application/json:
-              examples:
-                NOT_FOUND:
-                  value:
-                    code: NOT_FOUND
-                    error: Not Found
-                    message: character not found
-                    statusCode: 404
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: default error response type
@@ -3356,7 +4469,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -3422,13 +4534,6 @@ paths:
         '404':
           content:
             application/json:
-              examples:
-                NOT_FOUND:
-                  value:
-                    code: NOT_FOUND
-                    error: Not Found
-                    message: character not found
-                    statusCode: 404
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: default error response type
@@ -3437,7 +4542,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -3492,13 +4596,6 @@ paths:
         '404':
           content:
             application/json:
-              examples:
-                NOT_FOUND:
-                  value:
-                    code: NOT_FOUND
-                    error: Not Found
-                    message: character not found
-                    statusCode: 404
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: default error response type
@@ -3507,7 +4604,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -3548,6 +4644,8 @@ paths:
                           type: array
                         relatedID:
                           type: integer
+                        relatedPhotoID:
+                          type: integer
                         state:
                           type: integer
                         user:
@@ -3569,19 +4667,11 @@ paths:
                       required:
                         - replies
                       type: object
-                  type: object
                 type: array
           description: Default Response
         '404':
           content:
             application/json:
-              examples:
-                NOT_FOUND:
-                  value:
-                    code: NOT_FOUND
-                    error: Not Found
-                    message: character not found
-                    statusCode: 404
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: default error response type
@@ -3590,7 +4680,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -3613,6 +4702,7 @@ paths:
               allOf:
                 - $ref: '#/components/schemas/CreateReply'
                 - $ref: '#/components/schemas/TurnstileToken'
+        required: true
       responses:
         '200':
           content:
@@ -3626,17 +4716,434 @@ paths:
                   - id
                 type: object
           description: Default Response
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
           HTTPBearer: []
       summary: 创建角色的吐槽
+      tags:
+        - character
+  /p1/characters/{characterID}/indexes:
+    get:
+      operationId: getCharacterIndexes
+      parameters:
+        - description: max 100
+          in: query
+          name: limit
+          required: false
+          schema:
+            default: 20
+            maximum: 100
+            minimum: 1
+            type: integer
+        - description: min 0
+          in: query
+          name: offset
+          required: false
+          schema:
+            default: 0
+            minimum: 0
+            type: integer
+        - in: path
+          name: characterID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/SlimIndex'
+                    type: array
+                  total:
+                    description: limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数
+                    type: integer
+                required:
+                  - data
+                  - total
+                type: object
+          description: Default Response
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取角色关联的目录
+      tags:
+        - character
+  /p1/characters/{characterID}/photos:
+    get:
+      operationId: getCharacterPhotos
+      parameters:
+        - description: max 100
+          in: query
+          name: limit
+          required: false
+          schema:
+            default: 24
+            maximum: 100
+            minimum: 1
+            type: integer
+        - description: min 0
+          in: query
+          name: offset
+          required: false
+          schema:
+            default: 0
+            minimum: 0
+            type: integer
+        - in: path
+          name: characterID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/MonoPhoto'
+                    type: array
+                  total:
+                    description: limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数
+                    type: integer
+                required:
+                  - data
+                  - total
+                type: object
+          description: Default Response
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取角色相册列表
+      tags:
+        - character
+  /p1/characters/{characterID}/photos/preview:
+    get:
+      operationId: getCharacterPhotoPreview
+      parameters:
+        - description: max 20
+          in: query
+          name: limit
+          required: false
+          schema:
+            default: 6
+            maximum: 20
+            minimum: 1
+            type: integer
+        - in: path
+          name: characterID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/MonoPhoto'
+                    type: array
+                  total:
+                    description: limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数
+                    type: integer
+                required:
+                  - data
+                  - total
+                type: object
+          description: Default Response
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取角色首页相册预览
+      tags:
+        - character
+  /p1/characters/{characterID}/photos/{photoID}:
+    get:
+      operationId: getCharacterPhoto
+      parameters:
+        - in: path
+          name: characterID
+          required: true
+          schema:
+            type: integer
+        - in: path
+          name: photoID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MonoPhoto'
+          description: Default Response
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取角色相册图片
+      tags:
+        - character
+  /p1/characters/{characterID}/photos/{photoID}/comments:
+    get:
+      operationId: getCharacterPhotoComments
+      parameters:
+        - in: path
+          name: characterID
+          required: true
+          schema:
+            type: integer
+        - in: path
+          name: photoID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  allOf:
+                    - properties:
+                        content:
+                          type: string
+                        createdAt:
+                          type: integer
+                        creatorID:
+                          type: integer
+                        id:
+                          type: integer
+                        mainID:
+                          type: integer
+                        reactions:
+                          items:
+                            $ref: '#/components/schemas/Reaction'
+                          type: array
+                        relatedID:
+                          type: integer
+                        relatedPhotoID:
+                          type: integer
+                        state:
+                          type: integer
+                        user:
+                          $ref: '#/components/schemas/SlimUser'
+                      required:
+                        - id
+                        - mainID
+                        - creatorID
+                        - relatedID
+                        - createdAt
+                        - content
+                        - state
+                      type: object
+                    - properties:
+                        replies:
+                          items:
+                            $ref: '#/components/schemas/CommentBase'
+                          type: array
+                      required:
+                        - replies
+                      type: object
+                type: array
+          description: Default Response
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取角色相册图片的评论
+      tags:
+        - character
+    post:
+      operationId: createCharacterPhotoComment
+      parameters:
+        - in: path
+          name: characterID
+          required: true
+          schema:
+            type: integer
+        - in: path
+          name: photoID
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/CreateReply'
+                - $ref: '#/components/schemas/TurnstileToken'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  id:
+                    description: new comment id
+                    type: integer
+                required:
+                  - id
+                type: object
+          description: Default Response
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 创建角色相册图片的评论
+      tags:
+        - character
+  /p1/characters/{characterID}/relations:
+    get:
+      operationId: getCharacterRelations
+      parameters:
+        - description: max 100
+          in: query
+          name: limit
+          required: false
+          schema:
+            default: 20
+            maximum: 100
+            minimum: 1
+            type: integer
+        - description: min 0
+          in: query
+          name: offset
+          required: false
+          schema:
+            default: 0
+            minimum: 0
+            type: integer
+        - in: path
+          name: characterID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/CharacterRelation'
+                    type: array
+                  total:
+                    description: limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数
+                    type: integer
+                required:
+                  - data
+                  - total
+                type: object
+          description: Default Response
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取角色关联角色
       tags:
         - character
   /p1/clear-notify:
@@ -3664,29 +5171,20 @@ paths:
                     type: integer
                   type: array
               type: object
+        required: true
       responses:
         '200':
-          description: 没有返回值
-        '401':
           content:
             application/json:
-              examples:
-                NeedLoginError:
-                  value:
-                    code: NEED_LOGIN
-                    error: Unauthorized
-                    message: you need to login before marking notifications as read
-                    statusCode: 401
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
-                description: 未登录
-          description: 未登录
+                properties: {}
+                type: object
+          description: Default Response
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -3738,12 +5236,80 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
           HTTPBearer: []
       summary: 获取当前用户的角色收藏
+      tags:
+        - collection
+  /p1/collections/characters/{characterID}:
+    delete:
+      operationId: deleteCharacterCollection
+      parameters:
+        - in: path
+          name: characterID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties: {}
+                type: object
+          description: Default Response
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 删除角色收藏
+      tags:
+        - collection
+    put:
+      operationId: addCharacterCollection
+      parameters:
+        - in: path
+          name: characterID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties: {}
+                type: object
+          description: Default Response
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 新增角色收藏
       tags:
         - collection
   /p1/collections/episodes/{episodeID}:
@@ -3760,6 +5326,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/UpdateEpisodeProgress'
+        required: true
       responses:
         '200':
           content:
@@ -3768,12 +5335,17 @@ paths:
                 properties: {}
                 type: object
           description: Default Response
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -3825,12 +5397,80 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
           HTTPBearer: []
       summary: 获取当前用户的目录收藏
+      tags:
+        - collection
+  /p1/collections/indexes/{indexID}:
+    delete:
+      operationId: deleteIndexCollection
+      parameters:
+        - in: path
+          name: indexID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties: {}
+                type: object
+          description: Default Response
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 删除目录收藏
+      tags:
+        - collection
+    put:
+      operationId: addIndexCollection
+      parameters:
+        - in: path
+          name: indexID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties: {}
+                type: object
+          description: Default Response
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 新增目录收藏
       tags:
         - collection
   /p1/collections/persons:
@@ -3877,12 +5517,80 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
           HTTPBearer: []
       summary: 获取当前用户的人物收藏
+      tags:
+        - collection
+  /p1/collections/persons/{personID}:
+    delete:
+      operationId: deletePersonCollection
+      parameters:
+        - in: path
+          name: personID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties: {}
+                type: object
+          description: Default Response
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 删除人物收藏
+      tags:
+        - collection
+    put:
+      operationId: addPersonCollection
+      parameters:
+        - in: path
+          name: personID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties: {}
+                type: object
+          description: Default Response
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 新增人物收藏
       tags:
         - collection
   /p1/collections/subjects:
@@ -3946,7 +5654,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -3968,6 +5675,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/UpdateSubjectProgress'
+        required: true
       responses:
         '200':
           content:
@@ -3976,12 +5684,17 @@ paths:
                 properties: {}
                 type: object
           description: Default Response
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -4002,6 +5715,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CollectSubject'
+        required: true
       responses:
         '200':
           content:
@@ -4010,12 +5724,17 @@ paths:
                 properties: {}
                 type: object
           description: Default Response
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -4038,7 +5757,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       summary: debug
   /p1/episodes/-/comments/{commentID}:
@@ -4064,12 +5782,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
           HTTPBearer: []
-      summary: 删除条目的剧集吐槽
+      summary: 删除条目的章节吐槽
       tags:
         - episode
     put:
@@ -4086,6 +5803,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/UpdateContent'
+        required: true
       responses:
         '200':
           content:
@@ -4099,12 +5817,85 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
           HTTPBearer: []
-      summary: 编辑条目的剧集吐槽
+      summary: 编辑条目的章节吐槽
+      tags:
+        - episode
+  /p1/episodes/-/comments/{commentID}/like:
+    delete:
+      operationId: unlikeEpisodeComment
+      parameters:
+        - in: path
+          name: commentID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties: {}
+                type: object
+          description: Default Response
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 取消条目的章节吐槽点赞
+      tags:
+        - episode
+    put:
+      operationId: likeEpisodeComment
+      parameters:
+        - in: path
+          name: commentID
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                value:
+                  type: integer
+              required:
+                - value
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties: {}
+                type: object
+          description: Default Response
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 给条目的章节吐槽点赞
       tags:
         - episode
   /p1/episodes/{episodeID}:
@@ -4129,12 +5920,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
           HTTPBearer: []
-      summary: 获取剧集信息
+      summary: 获取章节信息
       tags:
         - episode
   /p1/episodes/{episodeID}/comments:
@@ -4171,6 +5961,8 @@ paths:
                           type: array
                         relatedID:
                           type: integer
+                        relatedPhotoID:
+                          type: integer
                         state:
                           type: integer
                         user:
@@ -4192,7 +5984,6 @@ paths:
                       required:
                         - replies
                       type: object
-                  type: object
                 type: array
           description: Default Response
         '500':
@@ -4200,9 +5991,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
-      summary: 获取条目的剧集吐槽箱
+      summary: 获取条目的章节吐槽箱
       tags:
         - episode
     post:
@@ -4221,6 +6011,7 @@ paths:
               allOf:
                 - $ref: '#/components/schemas/CreateReply'
                 - $ref: '#/components/schemas/TurnstileToken'
+        required: true
       responses:
         '200':
           content:
@@ -4234,17 +6025,22 @@ paths:
                   - id
                 type: object
           description: Default Response
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
           HTTPBearer: []
-      summary: 创建条目的剧集吐槽
+      summary: 创建条目的章节吐槽
       tags:
         - episode
   /p1/followers:
@@ -4291,14 +6087,42 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
           HTTPBearer: []
       summary: 获取当前用户的关注者列表
       tags:
-        - friend
+        - relationship
+  /p1/friendlist:
+    get:
+      operationId: getFriendlist
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  friendlist:
+                    items:
+                      type: integer
+                    type: array
+                required:
+                  - friendlist
+                type: object
+          description: Default Response
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取当前用户的好友 ID 列表
+      tags:
+        - relationship
   /p1/friends:
     get:
       operationId: getMyFriends
@@ -4343,18 +6167,91 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
           HTTPBearer: []
       summary: 获取当前用户的好友列表
       tags:
-        - friend
+        - relationship
+  /p1/friends/{username}:
+    delete:
+      operationId: removeFriend
+      parameters:
+        - in: path
+          name: username
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties: {}
+                type: object
+          description: Default Response
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 取消好友
+      tags:
+        - relationship
+    put:
+      operationId: addFriend
+      parameters:
+        - in: path
+          name: username
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties: {}
+                type: object
+          description: Default Response
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 添加好友
+      tags:
+        - relationship
   /p1/groups:
     get:
       operationId: getGroups
       parameters:
+        - in: query
+          name: mode
+          required: false
+          schema:
+            $ref: '#/components/schemas/GroupFilterMode'
         - in: query
           name: sort
           required: true
@@ -4396,7 +6293,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -4426,7 +6322,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -4454,7 +6349,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       summary: 获取小组话题回复详情
       tags:
@@ -4472,6 +6366,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/UpdateContent'
+        required: true
       responses:
         '200':
           content:
@@ -4485,7 +6380,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -4493,12 +6387,85 @@ paths:
       summary: 编辑小组话题回复
       tags:
         - topic
+  /p1/groups/-/posts/{postID}/like:
+    delete:
+      operationId: unlikeGroupPost
+      parameters:
+        - in: path
+          name: postID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties: {}
+                type: object
+          description: Default Response
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 取消小组话题回复点赞
+      tags:
+        - topic
+    put:
+      operationId: likeGroupPost
+      parameters:
+        - in: path
+          name: postID
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                value:
+                  type: integer
+              required:
+                - value
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties: {}
+                type: object
+          description: Default Response
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 给小组话题回复点赞
+      tags:
+        - topic
   /p1/groups/-/topics:
     get:
       operationId: getRecentGroupTopics
       parameters:
-        - description: 登录时默认为 joined, 未登录或没有加入小组时始终为 all
-          in: query
+        - in: query
           name: mode
           required: true
           schema:
@@ -4517,12 +6484,28 @@ paths:
             default: 0
             type: integer
       responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/GroupTopic'
+                    type: array
+                  total:
+                    description: limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数
+                    type: integer
+                required:
+                  - data
+                  - total
+                type: object
+          description: Default Response
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -4551,7 +6534,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -4573,6 +6555,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/UpdateTopic'
+        required: true
       responses:
         '200':
           content:
@@ -4586,7 +6569,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -4609,6 +6591,7 @@ paths:
               allOf:
                 - $ref: '#/components/schemas/CreateReply'
                 - $ref: '#/components/schemas/TurnstileToken'
+        required: true
       responses:
         '200':
           content:
@@ -4621,12 +6604,17 @@ paths:
                   - id
                 type: object
           description: Default Response
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -4656,7 +6644,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -4715,7 +6702,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -4769,7 +6755,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -4793,6 +6778,7 @@ paths:
               allOf:
                 - $ref: '#/components/schemas/CreateTopic'
                 - $ref: '#/components/schemas/TurnstileToken'
+        required: true
       responses:
         '200':
           content:
@@ -4806,12 +6792,17 @@ paths:
                   - id
                 type: object
           description: Default Response
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -4819,6 +6810,492 @@ paths:
       summary: 创建小组话题
       tags:
         - group
+  /p1/indexes:
+    post:
+      operationId: createIndex
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateIndex'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  id:
+                    type: integer
+                required:
+                  - id
+                type: object
+          description: Default Response
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 创建目录
+      tags:
+        - index
+  /p1/indexes/-/comments/{commentID}:
+    delete:
+      operationId: deleteIndexComment
+      parameters:
+        - in: path
+          name: commentID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties: {}
+                type: object
+          description: Default Response
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 删除目录的评论
+      tags:
+        - index
+    put:
+      operationId: updateIndexComment
+      parameters:
+        - in: path
+          name: commentID
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateContent'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties: {}
+                type: object
+          description: Default Response
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 编辑目录的评论
+      tags:
+        - index
+  /p1/indexes/{indexID}:
+    delete:
+      operationId: deleteIndex
+      parameters:
+        - in: path
+          name: indexID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties: {}
+                type: object
+          description: Default Response
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 删除目录
+      tags:
+        - index
+    get:
+      operationId: getIndex
+      parameters:
+        - in: path
+          name: indexID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Index'
+          description: Default Response
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取目录详情
+      tags:
+        - index
+    patch:
+      operationId: updateIndex
+      parameters:
+        - in: path
+          name: indexID
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateIndex'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties: {}
+                type: object
+          description: Default Response
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 更新目录
+      tags:
+        - index
+  /p1/indexes/{indexID}/comments:
+    get:
+      operationId: getIndexComments
+      parameters:
+        - in: path
+          name: indexID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  allOf:
+                    - properties:
+                        content:
+                          type: string
+                        createdAt:
+                          type: integer
+                        creatorID:
+                          type: integer
+                        id:
+                          type: integer
+                        mainID:
+                          type: integer
+                        reactions:
+                          items:
+                            $ref: '#/components/schemas/Reaction'
+                          type: array
+                        relatedID:
+                          type: integer
+                        relatedPhotoID:
+                          type: integer
+                        state:
+                          type: integer
+                        user:
+                          $ref: '#/components/schemas/SlimUser'
+                      required:
+                        - id
+                        - mainID
+                        - creatorID
+                        - relatedID
+                        - createdAt
+                        - content
+                        - state
+                      type: object
+                    - properties:
+                        replies:
+                          items:
+                            $ref: '#/components/schemas/CommentBase'
+                          type: array
+                      required:
+                        - replies
+                      type: object
+                type: array
+          description: Default Response
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取目录的评论
+      tags:
+        - index
+    post:
+      operationId: createIndexComment
+      parameters:
+        - in: path
+          name: indexID
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/CreateReply'
+                - $ref: '#/components/schemas/TurnstileToken'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  id:
+                    description: new comment id
+                    type: integer
+                required:
+                  - id
+                type: object
+          description: Default Response
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 创建目录的评论
+      tags:
+        - index
+  /p1/indexes/{indexID}/related:
+    get:
+      operationId: getIndexRelated
+      parameters:
+        - in: query
+          name: cat
+          required: false
+          schema:
+            $ref: '#/components/schemas/IndexRelatedCategory'
+        - in: query
+          name: type
+          required: false
+          schema:
+            $ref: '#/components/schemas/SubjectType'
+        - description: max 100
+          in: query
+          name: limit
+          required: false
+          schema:
+            default: 20
+            maximum: 100
+            minimum: 1
+            type: integer
+        - description: min 0
+          in: query
+          name: offset
+          required: false
+          schema:
+            default: 0
+            minimum: 0
+            type: integer
+        - in: path
+          name: indexID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/IndexRelated'
+                    type: array
+                  total:
+                    description: limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数
+                    type: integer
+                required:
+                  - data
+                  - total
+                type: object
+          description: Default Response
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取目录的关联内容
+      tags:
+        - index
+    put:
+      operationId: putIndexRelated
+      parameters:
+        - in: path
+          name: indexID
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateIndexRelated'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  id:
+                    type: integer
+                required:
+                  - id
+                type: object
+          description: Default Response
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 添加目录关联内容
+      tags:
+        - index
+  /p1/indexes/{indexID}/related/{id}:
+    delete:
+      operationId: deleteIndexRelated
+      parameters:
+        - in: path
+          name: indexID
+          required: true
+          schema:
+            type: integer
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties: {}
+                type: object
+          description: Default Response
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 删除目录关联内容
+      tags:
+        - index
+    patch:
+      operationId: patchIndexRelated
+      parameters:
+        - in: path
+          name: indexID
+          required: true
+          schema:
+            type: integer
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateIndexRelated'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties: {}
+                type: object
+          description: Default Response
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 更新目录关联内容
+      tags:
+        - index
   /p1/login:
     post:
       description: >-
@@ -4836,6 +7313,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/LoginRequestBody'
+        required: true
       responses:
         '200':
           content:
@@ -4853,27 +7331,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: request validation error
           description: request validation error
         '401':
           content:
             application/json:
-              examples:
-                CAPTCHA_ERROR:
-                  value:
-                    code: CAPTCHA_ERROR
-                    error: Unauthorized
-                    message: wrong captcha
-                    statusCode: 401
-                EMAIL_PASSWORD_ERROR:
-                  value:
-                    code: EMAIL_PASSWORD_ERROR
-                    error: Unauthorized
-                    message: email does not exists or email and password not match
-                    statusCode: 401
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 验证码错误/账号密码不匹配
           description: 验证码错误/账号密码不匹配
           headers:
             X-RateLimit-Limit:
@@ -4891,14 +7354,8 @@ paths:
         '429':
           content:
             application/json:
-              example:
-                code: TOO_MANY_REQUESTS
-                error: Too Many Requests
-                message: too many failed login attempts
-                statusCode: 429
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 失败次数太多，需要过一段时间再重试
           description: 失败次数太多，需要过一段时间再重试
           headers:
             X-RateLimit-Limit:
@@ -4918,7 +7375,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       tags:
         - auth
@@ -4932,6 +7388,7 @@ paths:
             schema:
               properties: {}
               type: object
+        required: true
       responses:
         '200':
           content:
@@ -4941,23 +7398,14 @@ paths:
         '401':
           content:
             application/json:
-              examples:
-                NeedLoginError:
-                  value:
-                    code: NEED_LOGIN
-                    error: Unauthorized
-                    message: you need to login before logout
-                    statusCode: 401
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 未登录
           description: 未登录
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       tags:
         - auth
@@ -4974,11 +7422,6 @@ paths:
         '401':
           content:
             application/json:
-              example:
-                code: NEED_LOGIN
-                error: Unauthorized
-                message: you need to login before get current user
-                statusCode: 401
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: default error response type
@@ -4987,7 +7430,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -5029,31 +7471,137 @@ paths:
                   - total
                 type: object
           description: Default Response
-        '401':
-          content:
-            application/json:
-              examples:
-                NeedLoginError:
-                  value:
-                    code: NEED_LOGIN
-                    error: Unauthorized
-                    message: you need to login before getting notifications
-                    statusCode: 401
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-                description: 未登录
-          description: 未登录
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
           HTTPBearer: []
       summary: 获取未读通知
+      tags:
+        - misc
+  /p1/passkey/login/options:
+    post:
+      description: |-
+
+        获取 WebAuthn authentication options。
+        不传 credentials 时（usernameless 模式），浏览器将展示系统账户选择器。
+      operationId: passkeyLoginOptions
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                credentials:
+                  items:
+                    properties:
+                      credentialId:
+                        type: string
+                      transports:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                      - credentialId
+                    type: object
+                  type: array
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  challenge:
+                    type: string
+                  options: {}
+                  rpId:
+                    type: string
+                required:
+                  - options
+                  - challenge
+                  - rpId
+                type: object
+          description: Default Response
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      summary: 获取 Passkey 登录选项
+      tags:
+        - misc
+  /p1/passkey/login/verify:
+    post:
+      operationId: passkeyLoginVerify
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                challenge:
+                  description: 之前 options 返回的 challenge
+                  type: string
+                credential:
+                  additionalProperties: true
+                  properties:
+                    clientExtensionResults:
+                      additionalProperties: true
+                      properties: {}
+                      type: object
+                    id:
+                      type: string
+                    rawId:
+                      type: string
+                    response:
+                      properties:
+                        authenticatorData:
+                          type: string
+                        clientDataJSON:
+                          type: string
+                        signature:
+                          type: string
+                        userHandle:
+                          type: string
+                      required:
+                        - clientDataJSON
+                        - authenticatorData
+                        - signature
+                      type: object
+                    type:
+                      enum:
+                        - public-key
+                      type: string
+                  required:
+                    - id
+                    - rawId
+                    - type
+                    - response
+                    - clientExtensionResults
+                  type: object
+              required:
+                - challenge
+                - credential
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema: {}
+          description: Default Response
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      summary: 验证 Passkey 登录并签发 session
       tags:
         - misc
   /p1/persons/-/comments/{commentID}:
@@ -5078,7 +7626,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -5099,6 +7646,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/UpdateContent'
+        required: true
       responses:
         '200':
           content:
@@ -5112,7 +7660,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -5139,13 +7686,6 @@ paths:
         '404':
           content:
             application/json:
-              examples:
-                NOT_FOUND:
-                  value:
-                    code: NOT_FOUND
-                    error: Not Found
-                    message: person not found
-                    statusCode: 404
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: default error response type
@@ -5154,7 +7694,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -5220,13 +7759,6 @@ paths:
         '404':
           content:
             application/json:
-              examples:
-                NOT_FOUND:
-                  value:
-                    code: NOT_FOUND
-                    error: Not Found
-                    message: person not found
-                    statusCode: 404
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: default error response type
@@ -5235,7 +7767,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -5290,13 +7821,6 @@ paths:
         '404':
           content:
             application/json:
-              examples:
-                NOT_FOUND:
-                  value:
-                    code: NOT_FOUND
-                    error: Not Found
-                    message: person not found
-                    statusCode: 404
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: default error response type
@@ -5305,7 +7829,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -5346,6 +7869,8 @@ paths:
                           type: array
                         relatedID:
                           type: integer
+                        relatedPhotoID:
+                          type: integer
                         state:
                           type: integer
                         user:
@@ -5367,19 +7892,11 @@ paths:
                       required:
                         - replies
                       type: object
-                  type: object
                 type: array
           description: Default Response
         '404':
           content:
             application/json:
-              examples:
-                NOT_FOUND:
-                  value:
-                    code: NOT_FOUND
-                    error: Not Found
-                    message: person not found
-                    statusCode: 404
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: default error response type
@@ -5388,7 +7905,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -5411,6 +7927,7 @@ paths:
               allOf:
                 - $ref: '#/components/schemas/CreateReply'
                 - $ref: '#/components/schemas/TurnstileToken'
+        required: true
       responses:
         '200':
           content:
@@ -5424,17 +7941,434 @@ paths:
                   - id
                 type: object
           description: Default Response
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
           HTTPBearer: []
       summary: 创建人物的吐槽
+      tags:
+        - person
+  /p1/persons/{personID}/indexes:
+    get:
+      operationId: getPersonIndexes
+      parameters:
+        - description: max 100
+          in: query
+          name: limit
+          required: false
+          schema:
+            default: 20
+            maximum: 100
+            minimum: 1
+            type: integer
+        - description: min 0
+          in: query
+          name: offset
+          required: false
+          schema:
+            default: 0
+            minimum: 0
+            type: integer
+        - in: path
+          name: personID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/SlimIndex'
+                    type: array
+                  total:
+                    description: limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数
+                    type: integer
+                required:
+                  - data
+                  - total
+                type: object
+          description: Default Response
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取人物关联的目录
+      tags:
+        - person
+  /p1/persons/{personID}/photos:
+    get:
+      operationId: getPersonPhotos
+      parameters:
+        - description: max 100
+          in: query
+          name: limit
+          required: false
+          schema:
+            default: 24
+            maximum: 100
+            minimum: 1
+            type: integer
+        - description: min 0
+          in: query
+          name: offset
+          required: false
+          schema:
+            default: 0
+            minimum: 0
+            type: integer
+        - in: path
+          name: personID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/MonoPhoto'
+                    type: array
+                  total:
+                    description: limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数
+                    type: integer
+                required:
+                  - data
+                  - total
+                type: object
+          description: Default Response
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取人物相册列表
+      tags:
+        - person
+  /p1/persons/{personID}/photos/preview:
+    get:
+      operationId: getPersonPhotoPreview
+      parameters:
+        - description: max 20
+          in: query
+          name: limit
+          required: false
+          schema:
+            default: 6
+            maximum: 20
+            minimum: 1
+            type: integer
+        - in: path
+          name: personID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/MonoPhoto'
+                    type: array
+                  total:
+                    description: limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数
+                    type: integer
+                required:
+                  - data
+                  - total
+                type: object
+          description: Default Response
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取人物首页相册预览
+      tags:
+        - person
+  /p1/persons/{personID}/photos/{photoID}:
+    get:
+      operationId: getPersonPhoto
+      parameters:
+        - in: path
+          name: personID
+          required: true
+          schema:
+            type: integer
+        - in: path
+          name: photoID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MonoPhoto'
+          description: Default Response
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取人物相册图片
+      tags:
+        - person
+  /p1/persons/{personID}/photos/{photoID}/comments:
+    get:
+      operationId: getPersonPhotoComments
+      parameters:
+        - in: path
+          name: personID
+          required: true
+          schema:
+            type: integer
+        - in: path
+          name: photoID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  allOf:
+                    - properties:
+                        content:
+                          type: string
+                        createdAt:
+                          type: integer
+                        creatorID:
+                          type: integer
+                        id:
+                          type: integer
+                        mainID:
+                          type: integer
+                        reactions:
+                          items:
+                            $ref: '#/components/schemas/Reaction'
+                          type: array
+                        relatedID:
+                          type: integer
+                        relatedPhotoID:
+                          type: integer
+                        state:
+                          type: integer
+                        user:
+                          $ref: '#/components/schemas/SlimUser'
+                      required:
+                        - id
+                        - mainID
+                        - creatorID
+                        - relatedID
+                        - createdAt
+                        - content
+                        - state
+                      type: object
+                    - properties:
+                        replies:
+                          items:
+                            $ref: '#/components/schemas/CommentBase'
+                          type: array
+                      required:
+                        - replies
+                      type: object
+                type: array
+          description: Default Response
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取人物相册图片的评论
+      tags:
+        - person
+    post:
+      operationId: createPersonPhotoComment
+      parameters:
+        - in: path
+          name: personID
+          required: true
+          schema:
+            type: integer
+        - in: path
+          name: photoID
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/CreateReply'
+                - $ref: '#/components/schemas/TurnstileToken'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  id:
+                    description: new comment id
+                    type: integer
+                required:
+                  - id
+                type: object
+          description: Default Response
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 创建人物相册图片的评论
+      tags:
+        - person
+  /p1/persons/{personID}/relations:
+    get:
+      operationId: getPersonRelations
+      parameters:
+        - description: max 100
+          in: query
+          name: limit
+          required: false
+          schema:
+            default: 20
+            maximum: 100
+            minimum: 1
+            type: integer
+        - description: min 0
+          in: query
+          name: offset
+          required: false
+          schema:
+            default: 0
+            minimum: 0
+            type: integer
+        - in: path
+          name: personID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/PersonRelation'
+                    type: array
+                  total:
+                    description: limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数
+                    type: integer
+                required:
+                  - data
+                  - total
+                type: object
+          description: Default Response
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取人物关联人物
       tags:
         - person
   /p1/persons/{personID}/works:
@@ -5495,13 +8429,6 @@ paths:
         '404':
           content:
             application/json:
-              examples:
-                NOT_FOUND:
-                  value:
-                    code: NOT_FOUND
-                    error: Not Found
-                    message: person not found
-                    statusCode: 404
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: default error response type
@@ -5510,7 +8437,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -5518,6 +8444,306 @@ paths:
       summary: 获取人物的参与作品
       tags:
         - person
+  /p1/privacy:
+    get:
+      operationId: getPrivacy
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  preferences:
+                    properties:
+                      allowNsfw:
+                        type: boolean
+                      canSetNsfwSubject:
+                        type: boolean
+                      showNsfwSubject:
+                        type: boolean
+                    required:
+                      - showNsfwSubject
+                      - canSetNsfwSubject
+                      - allowNsfw
+                    type: object
+                  settings:
+                    properties:
+                      commentNotification:
+                        enum:
+                          - all
+                          - friends
+                          - none
+                        type: string
+                      follow:
+                        enum:
+                          - all
+                          - none
+                        type: string
+                      friendNotification:
+                        enum:
+                          - all
+                          - none
+                        type: string
+                      mentionNotification:
+                        enum:
+                          - all
+                          - friends
+                          - none
+                        type: string
+                      privateMessage:
+                        enum:
+                          - all
+                          - friends
+                          - none
+                        type: string
+                      timelineCollectReply:
+                        enum:
+                          - all
+                          - friends
+                          - none
+                        type: string
+                      timelineReply:
+                        enum:
+                          - all
+                          - friends
+                          - none
+                        type: string
+                    required:
+                      - privateMessage
+                      - timelineReply
+                      - timelineCollectReply
+                      - follow
+                      - mentionNotification
+                      - commentNotification
+                      - friendNotification
+                    type: object
+                required:
+                  - settings
+                  - preferences
+                type: object
+          description: Default Response
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: Get current user privacy settings
+      tags:
+        - user
+    patch:
+      operationId: patchPrivacy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              additionalProperties: false
+              properties:
+                preferences:
+                  additionalProperties: false
+                  properties:
+                    showNsfwSubject:
+                      type: boolean
+                  type: object
+                settings:
+                  additionalProperties: false
+                  properties:
+                    commentNotification:
+                      enum:
+                        - all
+                        - friends
+                        - none
+                      type: string
+                    follow:
+                      enum:
+                        - all
+                        - none
+                      type: string
+                    friendNotification:
+                      enum:
+                        - all
+                        - none
+                      type: string
+                    mentionNotification:
+                      enum:
+                        - all
+                        - friends
+                        - none
+                      type: string
+                    privateMessage:
+                      enum:
+                        - all
+                        - friends
+                        - none
+                      type: string
+                    timelineCollectReply:
+                      enum:
+                        - all
+                        - friends
+                        - none
+                      type: string
+                    timelineReply:
+                      enum:
+                        - all
+                        - friends
+                        - none
+                      type: string
+                  type: object
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  preferences:
+                    properties:
+                      allowNsfw:
+                        type: boolean
+                      canSetNsfwSubject:
+                        type: boolean
+                      showNsfwSubject:
+                        type: boolean
+                    required:
+                      - showNsfwSubject
+                      - canSetNsfwSubject
+                      - allowNsfw
+                    type: object
+                  settings:
+                    properties:
+                      commentNotification:
+                        enum:
+                          - all
+                          - friends
+                          - none
+                        type: string
+                      follow:
+                        enum:
+                          - all
+                          - none
+                        type: string
+                      friendNotification:
+                        enum:
+                          - all
+                          - none
+                        type: string
+                      mentionNotification:
+                        enum:
+                          - all
+                          - friends
+                          - none
+                        type: string
+                      privateMessage:
+                        enum:
+                          - all
+                          - friends
+                          - none
+                        type: string
+                      timelineCollectReply:
+                        enum:
+                          - all
+                          - friends
+                          - none
+                        type: string
+                      timelineReply:
+                        enum:
+                          - all
+                          - friends
+                          - none
+                        type: string
+                    required:
+                      - privateMessage
+                      - timelineReply
+                      - timelineCollectReply
+                      - follow
+                      - mentionNotification
+                      - commentNotification
+                      - friendNotification
+                    type: object
+                required:
+                  - settings
+                  - preferences
+                type: object
+          description: Default Response
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: Update current user privacy settings
+      tags:
+        - user
+  /p1/report:
+    post:
+      operationId: createReport
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateReport'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+                type: object
+          description: Default Response
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 报告疑虑
+      tags:
+        - user
   /p1/search/characters:
     post:
       operationId: searchCharacters
@@ -5544,6 +8770,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/SearchCharacter'
+        required: true
       responses:
         '200':
           content:
@@ -5567,7 +8794,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -5601,6 +8827,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/SearchPerson'
+        required: true
       responses:
         '200':
           content:
@@ -5624,7 +8851,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -5658,6 +8884,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/SearchSubject'
+        required: true
       responses:
         '200':
           content:
@@ -5681,7 +8908,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -5742,9 +8968,21 @@ paths:
           required: false
           schema:
             items:
-              description: wiki 标签，包括 分类/来源/类型/题材/地区/受众 等
+              description: 标签。默认按 wiki/meta 标签查询，结合 tagsCat 可切换为用户标签。
               type: string
             type: array
+        - description: tags 过滤类别：meta=wiki 标签（默认），subject=用户标签
+          in: query
+          name: tagsCat
+          required: false
+          schema:
+            anyOf:
+              - enum:
+                  - meta
+                type: string
+              - enum:
+                  - subject
+                type: string
       responses:
         '200':
           content:
@@ -5768,12 +9006,85 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
           HTTPBearer: []
       summary: 获取条目列表
+      tags:
+        - subject
+  /p1/subjects/-/collects/{collectID}/like:
+    delete:
+      operationId: unlikeSubjectCollect
+      parameters:
+        - in: path
+          name: collectID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties: {}
+                type: object
+          description: Default Response
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 取消条目收藏点赞
+      tags:
+        - subject
+    put:
+      operationId: likeSubjectCollect
+      parameters:
+        - in: path
+          name: collectID
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                value:
+                  type: integer
+              required:
+                - value
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties: {}
+                type: object
+          description: Default Response
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 给条目收藏点赞
       tags:
         - subject
   /p1/subjects/-/posts/{postID}:
@@ -5798,7 +9109,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -5826,7 +9136,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       summary: 获取条目讨论回复详情
       tags:
@@ -5844,6 +9153,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/UpdateContent'
+        required: true
       responses:
         '200':
           content:
@@ -5857,7 +9167,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -5865,6 +9174,131 @@ paths:
       summary: 编辑条目讨论回复
       tags:
         - topic
+  /p1/subjects/-/posts/{postID}/like:
+    delete:
+      operationId: unlikeSubjectPost
+      parameters:
+        - in: path
+          name: postID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties: {}
+                type: object
+          description: Default Response
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 取消条目讨论回复点赞
+      tags:
+        - topic
+    put:
+      operationId: likeSubjectPost
+      parameters:
+        - in: path
+          name: postID
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                value:
+                  type: integer
+              required:
+                - value
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties: {}
+                type: object
+          description: Default Response
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 给条目讨论回复点赞
+      tags:
+        - topic
+  /p1/subjects/-/topics:
+    get:
+      operationId: getRecentSubjectTopics
+      parameters:
+        - description: max 100
+          in: query
+          name: limit
+          required: false
+          schema:
+            default: 20
+            maximum: 100
+            minimum: 1
+            type: integer
+        - description: min 0
+          in: query
+          name: offset
+          required: false
+          schema:
+            default: 0
+            minimum: 0
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/SubjectTopic'
+                    type: array
+                  total:
+                    description: limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数
+                    type: integer
+                required:
+                  - data
+                  - total
+                type: object
+          description: Default Response
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取最新的条目讨论
+      tags:
+        - subject
   /p1/subjects/-/topics/{topicID}:
     get:
       operationId: getSubjectTopic
@@ -5886,7 +9320,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -5933,7 +9366,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -5957,6 +9389,7 @@ paths:
               allOf:
                 - $ref: '#/components/schemas/CreateReply'
                 - $ref: '#/components/schemas/TurnstileToken'
+        required: true
       responses:
         '200':
           content:
@@ -5969,12 +9402,17 @@ paths:
                   - id
                 type: object
           description: Default Response
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -6003,7 +9441,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -6066,12 +9503,78 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
           HTTPBearer: []
       summary: 获取条目的角色
+      tags:
+        - subject
+  /p1/subjects/{subjectID}/collects:
+    get:
+      operationId: getSubjectCollects
+      parameters:
+        - in: query
+          name: type
+          required: false
+          schema:
+            $ref: '#/components/schemas/CollectionType'
+        - in: query
+          name: mode
+          required: false
+          schema:
+            $ref: '#/components/schemas/FilterMode'
+        - description: max 100
+          in: query
+          name: limit
+          required: false
+          schema:
+            default: 20
+            maximum: 100
+            minimum: 1
+            type: integer
+        - description: min 0
+          in: query
+          name: offset
+          required: false
+          schema:
+            default: 0
+            maximum: 500
+            minimum: 0
+            type: integer
+        - in: path
+          name: subjectID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/SubjectCollect'
+                    type: array
+                  total:
+                    description: limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数
+                    type: integer
+                required:
+                  - data
+                  - total
+                type: object
+          description: Default Response
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取条目的收藏用户
       tags:
         - subject
   /p1/subjects/{subjectID}/comments:
@@ -6128,7 +9631,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -6190,12 +9692,67 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
           HTTPBearer: []
-      summary: 获取条目的剧集
+      summary: 获取条目的章节
+      tags:
+        - subject
+  /p1/subjects/{subjectID}/indexes:
+    get:
+      operationId: getSubjectIndexes
+      parameters:
+        - description: max 100
+          in: query
+          name: limit
+          required: false
+          schema:
+            default: 20
+            maximum: 100
+            minimum: 1
+            type: integer
+        - description: min 0
+          in: query
+          name: offset
+          required: false
+          schema:
+            default: 0
+            minimum: 0
+            type: integer
+        - in: path
+          name: subjectID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/SlimIndex'
+                    type: array
+                  total:
+                    description: limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数
+                    type: integer
+                required:
+                  - data
+                  - total
+                type: object
+          description: Default Response
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取条目关联的目录
       tags:
         - subject
   /p1/subjects/{subjectID}/recs:
@@ -6247,7 +9804,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -6316,7 +9872,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -6373,7 +9928,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -6436,7 +9990,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -6493,7 +10046,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -6550,7 +10102,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -6574,6 +10125,7 @@ paths:
               allOf:
                 - $ref: '#/components/schemas/CreateTopic'
                 - $ref: '#/components/schemas/TurnstileToken'
+        required: true
       responses:
         '200':
           content:
@@ -6587,12 +10139,17 @@ paths:
                   - id
                 type: object
           description: Default Response
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -6604,12 +10161,11 @@ paths:
     get:
       operationId: getTimeline
       parameters:
-        - description: 登录时默认为 friends, 未登录或没有好友时始终为 all
-          in: query
+        - in: query
           name: mode
           required: false
           schema:
-            $ref: '#/components/schemas/TimelineFilterMode'
+            $ref: '#/components/schemas/FilterMode'
         - description: min 1, max 20
           in: query
           name: limit
@@ -6639,7 +10195,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -6656,6 +10211,7 @@ paths:
               allOf:
                 - $ref: '#/components/schemas/CreateContent'
                 - $ref: '#/components/schemas/TurnstileToken'
+        required: true
       responses:
         '200':
           content:
@@ -6668,17 +10224,67 @@ paths:
                   - id
                 type: object
           description: Default Response
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
           HTTPBearer: []
       summary: 发送时间线吐槽
+      tags:
+        - timeline
+  /p1/timeline/-/events:
+    get:
+      description: >-
+        这是一个 SSE (Server-Sent Events) 流，不是普通的 JSON 响应。客户端需要使用 EventSource 或类似的
+        SSE 客户端来订阅此接口。每个事件以 `data: {...}\n\n` 格式发送。
+      operationId: getTimelineEvents
+      parameters:
+        - in: query
+          name: cat
+          required: false
+          schema:
+            $ref: '#/components/schemas/TimelineCat'
+        - in: query
+          name: mode
+          required: false
+          schema:
+            $ref: '#/components/schemas/FilterMode'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                description: SSE 事件数据
+                properties:
+                  event:
+                    description: "事件类型: 'connected' | 'timeline'"
+                    type: string
+                  timeline:
+                    $ref: '#/components/schemas/Timeline'
+                required:
+                  - event
+                type: object
+          description: SSE 事件数据
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 时间线事件流 (SSE)
       tags:
         - timeline
   /p1/timeline/{timelineID}:
@@ -6703,12 +10309,85 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
           HTTPBearer: []
       summary: 删除时间线
+      tags:
+        - timeline
+  /p1/timeline/{timelineID}/like:
+    delete:
+      operationId: unlikeTimeline
+      parameters:
+        - in: path
+          name: timelineID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties: {}
+                type: object
+          description: Default Response
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 取消时间线吐槽点赞
+      tags:
+        - timeline
+    put:
+      operationId: likeTimeline
+      parameters:
+        - in: path
+          name: timelineID
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                value:
+                  type: integer
+              required:
+                - value
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties: {}
+                type: object
+          description: Default Response
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 给时间线吐槽点赞
       tags:
         - timeline
   /p1/timeline/{timelineID}/replies:
@@ -6744,6 +10423,8 @@ paths:
                           type: array
                         relatedID:
                           type: integer
+                        relatedPhotoID:
+                          type: integer
                         state:
                           type: integer
                         user:
@@ -6765,19 +10446,11 @@ paths:
                       required:
                         - replies
                       type: object
-                  type: object
                 type: array
           description: Default Response
         '404':
           content:
             application/json:
-              examples:
-                NOT_FOUND:
-                  value:
-                    code: NOT_FOUND
-                    error: Not Found
-                    message: timeline not found
-                    statusCode: 404
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: default error response type
@@ -6786,7 +10459,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -6809,6 +10481,7 @@ paths:
               allOf:
                 - $ref: '#/components/schemas/CreateReply'
                 - $ref: '#/components/schemas/TurnstileToken'
+        required: true
       responses:
         '200':
           content:
@@ -6821,12 +10494,17 @@ paths:
                   - id
                 type: object
           description: Default Response
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -6883,7 +10561,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -6935,7 +10612,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -6952,16 +10628,10 @@ paths:
           name: theme
           required: false
           schema:
-            anyOf:
-              - enum:
-                  - dark
-                type: string
-              - enum:
-                  - light
-                type: string
-              - enum:
-                  - auto
-                type: string
+            enum:
+              - dark
+              - light
+              - auto
         - in: query
           name: redirect_uri
           required: true
@@ -6973,7 +10643,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       summary: 获取 Turnstile 令牌
       tags:
@@ -6999,7 +10668,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -7057,7 +10725,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -7115,7 +10782,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -7173,7 +10839,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -7231,7 +10896,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -7299,7 +10963,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -7356,7 +11019,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -7413,7 +11075,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -7471,7 +11132,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -7529,7 +11189,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -7576,7 +11235,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -7584,6 +11242,562 @@ paths:
       summary: 获取用户时间胶囊
       tags:
         - user
+  /p1/wiki/characters:
+    post:
+      operationId: postCharacterInfo
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                authorID:
+                  description: >-
+                    when header x-admin-token is provided, use this as author
+                    id.
+                  exclusiveMinimum: 0
+                  type: integer
+                character:
+                  additionalProperties: false
+                  properties:
+                    img:
+                      description: >-
+                        base64 encoded raw bytes, 4mb size limit on **decoded**
+                        size
+                      format: byte
+                      type: string
+                    infobox:
+                      minLength: 1
+                      type: string
+                    name:
+                      minLength: 1
+                      type: string
+                    summary:
+                      type: string
+                    type:
+                      $ref: '#/components/schemas/CharacterType'
+                  required:
+                    - name
+                    - infobox
+                    - summary
+                    - type
+                  type: object
+              required:
+                - character
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  characterID:
+                    type: integer
+                required:
+                  - characterID
+                type: object
+          description: Default Response
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 创建角色
+      tags:
+        - wiki
+  /p1/wiki/characters/-/casts/revisions/{revisionID}:
+    get:
+      operationId: getCharacterCastRevisionInfo
+      parameters:
+        - in: path
+          name: revisionID
+          required: true
+          schema:
+            minimum: 1
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CharacterCastRevisionWikiInfo'
+          description: Default Response
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取角色-人物关联历史版本 wiki 信息
+      tags:
+        - wiki
+  /p1/wiki/characters/-/revisions/{revisionID}:
+    get:
+      operationId: getCharacterRevisionInfo
+      parameters:
+        - in: path
+          name: revisionID
+          required: true
+          schema:
+            minimum: 1
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CharacterRevisionWikiInfo'
+          description: Default Response
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取角色历史版本 wiki 信息
+      tags:
+        - wiki
+  /p1/wiki/characters/-/subjects/revisions/{revisionID}:
+    get:
+      operationId: getCharacterSubjectRevisionInfo
+      parameters:
+        - in: path
+          name: revisionID
+          required: true
+          schema:
+            minimum: 1
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CharacterSubjectRevisionWikiInfo'
+          description: Default Response
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取角色-条目关联历史版本 wiki 信息
+      tags:
+        - wiki
+  /p1/wiki/characters/{characterID}:
+    get:
+      operationId: getCharacterWikiInfo
+      parameters:
+        - in: path
+          name: characterID
+          required: true
+          schema:
+            minimum: 1
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CharacterWikiInfo'
+          description: Default Response
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取角色当前的 wiki 信息
+      tags:
+        - wiki
+    patch:
+      operationId: patchCharacterInfo
+      parameters:
+        - in: path
+          name: characterID
+          required: true
+          schema:
+            minimum: 1
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              additionalProperties: false
+              properties:
+                authorID:
+                  description: >-
+                    when header x-admin-token is provided, use this as author
+                    id.
+                  exclusiveMinimum: 0
+                  type: integer
+                character:
+                  additionalProperties: false
+                  properties:
+                    infobox:
+                      minLength: 1
+                      type: string
+                    name:
+                      minLength: 1
+                      type: string
+                    summary:
+                      type: string
+                  type: object
+                commitMessage:
+                  minLength: 1
+                  type: string
+                expectedRevision:
+                  additionalProperties: false
+                  default: {}
+                  properties:
+                    infobox:
+                      minLength: 1
+                      type: string
+                    name:
+                      minLength: 1
+                      type: string
+                    summary:
+                      type: string
+                  type: object
+              required:
+                - commitMessage
+                - expectedRevision
+                - character
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties: {}
+                type: object
+          description: Default Response
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 编辑角色
+      tags:
+        - wiki
+  /p1/wiki/characters/{characterID}/casts/history-summary:
+    get:
+      operationId: characterCastHistorySummary
+      parameters:
+        - description: max 100
+          in: query
+          name: limit
+          required: false
+          schema:
+            default: 20
+            maximum: 100
+            minimum: 1
+            type: integer
+        - description: min 0
+          in: query
+          name: offset
+          required: false
+          schema:
+            default: 0
+            minimum: 0
+            type: integer
+        - in: path
+          name: characterID
+          required: true
+          schema:
+            minimum: 1
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/RevisionHistory'
+                    type: array
+                  total:
+                    description: limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数
+                    type: integer
+                required:
+                  - data
+                  - total
+                type: object
+          description: Default Response
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取角色-人物关联 wiki 历史编辑摘要
+      tags:
+        - wiki
+  /p1/wiki/characters/{characterID}/history-summary:
+    get:
+      operationId: characterEditHistorySummary
+      parameters:
+        - description: max 100
+          in: query
+          name: limit
+          required: false
+          schema:
+            default: 20
+            maximum: 100
+            minimum: 1
+            type: integer
+        - description: min 0
+          in: query
+          name: offset
+          required: false
+          schema:
+            default: 0
+            minimum: 0
+            type: integer
+        - in: path
+          name: characterID
+          required: true
+          schema:
+            minimum: 1
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/RevisionHistory'
+                    type: array
+                  total:
+                    description: limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数
+                    type: integer
+                required:
+                  - data
+                  - total
+                type: object
+          description: Default Response
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取角色 wiki 历史编辑摘要
+      tags:
+        - wiki
+  /p1/wiki/characters/{characterID}/portraits:
+    post:
+      operationId: uploadCharacterPortrait
+      parameters:
+        - in: path
+          name: characterID
+          required: true
+          schema:
+            minimum: 1
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              additionalProperties: false
+              properties:
+                authorID:
+                  description: >-
+                    when header x-admin-token is provided, use this as author
+                    id.
+                  exclusiveMinimum: 0
+                  type: integer
+                img:
+                  description: base64 encoded raw bytes, 4mb size limit on **decoded** size
+                  format: byte
+                  type: string
+              required:
+                - img
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  img:
+                    description: image filename
+                    type: string
+                required:
+                  - img
+                type: object
+          description: Default Response
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 上传角色肖像
+      tags:
+        - wiki
+  /p1/wiki/characters/{characterID}/subjects/history-summary:
+    get:
+      operationId: characterSubjectHistorySummary
+      parameters:
+        - description: max 100
+          in: query
+          name: limit
+          required: false
+          schema:
+            default: 20
+            maximum: 100
+            minimum: 1
+            type: integer
+        - description: min 0
+          in: query
+          name: offset
+          required: false
+          schema:
+            default: 0
+            minimum: 0
+            type: integer
+        - in: path
+          name: characterID
+          required: true
+          schema:
+            minimum: 1
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/RevisionHistory'
+                    type: array
+                  total:
+                    description: limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数
+                    type: integer
+                required:
+                  - data
+                  - total
+                type: object
+          description: Default Response
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取角色-条目关联 wiki 历史编辑摘要
+      tags:
+        - wiki
   /p1/wiki/ep/{episodeID}:
     get:
       operationId: getEpisodeWikiInfo
@@ -7598,30 +11812,12 @@ paths:
         '200':
           content:
             application/json:
-              example:
-                date: '2012-12-23'
-                duration: '00:23:37'
-                ep: 60
-                id: 1148124
-                name: キマリ×ト×ハジマリ
-                nameCN: 结末×与×开始
-                subjectID: 65536
-                summary: >-
-                  ゴンとキルアはG.I.プレイヤー選考会にいよいよ挑戦する。審査を担当するツェズゲラから提示された合格の条件はただ一つ「練を見せる」こと。合格できる者は200人中32名という狭き門だが、ゴンとキルアはくぐり抜けることができるのか！？
-                type: 0
               schema:
                 $ref: '#/components/schemas/EpisodeWikiInfo'
           description: Default Response
         '404':
           content:
             application/json:
-              examples:
-                NOT_FOUND:
-                  value:
-                    code: NOT_FOUND
-                    error: Not Found
-                    message: episode not found
-                    statusCode: 404
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: default error response type
@@ -7630,10 +11826,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
+          HTTPBearer: []
       tags:
         - wiki
     patch:
@@ -7663,6 +11859,12 @@ paths:
                 nameCN: old cn name
             schema:
               properties:
+                authorID:
+                  description: >-
+                    when header x-admin-token is provided, use this as author
+                    id.
+                  exclusiveMinimum: 0
+                  type: integer
                 commitMessage:
                   type: string
                 episode:
@@ -7691,11 +11893,6 @@ paths:
                       $ref: '#/components/schemas/EpisodeType'
                   type: object
                 expectedRevision:
-                  description: >-
-                    a optional object to check if input is changed by others
-
-                    if some key is given, and current data in database doesn't
-                    match input, subject will not be changed
                   properties:
                     date:
                       type: string
@@ -7726,18 +11923,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: invalid input
           description: invalid input
         '404':
           content:
             application/json:
-              examples:
-                NOT_FOUND:
-                  value:
-                    code: NOT_FOUND
-                    error: Not Found
-                    message: episode 1 not found
-                    statusCode: 404
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: default error response type
@@ -7746,10 +11935,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
+          HTTPBearer: []
       tags:
         - wiki
   /p1/wiki/lock/subjects:
@@ -7783,13 +11972,212 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
+      tags:
+        - wiki
+  /p1/wiki/persons:
+    post:
+      operationId: postPersonInfo
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                authorID:
+                  description: >-
+                    when header x-admin-token is provided, use this as author
+                    id.
+                  exclusiveMinimum: 0
+                  type: integer
+                person:
+                  additionalProperties: false
+                  properties:
+                    img:
+                      description: >-
+                        base64 encoded raw bytes, 4mb size limit on **decoded**
+                        size
+                      format: byte
+                      type: string
+                    infobox:
+                      minLength: 1
+                      type: string
+                    name:
+                      minLength: 1
+                      type: string
+                    profession:
+                      properties:
+                        actor:
+                          type: boolean
+                        artist:
+                          type: boolean
+                        illustrator:
+                          type: boolean
+                        mangaka:
+                          type: boolean
+                        producer:
+                          type: boolean
+                        seiyu:
+                          type: boolean
+                        writer:
+                          type: boolean
+                      type: object
+                    summary:
+                      type: string
+                    type:
+                      $ref: '#/components/schemas/PersonType'
+                  required:
+                    - name
+                    - infobox
+                    - summary
+                    - type
+                  type: object
+              required:
+                - person
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  personID:
+                    type: integer
+                required:
+                  - personID
+                type: object
+          description: Default Response
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 创建人物
+      tags:
+        - wiki
+  /p1/wiki/persons/-/casts/revisions/{revisionID}:
+    get:
+      operationId: getPersonCastRevisionInfo
+      parameters:
+        - in: path
+          name: revisionID
+          required: true
+          schema:
+            minimum: 1
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PersonCastRevisionWikiInfo'
+          description: Default Response
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取人物-角色关联历史版本 wiki 信息
+      tags:
+        - wiki
+  /p1/wiki/persons/-/revisions/{revisionID}:
+    get:
+      operationId: getPersonRevisionInfo
+      parameters:
+        - in: path
+          name: revisionID
+          required: true
+          schema:
+            minimum: 1
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PersonRevisionWikiInfo'
+          description: Default Response
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取人物历史版本 wiki 信息
+      tags:
+        - wiki
+  /p1/wiki/persons/-/subjects/revisions/{revisionID}:
+    get:
+      operationId: getPersonSubjectRevisionInfo
+      parameters:
+        - in: path
+          name: revisionID
+          required: true
+          schema:
+            minimum: 1
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PersonSubjectRevisionWikiInfo'
+          description: Default Response
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取人物-条目关联历史版本 wiki 信息
       tags:
         - wiki
   /p1/wiki/persons/{personID}:
     get:
-      description: 获取当前的 wiki 信息
       operationId: getPersonWikiInfo
       parameters:
         - in: path
@@ -7808,13 +12196,6 @@ paths:
         '401':
           content:
             application/json:
-              examples:
-                INVALID_SYNTAX_ERROR:
-                  value:
-                    code: INVALID_SYNTAX_ERROR
-                    error: Bad Request
-                    message: '%s'
-                    statusCode: 400
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: default error response type
@@ -7823,18 +12204,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 角色不存在
-          description: 角色不存在
+          description: 人物不存在
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
           HTTPBearer: []
+      summary: 获取人物当前的 wiki 信息
       tags:
         - wiki
     patch:
@@ -7852,6 +12232,12 @@ paths:
             schema:
               additionalProperties: false
               properties:
+                authorID:
+                  description: >-
+                    when header x-admin-token is provided, use this as author
+                    id.
+                  exclusiveMinimum: 0
+                  type: integer
                 commitMessage:
                   minLength: 1
                   type: string
@@ -7877,6 +12263,23 @@ paths:
                     name:
                       minLength: 1
                       type: string
+                    profession:
+                      properties:
+                        actor:
+                          type: boolean
+                        artist:
+                          type: boolean
+                        illustrator:
+                          type: boolean
+                        mangaka:
+                          type: boolean
+                        producer:
+                          type: boolean
+                        seiyu:
+                          type: boolean
+                        writer:
+                          type: boolean
+                      type: object
                     summary:
                       type: string
                   type: object
@@ -7897,28 +12300,18 @@ paths:
         '400':
           content:
             application/json:
-              examples:
-                WIKI_CHANGED:
-                  value:
-                    code: WIKI_CHANGED
-                    error: Bad Request
-                    message: >-
-                      expected data doesn't match, name changed, expecting "1",
-                      currently "2"
-                    statusCode: 400
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: default error response type
         '401':
           content:
             application/json:
-              examples:
-                INVALID_SYNTAX_ERROR:
-                  value:
-                    code: INVALID_SYNTAX_ERROR
-                    error: Bad Request
-                    message: '%s'
-                    statusCode: 400
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '403':
+          content:
+            application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: default error response type
@@ -7927,17 +12320,393 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
           HTTPBearer: []
+      summary: 编辑人物
       tags:
         - wiki
-  /p1/wiki/recent:
+  /p1/wiki/persons/{personID}/casts/history-summary:
+    get:
+      operationId: personCastHistorySummary
+      parameters:
+        - description: max 100
+          in: query
+          name: limit
+          required: false
+          schema:
+            default: 20
+            maximum: 100
+            minimum: 1
+            type: integer
+        - description: min 0
+          in: query
+          name: offset
+          required: false
+          schema:
+            default: 0
+            minimum: 0
+            type: integer
+        - in: path
+          name: personID
+          required: true
+          schema:
+            minimum: 1
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/RevisionHistory'
+                    type: array
+                  total:
+                    description: limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数
+                    type: integer
+                required:
+                  - data
+                  - total
+                type: object
+          description: Default Response
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取人物-角色关联 wiki 历史编辑摘要
+      tags:
+        - wiki
+  /p1/wiki/persons/{personID}/history-summary:
+    get:
+      operationId: personEditHistorySummary
+      parameters:
+        - description: max 100
+          in: query
+          name: limit
+          required: false
+          schema:
+            default: 20
+            maximum: 100
+            minimum: 1
+            type: integer
+        - description: min 0
+          in: query
+          name: offset
+          required: false
+          schema:
+            default: 0
+            minimum: 0
+            type: integer
+        - in: path
+          name: personID
+          required: true
+          schema:
+            minimum: 1
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/RevisionHistory'
+                    type: array
+                  total:
+                    description: limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数
+                    type: integer
+                required:
+                  - data
+                  - total
+                type: object
+          description: Default Response
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取人物 wiki 历史编辑摘要
+      tags:
+        - wiki
+  /p1/wiki/persons/{personID}/portraits:
+    post:
+      operationId: uploadPersonPortrait
+      parameters:
+        - in: path
+          name: personID
+          required: true
+          schema:
+            minimum: 1
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              additionalProperties: false
+              properties:
+                authorID:
+                  description: >-
+                    when header x-admin-token is provided, use this as author
+                    id.
+                  exclusiveMinimum: 0
+                  type: integer
+                img:
+                  description: base64 encoded raw bytes, 4mb size limit on **decoded** size
+                  format: byte
+                  type: string
+              required:
+                - img
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  img:
+                    description: image filename
+                    type: string
+                required:
+                  - img
+                type: object
+          description: Default Response
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 上传人物肖像
+      tags:
+        - wiki
+  /p1/wiki/persons/{personID}/subjects/history-summary:
+    get:
+      operationId: personSubjectHistorySummary
+      parameters:
+        - description: max 100
+          in: query
+          name: limit
+          required: false
+          schema:
+            default: 20
+            maximum: 100
+            minimum: 1
+            type: integer
+        - description: min 0
+          in: query
+          name: offset
+          required: false
+          schema:
+            default: 0
+            minimum: 0
+            type: integer
+        - in: path
+          name: personID
+          required: true
+          schema:
+            minimum: 1
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/RevisionHistory'
+                    type: array
+                  total:
+                    description: limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数
+                    type: integer
+                required:
+                  - data
+                  - total
+                type: object
+          description: Default Response
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取人物-条目关联 wiki 历史编辑摘要
+      tags:
+        - wiki
+  /p1/wiki/recent/characters:
+    get:
+      description: 获取最近两天的角色wiki更新
+      operationId: getRecentCharacterWiki
+      parameters:
+        - description: |-
+            unix time stamp, only return last update time >= since
+
+            only allow recent 2 days
+          in: path
+          name: since
+          required: true
+          schema:
+            default: 0
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  properties:
+                    createdAt:
+                      type: integer
+                    id:
+                      type: integer
+                  required:
+                    - id
+                    - createdAt
+                  type: object
+                type: array
+          description: Default Response
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      tags:
+        - wiki
+  /p1/wiki/recent/episodes:
+    get:
+      description: 获取最近两天的章节wiki更新
+      operationId: getRecentEpisodeWiki
+      parameters:
+        - description: |-
+            unix time stamp, only return last update time >= since
+
+            only allow recent 2 days
+          in: path
+          name: since
+          required: true
+          schema:
+            default: 0
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  properties:
+                    createdAt:
+                      type: integer
+                    id:
+                      type: integer
+                  required:
+                    - id
+                    - createdAt
+                  type: object
+                type: array
+          description: Default Response
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      tags:
+        - wiki
+  /p1/wiki/recent/persons:
+    get:
+      description: 获取最近两天的人物wiki更新
+      operationId: getRecentPersonWiki
+      parameters:
+        - description: |-
+            unix time stamp, only return last update time >= since
+
+            only allow recent 2 days
+          in: path
+          name: since
+          required: true
+          schema:
+            default: 0
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  properties:
+                    createdAt:
+                      type: integer
+                    id:
+                      type: integer
+                  required:
+                    - id
+                    - createdAt
+                  type: object
+                type: array
+          description: Default Response
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      tags:
+        - wiki
+  /p1/wiki/recent/subjects:
     get:
       description: 获取最近两天的wiki更新
-      operationId: getRecentWiki
+      operationId: getRecentSubjectWiki
       parameters:
         - description: |-
             unix time stamp, only return last update time >= since
@@ -7967,19 +12736,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       tags:
         - wiki
   /p1/wiki/subjects:
     post:
-      description: 创建新条目
       operationId: createNewSubject
       requestBody:
         content:
           application/json:
             schema:
               properties:
+                date:
+                  example: '0000-00-00'
+                  pattern: ^\d{4}-\d{2}-\d{2}$
+                  type: string
                 infobox:
                   minLength: 1
                   type: string
@@ -7994,6 +12765,8 @@ paths:
                   type: boolean
                 platform:
                   type: integer
+                series:
+                  type: boolean
                 summary:
                   type: string
                 type:
@@ -8023,13 +12796,6 @@ paths:
         '400':
           content:
             application/json:
-              examples:
-                INVALID_SYNTAX_ERROR:
-                  value:
-                    code: INVALID_SYNTAX_ERROR
-                    error: Bad Request
-                    message: '%s'
-                    statusCode: 400
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: default error response type
@@ -8044,16 +12810,155 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
           HTTPBearer: []
+      summary: 创建新条目
+      tags:
+        - wiki
+  /p1/wiki/subjects/-/characters/revisions/{revisionID}:
+    get:
+      operationId: getSubjectCharacterRevisionInfo
+      parameters:
+        - in: path
+          name: revisionID
+          required: true
+          schema:
+            minimum: 1
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubjectCharacterRevisionWikiInfo'
+          description: Default Response
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取条目-角色关联历史版本 wiki 信息
+      tags:
+        - wiki
+  /p1/wiki/subjects/-/persons/revisions/{revisionID}:
+    get:
+      operationId: getSubjectPersonRevisionInfo
+      parameters:
+        - in: path
+          name: revisionID
+          required: true
+          schema:
+            minimum: 1
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubjectPersonRevisionWikiInfo'
+          description: Default Response
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取条目-人物关联历史版本 wiki 信息
+      tags:
+        - wiki
+  /p1/wiki/subjects/-/relations/revisions/{revisionID}:
+    get:
+      operationId: getSubjectRelationRevisionInfo
+      parameters:
+        - in: path
+          name: revisionID
+          required: true
+          schema:
+            minimum: 1
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubjectRelationRevisionWikiInfo'
+          description: Default Response
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取条目关联历史版本 wiki 信息
+      tags:
+        - wiki
+  /p1/wiki/subjects/-/revisions/{revisionID}:
+    get:
+      operationId: getSubjectRevisionInfo
+      parameters:
+        - in: path
+          name: revisionID
+          required: true
+          schema:
+            minimum: 1
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubjectRevisionWikiInfo'
+          description: Default Response
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取条目历史版本 wiki 信息
       tags:
         - wiki
   /p1/wiki/subjects/{subjectID}:
     get:
-      description: 获取当前的 wiki 信息
       operationId: subjectInfo
       parameters:
         - in: path
@@ -8072,13 +12977,12 @@ paths:
         '401':
           content:
             application/json:
-              examples:
-                INVALID_SYNTAX_ERROR:
-                  value:
-                    code: INVALID_SYNTAX_ERROR
-                    error: Bad Request
-                    message: '%s'
-                    statusCode: 400
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '404':
+          content:
+            application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: default error response type
@@ -8087,10 +12991,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取条目当前的 wiki 信息
       tags:
         - wiki
     patch:
@@ -8115,13 +13020,13 @@ paths:
                   }
                   |话数= 7
                   |放送开始= 0000-10-06
-                  |放送星期= 
-                  |官方网站= 
-                  |播放电视台= 
-                  |其他电视台= 
-                  |播放结束= 
-                  |其他= 
-                  |Copyright= 
+                  |放送星期=
+                  |官方网站=
+                  |播放电视台=
+                  |其他电视台=
+                  |播放结束=
+                  |其他=
+                  |Copyright=
                   |平台={
                   [龟壳]
                   [Xbox Series S]
@@ -8133,65 +13038,44 @@ paths:
                   }}
             schema:
               properties:
+                authorID:
+                  description: >-
+                    when header x-admin-token is provided, use this as author
+                    id.
+                  exclusiveMinimum: 0
+                  type: integer
                 commitMessage:
                   minLength: 1
                   type: string
                 expectedRevision:
-                  description: >-
-                    a optional object to check if input is changed by others
-
-                    if `infobox` is given, and current data in database doesn't
-                    match input, subject will not be changed
                   properties:
                     infobox:
-                      minLength: 1
-                      type: string
+                      anyOf:
+                        - type: 'null'
+                        - minLength: 1
+                          type: string
                     metaTags:
-                      items:
-                        type: string
-                      type: array
+                      anyOf:
+                        - type: 'null'
+                        - items:
+                            type: string
+                          type: array
                     name:
-                      minLength: 1
-                      type: string
+                      anyOf:
+                        - type: 'null'
+                        - minLength: 1
+                          type: string
                     platform:
-                      type: integer
+                      anyOf:
+                        - type: 'null'
+                        - type: integer
+                    summary:
+                      anyOf:
+                        - type: 'null'
+                        - minLength: 1
+                          type: string
                   type: object
                 subject:
-                  example:
-                    infobox: |-
-                      {{Infobox animanga/TVAnime
-                      |中文名= 沙盒
-                      |别名={
-                      }
-                      |话数= 7
-                      |放送开始= 0000-10-06
-                      |放送星期= 
-                      |官方网站= 
-                      |播放电视台= 
-                      |其他电视台= 
-                      |播放结束= 
-                      |其他= 
-                      |Copyright= 
-                      |平台={
-                      [龟壳]
-                      [Xbox Series S]
-                      [Xbox Series X]
-                      [Xbox Series X/S]
-                      [PC]
-                      [Xbox Series X|S]
-                      }
-                      }}
-                    name: 沙盒
-                    nsfw: false
-                    platform: 0
-                    summary: >-
-                      本条目是一个沙盒，可以用于尝试bgm功能。
-
-
-                      普通维基人可以随意编辑条目信息以及相关关联查看编辑效果，但是请不要完全删除沙盒说明并且不要关联非沙盒条目/人物/角色。
-
-
-                      https://bgm.tv/group/topic/366812#post_1923517
                   properties:
                     date:
                       example: '0000-00-00'
@@ -8211,6 +13095,8 @@ paths:
                       type: boolean
                     platform:
                       type: integer
+                    series:
+                      type: boolean
                     summary:
                       type: string
                   type: object
@@ -8225,13 +13111,6 @@ paths:
         '401':
           content:
             application/json:
-              examples:
-                INVALID_SYNTAX_ERROR:
-                  value:
-                    code: INVALID_SYNTAX_ERROR
-                    error: Bad Request
-                    message: '%s'
-                    statusCode: 400
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: default error response type
@@ -8240,10 +13119,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
+          HTTPBearer: []
       tags:
         - wiki
     put:
@@ -8269,13 +13148,13 @@ paths:
                   }
                   |话数= 7
                   |放送开始= 0000-10-06
-                  |放送星期= 
-                  |官方网站= 
-                  |播放电视台= 
-                  |其他电视台= 
-                  |播放结束= 
-                  |其他= 
-                  |Copyright= 
+                  |放送星期=
+                  |官方网站=
+                  |播放电视台=
+                  |其他电视台=
+                  |播放结束=
+                  |其他=
+                  |Copyright=
                   |平台={
                   [龟壳]
                   [Xbox Series S]
@@ -8300,24 +13179,32 @@ paths:
                   minLength: 1
                   type: string
                 expectedRevision:
-                  description: >-
-                    a optional object to check if input is changed by others
-
-                    if `infobox` is given, and current data in database doesn't
-                    match input, subject will not be changed
                   properties:
                     infobox:
-                      minLength: 1
-                      type: string
+                      anyOf:
+                        - type: 'null'
+                        - minLength: 1
+                          type: string
                     metaTags:
-                      items:
-                        type: string
-                      type: array
+                      anyOf:
+                        - type: 'null'
+                        - items:
+                            type: string
+                          type: array
                     name:
-                      minLength: 1
-                      type: string
+                      anyOf:
+                        - type: 'null'
+                        - minLength: 1
+                          type: string
                     platform:
-                      type: integer
+                      anyOf:
+                        - type: 'null'
+                        - type: integer
+                    summary:
+                      anyOf:
+                        - type: 'null'
+                        - minLength: 1
+                          type: string
                   type: object
                 subject:
                   $ref: '#/components/schemas/SubjectEdit'
@@ -8332,13 +13219,6 @@ paths:
         '401':
           content:
             application/json:
-              examples:
-                INVALID_SYNTAX_ERROR:
-                  value:
-                    code: INVALID_SYNTAX_ERROR
-                    error: Bad Request
-                    message: '%s'
-                    statusCode: 400
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: default error response type
@@ -8347,10 +13227,67 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
+          HTTPBearer: []
+      tags:
+        - wiki
+  /p1/wiki/subjects/{subjectID}/characters/history-summary:
+    get:
+      operationId: subjectCharacterHistorySummary
+      parameters:
+        - description: max 100
+          in: query
+          name: limit
+          required: false
+          schema:
+            default: 20
+            maximum: 100
+            minimum: 1
+            type: integer
+        - description: min 0
+          in: query
+          name: offset
+          required: false
+          schema:
+            default: 0
+            minimum: 0
+            type: integer
+        - in: path
+          name: subjectID
+          required: true
+          schema:
+            minimum: 1
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/RevisionHistory'
+                    type: array
+                  total:
+                    description: limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数
+                    type: integer
+                required:
+                  - data
+                  - total
+                type: object
+          description: Default Response
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取条目-角色关联 wiki 历史编辑摘要
       tags:
         - wiki
   /p1/wiki/subjects/{subjectID}/covers:
@@ -8439,7 +13376,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       tags:
         - wiki
@@ -8476,32 +13412,12 @@ paths:
         '400':
           content:
             application/json:
-              examples:
-                IMAGE_FILE_TOO_LARGE:
-                  value:
-                    code: IMAGE_FILE_TOO_LARGE
-                    error: Bad Request
-                    message: uploaded image file is too large
-                    statusCode: 400
-                IMAGE_FORMAT_NOT_SUPPORT:
-                  value:
-                    code: IMAGE_FORMAT_NOT_SUPPORT
-                    error: Bad Request
-                    message: not valid image file, only support jpeg, jpg, png, webp
-                    statusCode: 400
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: default error response type
-        '401':
+        '403':
           content:
             application/json:
-              examples:
-                NOT_ALLOWED:
-                  value:
-                    code: NOT_ALLOWED
-                    error: Unauthorized
-                    message: you don't have permission to non sandbox subject
-                    statusCode: 401
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: default error response type
@@ -8510,7 +13426,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       tags:
         - wiki
@@ -8544,7 +13459,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       summary: 撤消条目封面投票
       tags:
@@ -8578,7 +13492,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       summary: 为条目封面投票
       tags:
@@ -8633,11 +13546,6 @@ paths:
                   type: array
                 expectedRevision:
                   items:
-                    description: >-
-                      a optional object to check if input is changed by others
-
-                      if some key is given, and current data in database doesn't
-                      match input, subject will not be changed
                     properties:
                       date:
                         type: string
@@ -8662,13 +13570,6 @@ paths:
         '401':
           content:
             application/json:
-              examples:
-                INVALID_SYNTAX_ERROR:
-                  value:
-                    code: INVALID_SYNTAX_ERROR
-                    error: Bad Request
-                    message: '%s'
-                    statusCode: 400
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: default error response type
@@ -8677,7 +13578,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -8748,13 +13648,6 @@ paths:
         '401':
           content:
             application/json:
-              examples:
-                INVALID_SYNTAX_ERROR:
-                  value:
-                    code: INVALID_SYNTAX_ERROR
-                    error: Bad Request
-                    message: '%s'
-                    statusCode: 400
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: default error response type
@@ -8763,7 +13656,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
@@ -8773,9 +13665,25 @@ paths:
         - wiki
   /p1/wiki/subjects/{subjectID}/history-summary:
     get:
-      description: 获取当前的 wiki 信息
       operationId: subjectEditHistorySummary
       parameters:
+        - description: max 100
+          in: query
+          name: limit
+          required: false
+          schema:
+            default: 20
+            maximum: 100
+            minimum: 1
+            type: integer
+        - description: min 0
+          in: query
+          name: offset
+          required: false
+          schema:
+            default: 0
+            minimum: 0
+            type: integer
         - in: path
           name: subjectID
           required: true
@@ -8787,20 +13695,22 @@ paths:
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/HistorySummary'
-                type: array
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/RevisionHistory'
+                    type: array
+                  total:
+                    description: limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数
+                    type: integer
+                required:
+                  - data
+                  - total
+                type: object
           description: Default Response
         '401':
           content:
             application/json:
-              examples:
-                INVALID_SYNTAX_ERROR:
-                  value:
-                    code: INVALID_SYNTAX_ERROR
-                    error: Bad Request
-                    message: '%s'
-                    statusCode: 400
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: default error response type
@@ -8809,10 +13719,125 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
       security:
         - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取条目 wiki 历史编辑摘要
+      tags:
+        - wiki
+  /p1/wiki/subjects/{subjectID}/persons/history-summary:
+    get:
+      operationId: subjectPersonHistorySummary
+      parameters:
+        - description: max 100
+          in: query
+          name: limit
+          required: false
+          schema:
+            default: 20
+            maximum: 100
+            minimum: 1
+            type: integer
+        - description: min 0
+          in: query
+          name: offset
+          required: false
+          schema:
+            default: 0
+            minimum: 0
+            type: integer
+        - in: path
+          name: subjectID
+          required: true
+          schema:
+            minimum: 1
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/RevisionHistory'
+                    type: array
+                  total:
+                    description: limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数
+                    type: integer
+                required:
+                  - data
+                  - total
+                type: object
+          description: Default Response
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取条目-人物关联 wiki 历史编辑摘要
+      tags:
+        - wiki
+  /p1/wiki/subjects/{subjectID}/relations/history-summary:
+    get:
+      operationId: subjectRelationHistorySummary
+      parameters:
+        - description: max 100
+          in: query
+          name: limit
+          required: false
+          schema:
+            default: 20
+            maximum: 100
+            minimum: 1
+            type: integer
+        - description: min 0
+          in: query
+          name: offset
+          required: false
+          schema:
+            default: 0
+            minimum: 0
+            type: integer
+        - in: path
+          name: subjectID
+          required: true
+          schema:
+            minimum: 1
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/RevisionHistory'
+                    type: array
+                  total:
+                    description: limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数
+                    type: integer
+                required:
+                  - data
+                  - total
+                type: object
+          description: Default Response
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取条目关联 wiki 历史编辑摘要
       tags:
         - wiki
   /p1/wiki/unlock/subjects:
@@ -8846,7 +13871,192 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                description: 意料之外的服务器错误
           description: 意料之外的服务器错误
+      tags:
+        - wiki
+  /p1/wiki/users/{username}/contributions/characters:
+    get:
+      operationId: getUserContributedCharacters
+      parameters:
+        - description: max 100
+          in: query
+          name: limit
+          required: false
+          schema:
+            default: 20
+            maximum: 100
+            minimum: 1
+            type: integer
+        - description: min 0
+          in: query
+          name: offset
+          required: false
+          schema:
+            default: 0
+            minimum: 0
+            type: integer
+        - in: path
+          name: username
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/UserCharacterContribution'
+                    type: array
+                  total:
+                    description: limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数
+                    type: integer
+                required:
+                  - data
+                  - total
+                type: object
+          description: Default Response
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取用户 wiki 角色编辑记录
+      tags:
+        - wiki
+  /p1/wiki/users/{username}/contributions/persons:
+    get:
+      operationId: getUserContributedPersons
+      parameters:
+        - description: max 100
+          in: query
+          name: limit
+          required: false
+          schema:
+            default: 20
+            maximum: 100
+            minimum: 1
+            type: integer
+        - description: min 0
+          in: query
+          name: offset
+          required: false
+          schema:
+            default: 0
+            minimum: 0
+            type: integer
+        - in: path
+          name: username
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/UserPersonContribution'
+                    type: array
+                  total:
+                    description: limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数
+                    type: integer
+                required:
+                  - data
+                  - total
+                type: object
+          description: Default Response
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取用户 wiki 人物编辑记录
+      tags:
+        - wiki
+  /p1/wiki/users/{username}/contributions/subjects:
+    get:
+      operationId: getUserContributedSubjects
+      parameters:
+        - description: max 100
+          in: query
+          name: limit
+          required: false
+          schema:
+            default: 20
+            maximum: 100
+            minimum: 1
+            type: integer
+        - description: min 0
+          in: query
+          name: offset
+          required: false
+          schema:
+            default: 0
+            minimum: 0
+            type: integer
+        - in: path
+          name: username
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/UserSubjectContribution'
+                    type: array
+                  total:
+                    description: limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数
+                    type: integer
+                required:
+                  - data
+                  - total
+                type: object
+          description: Default Response
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: 获取用户 wiki 条目编辑记录
       tags:
         - wiki

--- a/packages/client/client.ts
+++ b/packages/client/client.ts
@@ -46,6 +46,7 @@ export type BlogEntry = {
   tags: string[];
   title: string;
   type: number;
+  uid: number;
   updatedAt: number;
   user: SlimUser;
   views: number;
@@ -67,6 +68,7 @@ export type CommentBase = {
   mainID: number;
   reactions?: Reaction[];
   relatedID: number;
+  relatedPhotoID?: number;
   state: number;
   user?: SlimUser;
 };
@@ -97,6 +99,7 @@ export type SubjectImages = {
 };
 export type SlimSubjectInterest = {
   comment: string;
+  id: number;
   rate: number;
   tags: string[];
   type: CollectionType;
@@ -114,6 +117,7 @@ export type SlimSubject = {
   info: string;
   interest?: SlimSubjectInterest;
   locked: boolean;
+  metaTags: string[];
   name: string;
   nameCN: string;
   nsfw: boolean;
@@ -152,10 +156,12 @@ export type Character = {
   nameCN: string;
   nsfw: boolean;
   redirect: number;
-  role: number;
+  role: CharacterType;
   summary: string;
 };
 export type SlimPerson = {
+  /** 职业 */
+  career: string[];
   comment: number;
   id: number;
   images?: PersonImages;
@@ -166,8 +172,13 @@ export type SlimPerson = {
   nsfw: boolean;
   type: number;
 };
+export type CharacterCast = {
+  person: SlimPerson;
+  relation: CharacterCastType;
+  summary: string;
+};
 export type CharacterSubject = {
-  actors: SlimPerson[];
+  casts: CharacterCast[];
   subject: SlimSubject;
   type: number;
 };
@@ -175,26 +186,103 @@ export type PersonCollect = {
   createdAt: number;
   user: SlimUser;
 };
+export type IndexStats = {
+  blog?: number;
+  character?: number;
+  episode?: number;
+  groupTopic?: number;
+  person?: number;
+  subject: {
+    anime?: number;
+    book?: number;
+    game?: number;
+    music?: number;
+    real?: number;
+  };
+  subjectTopic?: number;
+};
+export type SlimIndex = {
+  createdAt: number;
+  id: number;
+  private: boolean;
+  stats: IndexStats;
+  title: string;
+  total: number;
+  type: IndexType;
+  uid: number;
+  updatedAt: number;
+  user?: SlimUser;
+};
+export type MonoPhotoImages = {
+  common: string;
+  grid: string;
+  large: string;
+  medium: string;
+  small: string;
+};
+export type MonoPhoto = {
+  comment: string;
+  createdAt: number;
+  creatorID: number;
+  id: number;
+  images: MonoPhotoImages;
+  lastPost: number;
+  mainID: number;
+  spoiler: boolean;
+  tags: string[];
+  target: string;
+  title: string;
+  type: number;
+  updatedAt: number;
+  user?: SlimUser;
+};
+export type SlimCharacter = {
+  comment: number;
+  id: number;
+  images?: PersonImages;
+  info: string;
+  lock: boolean;
+  name: string;
+  nameCN: string;
+  nsfw: boolean;
+  role: number;
+};
+export type PersonRelationType = {
+  cn: string;
+  desc: string;
+  id: number;
+  primary?: boolean;
+  skipViceVersa?: boolean;
+  viceVersaTo?: number;
+};
+export type CharacterRelation = {
+  character: SlimCharacter;
+  comment: string;
+  ended: boolean;
+  relation: PersonRelationType;
+  spoiler: boolean;
+};
 export type UpdateEpisodeProgress = {
   /** 是否批量更新(看到当前章节), 批量更新时 type 无效 */
   batch?: boolean;
   type?: EpisodeCollectionStatus;
 };
-export type IndexStats = {
-  [key: string]: number;
-};
 export type Index = {
+  award: number;
   collectedAt?: number;
   collects: number;
   createdAt: number;
   desc: string;
   id: number;
+  private: boolean;
   replies: number;
   stats: IndexStats;
   title: string;
   total: number;
-  type: number;
+  type: IndexType;
+  uid: number;
   updatedAt: number;
+  user?: SlimUser;
 };
 export type Person = {
   /** 职业 */
@@ -212,7 +300,7 @@ export type Person = {
   nsfw: boolean;
   redirect: number;
   summary: string;
-  type: number;
+  type: PersonType;
 };
 export type SubjectAirtime = {
   date: string;
@@ -226,6 +314,7 @@ export type SubjectCollection = {
 export type SubjectInterest = {
   comment: string;
   epStatus: number;
+  id: number;
   private: boolean;
   rate: number;
   tags: string[];
@@ -283,6 +372,10 @@ export type CollectSubject = {
   comment?: string;
   /** 仅自己可见 */
   private?: boolean;
+  /** 是否自动完成条目进度，仅在 `type` 为 `看过` 时有效，并且不会产生对应的时间线记录：
+              - 书籍条目会检查总的话数和卷数，并更新收藏进度到最新;
+              - 动画和三次元会标记所有正片章节为已完成，并同时更新收藏进度 */
+  progress?: boolean;
   /** 评分，0 表示删除评分 */
   rate?: number;
   tags?: string[];
@@ -290,15 +383,18 @@ export type CollectSubject = {
 };
 export type Episode = {
   airdate: string;
+  collection?: {
+    status: EpisodeCollectionStatus;
+    updatedAt?: number;
+  };
   comment: number;
-  desc?: string;
+  desc: string;
   disc: number;
   duration: string;
   id: number;
   name: string;
   nameCN: string;
   sort: number;
-  status?: EpisodeCollectionStatus;
   subject?: SlimSubject;
   subjectID: number;
   type: EpisodeType;
@@ -320,22 +416,20 @@ export type SlimGroup = {
   nsfw: boolean;
   title: string;
 };
-export type TopicBase = {
+export type Topic = {
   /** 发帖时间，unix time stamp in seconds */
   createdAt: number;
+  creator?: SlimUser;
   creatorID: number;
   display: number;
   id: number;
   /** 小组/条目ID */
   parentID: number;
+  replyCount: number;
   state: number;
   title: string;
   /** 最后回复时间，unix time stamp in seconds */
   updatedAt: number;
-};
-export type Topic = TopicBase & {
-  creator?: SlimUser;
-  replies: number;
 };
 export type Post = {
   content: string;
@@ -358,8 +452,7 @@ export type ReplyBase = {
 export type Reply = ReplyBase & {
   replies: ReplyBase[];
 };
-export type GroupTopic = TopicBase & {
-  creator: SlimUser;
+export type GroupTopic = Topic & {
   group: SlimGroup;
   replies: Reply[];
 };
@@ -367,6 +460,12 @@ export type UpdateTopic = {
   /** bbcode */
   content: string;
   title: string;
+};
+export type GroupMember = {
+  joinedAt: number;
+  role: GroupMemberRole;
+  uid: number;
+  user?: SlimUser;
 };
 export type Group = {
   accessible: boolean;
@@ -378,22 +477,79 @@ export type Group = {
   icon: Avatar;
   id: number;
   members: number;
+  membership?: GroupMember;
   name: string;
   nsfw: boolean;
   posts: number;
   title: string;
   topics: number;
 };
-export type GroupMember = {
-  joinedAt: number;
-  role: GroupMemberRole;
-  uid: number;
-  user?: SlimUser;
-};
 export type CreateTopic = {
   /** bbcode */
   content: string;
   title: string;
+};
+export type CreateIndex = {
+  /** 目录描述 */
+  desc: string;
+  /** 仅自己可见 */
+  private?: boolean;
+  /** 目录标题 */
+  title: string;
+};
+export type UpdateIndex = {
+  /** 目录描述 */
+  desc?: string;
+  /** 仅自己可见 */
+  private?: boolean;
+  /** 目录标题 */
+  title?: string;
+};
+export type SlimBlogEntry = {
+  createdAt: number;
+  icon: string;
+  id: number;
+  public: boolean;
+  replies: number;
+  summary: string;
+  title: string;
+  type: number;
+  uid: number;
+  updatedAt: number;
+  user?: SlimUser;
+};
+export type SubjectTopic = Topic & {
+  replies: Reply[];
+  subject: SlimSubject;
+};
+export type IndexRelated = {
+  award: string;
+  blog?: SlimBlogEntry;
+  cat: IndexRelatedCategory;
+  character?: SlimCharacter;
+  comment: string;
+  createdAt: number;
+  episode?: Episode;
+  groupTopic?: GroupTopic;
+  id: number;
+  order: number;
+  person?: SlimPerson;
+  rid: number;
+  sid: number;
+  subject?: SlimSubject;
+  subjectTopic?: SubjectTopic;
+  type: number;
+};
+export type CreateIndexRelated = {
+  award?: string;
+  cat: IndexRelatedCategory;
+  comment?: string;
+  order?: number;
+  sid: number;
+};
+export type UpdateIndexRelated = {
+  comment: string;
+  order: number;
 };
 export type LoginRequestBody = {
   email: string;
@@ -405,9 +561,6 @@ export type Permissions = {
 };
 export type Profile = {
   avatar: Avatar;
-  bio: string;
-  blocklist: number[];
-  friendIDs: number[];
   group: number;
   id: number;
   joinedAt: number;
@@ -419,35 +572,17 @@ export type Profile = {
   username: string;
 };
 export type Notice = {
-  /** unix timestamp in seconds */
   createdAt: number;
   id: number;
-  postID: number;
-  sender: {
-    avatar: Avatar;
-    group: number;
-    id: number;
-    joinedAt: number;
-    nickname: string;
-    sign: string;
-    username: string;
-  };
+  /** 对应的 topicID, episodeID, userID ... */
+  mainID: number;
+  /** 对应的 postID ... */
+  relatedID: number;
+  sender: SlimUser;
   title: string;
-  topicID: number;
   /** 查看 `./lib/notify.ts` _settings */
   type: number;
   unread: boolean;
-};
-export type SlimCharacter = {
-  comment: number;
-  id: number;
-  images?: PersonImages;
-  info: string;
-  lock: boolean;
-  name: string;
-  nameCN: string;
-  nsfw: boolean;
-  role: number;
 };
 export type CharacterSubjectRelation = {
   subject: SlimSubject;
@@ -456,6 +591,13 @@ export type CharacterSubjectRelation = {
 export type PersonCharacter = {
   character: SlimCharacter;
   relations: CharacterSubjectRelation[];
+};
+export type PersonRelation = {
+  comment: string;
+  ended: boolean;
+  person: SlimPerson;
+  relation: PersonRelationType;
+  spoiler: boolean;
 };
 export type SubjectStaffPositionType = {
   cn: string;
@@ -471,6 +613,14 @@ export type SubjectStaffPosition = {
 export type PersonWork = {
   positions: SubjectStaffPosition[];
   subject: SlimSubject;
+};
+export type CreateReport = {
+  /** 举报说明（可选） */
+  comment?: string;
+  /** 被举报对象的 ID */
+  id: number;
+  type: ReportType;
+  value: ReportReason;
 };
 export type CharacterSearchFilter = {
   /** 无权限的用户会直接忽略此字段，不会返回 R18 条目。
@@ -509,16 +659,15 @@ export type SearchSubject = {
   keyword: string;
   sort?: SubjectSearchSort;
 };
-export type SubjectTopic = TopicBase & {
-  creator: SlimUser;
-  replies: Reply[];
-  subject: SlimSubject;
-};
 export type SubjectCharacter = {
-  actors: SlimPerson[];
+  casts: CharacterCast[];
   character: SlimCharacter;
   order: number;
   type: number;
+};
+export type SubjectCollect = {
+  interest: SlimSubjectInterest;
+  user: SlimUser;
 };
 export type SubjectInterestComment = {
   comment: string;
@@ -546,18 +695,6 @@ export type SubjectRelation = {
   relation: SubjectRelationType;
   subject: SlimSubject;
 };
-export type SlimBlogEntry = {
-  createdAt: number;
-  icon: string;
-  id: number;
-  public: boolean;
-  replies: number;
-  summary: string;
-  title: string;
-  type: number;
-  uid: number;
-  updatedAt: number;
-};
 export type SubjectReview = {
   entry: SlimBlogEntry;
   id: number;
@@ -575,13 +712,6 @@ export type SubjectPositionStaff = {
 export type SubjectPosition = {
   position: SubjectStaffPositionType;
   staffs: SubjectPositionStaff[];
-};
-export type SlimIndex = {
-  createdAt: number;
-  id: number;
-  title: string;
-  total: number;
-  type: number;
 };
 export type TimelineMemo = {
   blog?: SlimBlogEntry;
@@ -618,13 +748,16 @@ export type TimelineMemo = {
   subject?: {
     collectID?: number;
     comment: string;
-    rate: number;
-    reactions?: Reaction[];
+    rate?: number;
     subject: SlimSubject;
   }[];
   wiki?: {
     subject?: SlimSubject;
   };
+};
+export type TimelineSource = {
+  name: string;
+  url?: string;
 };
 export type Timeline = {
   batch: boolean;
@@ -632,6 +765,7 @@ export type Timeline = {
   createdAt: number;
   id: number;
   memo: TimelineMemo;
+  reactions?: Reaction[];
   replies: number;
   source: TimelineSource;
   type: number;
@@ -691,6 +825,56 @@ export type User = {
   stats: UserStats;
   username: string;
 };
+export type CharacterCastRevisionWikiInfo = {
+  person: {
+    id: number;
+    name: string;
+    nameCN: string;
+  };
+  subject: {
+    id: number;
+    name: string;
+    nameCN: string;
+    typeID: SubjectType;
+  };
+}[];
+export type CharacterRevisionWikiInfo = {
+  extra: {
+    img?: string;
+  };
+  infobox: string;
+  name: string;
+  summary: string;
+};
+export type CharacterSubjectRevisionWikiInfo = {
+  order: number;
+  subject: {
+    id: number;
+    name: string;
+    nameCN: string;
+    typeID: SubjectType;
+  };
+  type: number;
+}[];
+export type CharacterWikiInfo = {
+  id: number;
+  infobox: string;
+  locked: boolean;
+  name: string;
+  redirect: number;
+  summary: string;
+};
+export type RevisionHistory = {
+  commitMessage: string;
+  /** unix timestamp seconds */
+  createdAt: number;
+  creator: {
+    nickname: string;
+    username: string;
+  };
+  id: number;
+  type: RevisionType;
+};
 export type EpisodeWikiInfo = {
   /** YYYY-MM-DD */
   date?: string;
@@ -704,12 +888,62 @@ export type EpisodeWikiInfo = {
   summary: string;
   type: EpisodeType;
 };
+export type PersonCastRevisionWikiInfo = {
+  character: {
+    id: number;
+    name: string;
+    nameCN: string;
+  };
+  subject: {
+    id: number;
+    name: string;
+    nameCN: string;
+    typeID: SubjectType;
+  };
+}[];
+export type PersonRevisionWikiInfo = {
+  extra: {
+    img?: string;
+  };
+  infobox: string;
+  name: string;
+  profession: {
+    actor?: boolean;
+    artist?: boolean;
+    illustrator?: boolean;
+    mangaka?: boolean;
+    producer?: boolean;
+    seiyu?: boolean;
+    writer?: boolean;
+  };
+  summary: string;
+};
+export type PersonSubjectRevisionWikiInfo = {
+  position: number;
+  subject: {
+    id: number;
+    name: string;
+    nameCN: string;
+    typeID: SubjectType;
+  };
+}[];
 export type PersonWikiInfo = {
   id: number;
   infobox: string;
+  locked: boolean;
   name: string;
+  profession: {
+    actor?: boolean;
+    artist?: boolean;
+    illustrator?: boolean;
+    mangaka?: boolean;
+    producer?: boolean;
+    seiyu?: boolean;
+    writer?: boolean;
+  };
+  redirect: number;
   summary: string;
-  typeID: SubjectType;
+  typeID: PersonType;
 };
 export type RecentWikiChange = {
   persons: {
@@ -721,6 +955,40 @@ export type RecentWikiChange = {
     id: number;
   }[];
 };
+export type SubjectCharacterRevisionWikiInfo = {
+  character: {
+    id: number;
+    name: string;
+    nameCN: string;
+  };
+  order: number;
+  type: number;
+}[];
+export type SubjectPersonRevisionWikiInfo = {
+  person: {
+    id: number;
+    name: string;
+    nameCN: string;
+  };
+  position: number;
+}[];
+export type SubjectRelationRevisionWikiInfo = {
+  order: number;
+  subject: {
+    id: number;
+    name: string;
+    nameCN: string;
+    typeID: SubjectType;
+  };
+  type: number;
+}[];
+export type SubjectRevisionWikiInfo = {
+  id: number;
+  infobox: string;
+  metaTags: string[];
+  name: string;
+  summary: string;
+};
 export type WikiPlatform = {
   id: number;
   text: string;
@@ -730,10 +998,13 @@ export type SubjectWikiInfo = {
   availablePlatform: WikiPlatform[];
   id: number;
   infobox: string;
+  locked: boolean;
   metaTags: string[];
   name: string;
   nsfw: boolean;
   platform: number;
+  redirect: number;
+  series?: boolean;
   summary: string;
   typeID: SubjectType;
 };
@@ -744,20 +1015,41 @@ export type SubjectEdit = {
   name: string;
   nsfw: boolean;
   platform: number;
+  series?: boolean;
   summary: string;
 };
-export type HistorySummary = {
+export type UserCharacterContribution = {
+  characterID: number;
   commitMessage: string;
   /** unix timestamp seconds */
   createdAt: number;
-  creator: {
-    username: string;
-  };
+  id: number;
+  name: string;
+  /** 2 = 角色编辑 */
+  type: number;
+};
+export type UserPersonContribution = {
+  commitMessage: string;
+  /** unix timestamp seconds */
+  createdAt: number;
+  id: number;
+  name: string;
+  personID: number;
+  /** 3 = 人物编辑，15 = 合并，16 = 删除 */
+  type: number;
+};
+export type UserSubjectContribution = {
+  commitMessage: string;
+  /** unix timestamp seconds */
+  createdAt: number;
+  id: number;
+  name: string;
+  subjectID: number;
   /** 修改类型。`1` 正常修改， `11` 合并，`103` 锁定/解锁 `104` 未知 */
   type: number;
 };
 /**
- * 获取绝交用户列表
+ * 获取当前用户的绝交用户列表
  */
 export function getBlocklist(opts?: Oazapfts.RequestOpts) {
   return oazapfts.fetchJson<
@@ -776,14 +1068,9 @@ export function getBlocklist(opts?: Oazapfts.RequestOpts) {
   });
 }
 /**
- * 将用户添加到绝交列表
+ * 取消与用户绝交
  */
-export function addToBlocklist(
-  body: {
-    id: number;
-  },
-  opts?: Oazapfts.RequestOpts,
-) {
+export function removeUserFromBlocklist(username: string, opts?: Oazapfts.RequestOpts) {
   return oazapfts.fetchJson<
     | {
         status: 200;
@@ -792,36 +1079,40 @@ export function addToBlocklist(
         };
       }
     | {
-        status: 500;
+        status: 429;
         data: ErrorResponse;
-      }
-  >(
-    '/p1/blocklist',
-    oazapfts.json({
-      ...opts,
-      method: 'POST',
-      body,
-    }),
-  );
-}
-/**
- * 将用户从绝交列表移出
- */
-export function removeFromBlocklist(id: number, opts?: Oazapfts.RequestOpts) {
-  return oazapfts.fetchJson<
-    | {
-        status: 200;
-        data: {
-          blocklist: number[];
-        };
       }
     | {
         status: 500;
         data: ErrorResponse;
       }
-  >(`/p1/blocklist/${encodeURIComponent(id)}`, {
+  >(`/p1/blocklist/${encodeURIComponent(username)}`, {
     ...opts,
     method: 'DELETE',
+  });
+}
+/**
+ * 与用户绝交
+ */
+export function addUserToBlocklist(username: string, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          blocklist: number[];
+        };
+      }
+    | {
+        status: 429;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(`/p1/blocklist/${encodeURIComponent(username)}`, {
+    ...opts,
+    method: 'PUT',
   });
 }
 /**
@@ -847,7 +1138,7 @@ export function deleteBlogComment(commentId: number, opts?: Oazapfts.RequestOpts
  */
 export function updateBlogComment(
   commentId: number,
-  updateContent?: UpdateContent,
+  updateContent: UpdateContent,
   opts?: Oazapfts.RequestOpts,
 ) {
   return oazapfts.fetchJson<
@@ -900,6 +1191,7 @@ export function getBlogComments(entryId: number, opts?: Oazapfts.RequestOpts) {
           mainID: number;
           reactions?: Reaction[];
           relatedID: number;
+          relatedPhotoID?: number;
           state: number;
           user?: SlimUser;
         } & {
@@ -923,7 +1215,7 @@ export function getBlogComments(entryId: number, opts?: Oazapfts.RequestOpts) {
  */
 export function createBlogComment(
   entryId: number,
-  body?: CreateReply & TurnstileToken,
+  body: CreateReply & TurnstileToken,
   opts?: Oazapfts.RequestOpts,
 ) {
   return oazapfts.fetchJson<
@@ -933,6 +1225,10 @@ export function createBlogComment(
           /** new comment id */
           id: number;
         };
+      }
+    | {
+        status: 429;
+        data: ErrorResponse;
       }
     | {
         status: 500;
@@ -1043,7 +1339,7 @@ export function deleteCharacterComment(commentId: number, opts?: Oazapfts.Reques
  */
 export function updateCharacterComment(
   commentId: number,
-  updateContent?: UpdateContent,
+  updateContent: UpdateContent,
   opts?: Oazapfts.RequestOpts,
 ) {
   return oazapfts.fetchJson<
@@ -1192,6 +1488,7 @@ export function getCharacterComments(characterId: number, opts?: Oazapfts.Reques
           mainID: number;
           reactions?: Reaction[];
           relatedID: number;
+          relatedPhotoID?: number;
           state: number;
           user?: SlimUser;
         } & {
@@ -1215,7 +1512,7 @@ export function getCharacterComments(characterId: number, opts?: Oazapfts.Reques
  */
 export function createCharacterComment(
   characterId: number,
-  body?: CreateReply & TurnstileToken,
+  body: CreateReply & TurnstileToken,
   opts?: Oazapfts.RequestOpts,
 ) {
   return oazapfts.fetchJson<
@@ -1225,6 +1522,10 @@ export function createCharacterComment(
           /** new comment id */
           id: number;
         };
+      }
+    | {
+        status: 429;
+        data: ErrorResponse;
       }
     | {
         status: 500;
@@ -1240,10 +1541,279 @@ export function createCharacterComment(
   );
 }
 /**
+ * 获取角色关联的目录
+ */
+export function getCharacterIndexes(
+  characterId: number,
+  {
+    limit,
+    offset,
+  }: {
+    limit?: number;
+    offset?: number;
+  } = {},
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          data: SlimIndex[];
+          /** limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+          total: number;
+        };
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/characters/${encodeURIComponent(characterId)}/indexes${QS.query(
+      QS.explode({
+        limit,
+        offset,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
+  );
+}
+/**
+ * 获取角色相册列表
+ */
+export function getCharacterPhotos(
+  characterId: number,
+  {
+    limit,
+    offset,
+  }: {
+    limit?: number;
+    offset?: number;
+  } = {},
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          data: MonoPhoto[];
+          /** limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+          total: number;
+        };
+      }
+    | {
+        status: 404;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/characters/${encodeURIComponent(characterId)}/photos${QS.query(
+      QS.explode({
+        limit,
+        offset,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
+  );
+}
+/**
+ * 获取角色首页相册预览
+ */
+export function getCharacterPhotoPreview(
+  characterId: number,
+  {
+    limit,
+  }: {
+    limit?: number;
+  } = {},
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          data: MonoPhoto[];
+          /** limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+          total: number;
+        };
+      }
+    | {
+        status: 404;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/characters/${encodeURIComponent(characterId)}/photos/preview${QS.query(
+      QS.explode({
+        limit,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
+  );
+}
+/**
+ * 获取角色相册图片
+ */
+export function getCharacterPhoto(
+  characterId: number,
+  photoId: number,
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: MonoPhoto;
+      }
+    | {
+        status: 404;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(`/p1/characters/${encodeURIComponent(characterId)}/photos/${encodeURIComponent(photoId)}`, {
+    ...opts,
+  });
+}
+/**
+ * 获取角色相册图片的评论
+ */
+export function getCharacterPhotoComments(
+  characterId: number,
+  photoId: number,
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: ({
+          content: string;
+          createdAt: number;
+          creatorID: number;
+          id: number;
+          mainID: number;
+          reactions?: Reaction[];
+          relatedID: number;
+          relatedPhotoID?: number;
+          state: number;
+          user?: SlimUser;
+        } & {
+          replies: CommentBase[];
+        })[];
+      }
+    | {
+        status: 404;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/characters/${encodeURIComponent(characterId)}/photos/${encodeURIComponent(photoId)}/comments`,
+    {
+      ...opts,
+    },
+  );
+}
+/**
+ * 创建角色相册图片的评论
+ */
+export function createCharacterPhotoComment(
+  characterId: number,
+  photoId: number,
+  body: CreateReply & TurnstileToken,
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          /** new comment id */
+          id: number;
+        };
+      }
+    | {
+        status: 404;
+        data: ErrorResponse;
+      }
+    | {
+        status: 429;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/characters/${encodeURIComponent(characterId)}/photos/${encodeURIComponent(photoId)}/comments`,
+    oazapfts.json({
+      ...opts,
+      method: 'POST',
+      body,
+    }),
+  );
+}
+/**
+ * 获取角色关联角色
+ */
+export function getCharacterRelations(
+  characterId: number,
+  {
+    limit,
+    offset,
+  }: {
+    limit?: number;
+    offset?: number;
+  } = {},
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          data: CharacterRelation[];
+          /** limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+          total: number;
+        };
+      }
+    | {
+        status: 404;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/characters/${encodeURIComponent(characterId)}/relations${QS.query(
+      QS.explode({
+        limit,
+        offset,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
+  );
+}
+/**
  * 标记通知为已读
  */
 export function clearNotice(
-  body?: {
+  body: {
     id?: number[];
   },
   opts?: Oazapfts.RequestOpts,
@@ -1251,10 +1821,7 @@ export function clearNotice(
   return oazapfts.fetchJson<
     | {
         status: 200;
-      }
-    | {
-        status: 401;
-        data: ErrorResponse;
+        data: {};
       }
     | {
         status: 500;
@@ -1308,17 +1875,65 @@ export function getMyCharacterCollections(
   );
 }
 /**
+ * 删除角色收藏
+ */
+export function deleteCharacterCollection(characterId: number, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {};
+      }
+    | {
+        status: 429;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(`/p1/collections/characters/${encodeURIComponent(characterId)}`, {
+    ...opts,
+    method: 'DELETE',
+  });
+}
+/**
+ * 新增角色收藏
+ */
+export function addCharacterCollection(characterId: number, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {};
+      }
+    | {
+        status: 429;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(`/p1/collections/characters/${encodeURIComponent(characterId)}`, {
+    ...opts,
+    method: 'PUT',
+  });
+}
+/**
  * 更新章节进度
  */
 export function updateEpisodeProgress(
   episodeId: number,
-  updateEpisodeProgress?: UpdateEpisodeProgress,
+  updateEpisodeProgress: UpdateEpisodeProgress,
   opts?: Oazapfts.RequestOpts,
 ) {
   return oazapfts.fetchJson<
     | {
         status: 200;
         data: {};
+      }
+    | {
+        status: 429;
+        data: ErrorResponse;
       }
     | {
         status: 500;
@@ -1372,6 +1987,50 @@ export function getMyIndexCollections(
   );
 }
 /**
+ * 删除目录收藏
+ */
+export function deleteIndexCollection(indexId: number, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {};
+      }
+    | {
+        status: 429;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(`/p1/collections/indexes/${encodeURIComponent(indexId)}`, {
+    ...opts,
+    method: 'DELETE',
+  });
+}
+/**
+ * 新增目录收藏
+ */
+export function addIndexCollection(indexId: number, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {};
+      }
+    | {
+        status: 429;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(`/p1/collections/indexes/${encodeURIComponent(indexId)}`, {
+    ...opts,
+    method: 'PUT',
+  });
+}
+/**
  * 获取当前用户的人物收藏
  */
 export function getMyPersonCollections(
@@ -1408,6 +2067,50 @@ export function getMyPersonCollections(
       ...opts,
     },
   );
+}
+/**
+ * 删除人物收藏
+ */
+export function deletePersonCollection(personId: number, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {};
+      }
+    | {
+        status: 429;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(`/p1/collections/persons/${encodeURIComponent(personId)}`, {
+    ...opts,
+    method: 'DELETE',
+  });
+}
+/**
+ * 新增人物收藏
+ */
+export function addPersonCollection(personId: number, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {};
+      }
+    | {
+        status: 429;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(`/p1/collections/persons/${encodeURIComponent(personId)}`, {
+    ...opts,
+    method: 'PUT',
+  });
 }
 /**
  * 获取当前用户的条目收藏
@@ -1461,13 +2164,17 @@ export function getMySubjectCollections(
  */
 export function updateSubjectProgress(
   subjectId: number,
-  updateSubjectProgress?: UpdateSubjectProgress,
+  updateSubjectProgress: UpdateSubjectProgress,
   opts?: Oazapfts.RequestOpts,
 ) {
   return oazapfts.fetchJson<
     | {
         status: 200;
         data: {};
+      }
+    | {
+        status: 429;
+        data: ErrorResponse;
       }
     | {
         status: 500;
@@ -1487,13 +2194,17 @@ export function updateSubjectProgress(
  */
 export function updateSubjectCollection(
   subjectId: number,
-  collectSubject?: CollectSubject,
+  collectSubject: CollectSubject,
   opts?: Oazapfts.RequestOpts,
 ) {
   return oazapfts.fetchJson<
     | {
         status: 200;
         data: {};
+      }
+    | {
+        status: 429;
+        data: ErrorResponse;
       }
     | {
         status: 500;
@@ -1526,7 +2237,7 @@ export function debug(opts?: Oazapfts.RequestOpts) {
   });
 }
 /**
- * 删除条目的剧集吐槽
+ * 删除条目的章节吐槽
  */
 export function deleteEpisodeComment(commentId: number, opts?: Oazapfts.RequestOpts) {
   return oazapfts.fetchJson<
@@ -1544,11 +2255,11 @@ export function deleteEpisodeComment(commentId: number, opts?: Oazapfts.RequestO
   });
 }
 /**
- * 编辑条目的剧集吐槽
+ * 编辑条目的章节吐槽
  */
 export function updateEpisodeComment(
   commentId: number,
-  updateContent?: UpdateContent,
+  updateContent: UpdateContent,
   opts?: Oazapfts.RequestOpts,
 ) {
   return oazapfts.fetchJson<
@@ -1570,7 +2281,57 @@ export function updateEpisodeComment(
   );
 }
 /**
- * 获取剧集信息
+ * 取消条目的章节吐槽点赞
+ */
+export function unlikeEpisodeComment(commentId: number, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {};
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(`/p1/episodes/-/comments/${encodeURIComponent(commentId)}/like`, {
+    ...opts,
+    method: 'DELETE',
+  });
+}
+/**
+ * 给条目的章节吐槽点赞
+ */
+export function likeEpisodeComment(
+  commentId: number,
+  body: {
+    value: number;
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {};
+      }
+    | {
+        status: 429;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/episodes/-/comments/${encodeURIComponent(commentId)}/like`,
+    oazapfts.json({
+      ...opts,
+      method: 'PUT',
+      body,
+    }),
+  );
+}
+/**
+ * 获取章节信息
  */
 export function getEpisode(episodeId: number, opts?: Oazapfts.RequestOpts) {
   return oazapfts.fetchJson<
@@ -1587,7 +2348,7 @@ export function getEpisode(episodeId: number, opts?: Oazapfts.RequestOpts) {
   });
 }
 /**
- * 获取条目的剧集吐槽箱
+ * 获取条目的章节吐槽箱
  */
 export function getEpisodeComments(episodeId: number, opts?: Oazapfts.RequestOpts) {
   return oazapfts.fetchJson<
@@ -1601,6 +2362,7 @@ export function getEpisodeComments(episodeId: number, opts?: Oazapfts.RequestOpt
           mainID: number;
           reactions?: Reaction[];
           relatedID: number;
+          relatedPhotoID?: number;
           state: number;
           user?: SlimUser;
         } & {
@@ -1616,11 +2378,11 @@ export function getEpisodeComments(episodeId: number, opts?: Oazapfts.RequestOpt
   });
 }
 /**
- * 创建条目的剧集吐槽
+ * 创建条目的章节吐槽
  */
 export function createEpisodeComment(
   episodeId: number,
-  body?: CreateReply & TurnstileToken,
+  body: CreateReply & TurnstileToken,
   opts?: Oazapfts.RequestOpts,
 ) {
   return oazapfts.fetchJson<
@@ -1630,6 +2392,10 @@ export function createEpisodeComment(
           /** new comment id */
           id: number;
         };
+      }
+    | {
+        status: 429;
+        data: ErrorResponse;
       }
     | {
         status: 500;
@@ -1683,6 +2449,25 @@ export function getMyFollowers(
   );
 }
 /**
+ * 获取当前用户的好友 ID 列表
+ */
+export function getFriendlist(opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          friendlist: number[];
+        };
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >('/p1/friendlist', {
+    ...opts,
+  });
+}
+/**
  * 获取当前用户的好友列表
  */
 export function getMyFriends(
@@ -1721,14 +2506,60 @@ export function getMyFriends(
   );
 }
 /**
+ * 取消好友
+ */
+export function removeFriend(username: string, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {};
+      }
+    | {
+        status: 429;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(`/p1/friends/${encodeURIComponent(username)}`, {
+    ...opts,
+    method: 'DELETE',
+  });
+}
+/**
+ * 添加好友
+ */
+export function addFriend(username: string, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {};
+      }
+    | {
+        status: 429;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(`/p1/friends/${encodeURIComponent(username)}`, {
+    ...opts,
+    method: 'PUT',
+  });
+}
+/**
  * 获取小组列表
  */
 export function getGroups(
   sort: GroupSort,
   {
+    mode,
     limit,
     offset,
   }: {
+    mode?: GroupFilterMode;
     limit?: number;
     offset?: number;
   } = {},
@@ -1750,6 +2581,7 @@ export function getGroups(
   >(
     `/p1/groups${QS.query(
       QS.explode({
+        mode,
         sort,
         limit,
         offset,
@@ -1800,7 +2632,7 @@ export function getGroupPost(postId: number, opts?: Oazapfts.RequestOpts) {
  */
 export function editGroupPost(
   postId: number,
-  updateContent?: UpdateContent,
+  updateContent: UpdateContent,
   opts?: Oazapfts.RequestOpts,
 ) {
   return oazapfts.fetchJson<
@@ -1822,6 +2654,56 @@ export function editGroupPost(
   );
 }
 /**
+ * 取消小组话题回复点赞
+ */
+export function unlikeGroupPost(postId: number, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {};
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(`/p1/groups/-/posts/${encodeURIComponent(postId)}/like`, {
+    ...opts,
+    method: 'DELETE',
+  });
+}
+/**
+ * 给小组话题回复点赞
+ */
+export function likeGroupPost(
+  postId: number,
+  body: {
+    value: number;
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {};
+      }
+    | {
+        status: 429;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/groups/-/posts/${encodeURIComponent(postId)}/like`,
+    oazapfts.json({
+      ...opts,
+      method: 'PUT',
+      body,
+    }),
+  );
+}
+/**
  * 获取最新的小组话题
  */
 export function getRecentGroupTopics(
@@ -1835,10 +2717,20 @@ export function getRecentGroupTopics(
   } = {},
   opts?: Oazapfts.RequestOpts,
 ) {
-  return oazapfts.fetchJson<{
-    status: 500;
-    data: ErrorResponse;
-  }>(
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          data: GroupTopic[];
+          /** limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+          total: number;
+        };
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
     `/p1/groups/-/topics${QS.query(
       QS.explode({
         mode,
@@ -1873,7 +2765,7 @@ export function getGroupTopic(topicId: number, opts?: Oazapfts.RequestOpts) {
  */
 export function editGroupTopic(
   topicId: number,
-  updateTopic?: UpdateTopic,
+  updateTopic: UpdateTopic,
   opts?: Oazapfts.RequestOpts,
 ) {
   return oazapfts.fetchJson<
@@ -1899,7 +2791,7 @@ export function editGroupTopic(
  */
 export function createGroupReply(
   topicId: number,
-  body?: CreateReply & TurnstileToken,
+  body: CreateReply & TurnstileToken,
   opts?: Oazapfts.RequestOpts,
 ) {
   return oazapfts.fetchJson<
@@ -1908,6 +2800,10 @@ export function createGroupReply(
         data: {
           id: number;
         };
+      }
+    | {
+        status: 429;
+        data: ErrorResponse;
       }
     | {
         status: 500;
@@ -2025,7 +2921,7 @@ export function getGroupTopics(
  */
 export function createGroupTopic(
   groupName: string,
-  body?: CreateTopic & TurnstileToken,
+  body: CreateTopic & TurnstileToken,
   opts?: Oazapfts.RequestOpts,
 ) {
   return oazapfts.fetchJson<
@@ -2035,6 +2931,10 @@ export function createGroupTopic(
           /** new topic id */
           id: number;
         };
+      }
+    | {
+        status: 429;
+        data: ErrorResponse;
       }
     | {
         status: 500;
@@ -2050,13 +2950,327 @@ export function createGroupTopic(
   );
 }
 /**
+ * 创建目录
+ */
+export function createIndex(createIndex: CreateIndex, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          id: number;
+        };
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    '/p1/indexes',
+    oazapfts.json({
+      ...opts,
+      method: 'POST',
+      body: createIndex,
+    }),
+  );
+}
+/**
+ * 删除目录的评论
+ */
+export function deleteIndexComment(commentId: number, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {};
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(`/p1/indexes/-/comments/${encodeURIComponent(commentId)}`, {
+    ...opts,
+    method: 'DELETE',
+  });
+}
+/**
+ * 编辑目录的评论
+ */
+export function updateIndexComment(
+  commentId: number,
+  updateContent: UpdateContent,
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {};
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/indexes/-/comments/${encodeURIComponent(commentId)}`,
+    oazapfts.json({
+      ...opts,
+      method: 'PUT',
+      body: updateContent,
+    }),
+  );
+}
+/**
+ * 删除目录
+ */
+export function deleteIndex(indexId: number, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {};
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(`/p1/indexes/${encodeURIComponent(indexId)}`, {
+    ...opts,
+    method: 'DELETE',
+  });
+}
+/**
+ * 获取目录详情
+ */
+export function getIndex(indexId: number, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: Index;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(`/p1/indexes/${encodeURIComponent(indexId)}`, {
+    ...opts,
+  });
+}
+/**
+ * 更新目录
+ */
+export function updateIndex(
+  indexId: number,
+  updateIndex: UpdateIndex,
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {};
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/indexes/${encodeURIComponent(indexId)}`,
+    oazapfts.json({
+      ...opts,
+      method: 'PATCH',
+      body: updateIndex,
+    }),
+  );
+}
+/**
+ * 获取目录的评论
+ */
+export function getIndexComments(indexId: number, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: ({
+          content: string;
+          createdAt: number;
+          creatorID: number;
+          id: number;
+          mainID: number;
+          reactions?: Reaction[];
+          relatedID: number;
+          relatedPhotoID?: number;
+          state: number;
+          user?: SlimUser;
+        } & {
+          replies: CommentBase[];
+        })[];
+      }
+    | {
+        status: 404;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(`/p1/indexes/${encodeURIComponent(indexId)}/comments`, {
+    ...opts,
+  });
+}
+/**
+ * 创建目录的评论
+ */
+export function createIndexComment(
+  indexId: number,
+  body: CreateReply & TurnstileToken,
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          /** new comment id */
+          id: number;
+        };
+      }
+    | {
+        status: 429;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/indexes/${encodeURIComponent(indexId)}/comments`,
+    oazapfts.json({
+      ...opts,
+      method: 'POST',
+      body,
+    }),
+  );
+}
+/**
+ * 获取目录的关联内容
+ */
+export function getIndexRelated(
+  indexId: number,
+  {
+    cat,
+    $type,
+    limit,
+    offset,
+  }: {
+    cat?: IndexRelatedCategory;
+    $type?: SubjectType;
+    limit?: number;
+    offset?: number;
+  } = {},
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          data: IndexRelated[];
+          /** limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+          total: number;
+        };
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/indexes/${encodeURIComponent(indexId)}/related${QS.query(
+      QS.explode({
+        cat,
+        type: $type,
+        limit,
+        offset,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
+  );
+}
+/**
+ * 添加目录关联内容
+ */
+export function putIndexRelated(
+  indexId: number,
+  createIndexRelated: CreateIndexRelated,
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          id: number;
+        };
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/indexes/${encodeURIComponent(indexId)}/related`,
+    oazapfts.json({
+      ...opts,
+      method: 'PUT',
+      body: createIndexRelated,
+    }),
+  );
+}
+/**
+ * 删除目录关联内容
+ */
+export function deleteIndexRelated(indexId: number, id: number, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {};
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(`/p1/indexes/${encodeURIComponent(indexId)}/related/${encodeURIComponent(id)}`, {
+    ...opts,
+    method: 'DELETE',
+  });
+}
+/**
+ * 更新目录关联内容
+ */
+export function patchIndexRelated(
+  indexId: number,
+  id: number,
+  updateIndexRelated: UpdateIndexRelated,
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {};
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/indexes/${encodeURIComponent(indexId)}/related/${encodeURIComponent(id)}`,
+    oazapfts.json({
+      ...opts,
+      method: 'PATCH',
+      body: updateIndexRelated,
+    }),
+  );
+}
+/**
  * 需要 [turnstile](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/)
  *
  * next.bgm.tv 域名对应的 site-key 为 `0x4AAAAAAABkMYinukE8nzYS`
  *
  * dev.bgm38.tv 域名使用测试用的 site-key `1x00000000000000000000AA`
  */
-export function login(loginRequestBody?: LoginRequestBody, opts?: Oazapfts.RequestOpts) {
+export function login(loginRequestBody: LoginRequestBody, opts?: Oazapfts.RequestOpts) {
   return oazapfts.fetchJson<
     | {
         status: 200;
@@ -2090,7 +3304,7 @@ export function login(loginRequestBody?: LoginRequestBody, opts?: Oazapfts.Reque
 /**
  * 登出
  */
-export function logout(body?: {}, opts?: Oazapfts.RequestOpts) {
+export function logout(body: {}, opts?: Oazapfts.RequestOpts) {
   return oazapfts.fetchJson<
     | {
         status: 200;
@@ -2157,10 +3371,6 @@ export function listNotice(
         };
       }
     | {
-        status: 401;
-        data: ErrorResponse;
-      }
-    | {
         status: 500;
         data: ErrorResponse;
       }
@@ -2174,6 +3384,83 @@ export function listNotice(
     {
       ...opts,
     },
+  );
+}
+/**
+ * 获取 Passkey 登录选项
+ */
+export function passkeyLoginOptions(
+  body: {
+    credentials?: {
+      credentialId: string;
+      transports?: string[];
+    }[];
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          challenge: string;
+          options: any;
+          rpId: string;
+        };
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    '/p1/passkey/login/options',
+    oazapfts.json({
+      ...opts,
+      method: 'POST',
+      body,
+    }),
+  );
+}
+/**
+ * 验证 Passkey 登录并签发 session
+ */
+export function passkeyLoginVerify(
+  body: {
+    /** 之前 options 返回的 challenge */
+    challenge: string;
+    credential: {
+      clientExtensionResults: {
+        [key: string]: any;
+      };
+      id: string;
+      rawId: string;
+      response: {
+        authenticatorData: string;
+        clientDataJSON: string;
+        signature: string;
+        userHandle?: string;
+      };
+      type: Type;
+      [key: string]: any;
+    };
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: any;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    '/p1/passkey/login/verify',
+    oazapfts.json({
+      ...opts,
+      method: 'POST',
+      body,
+    }),
   );
 }
 /**
@@ -2199,7 +3486,7 @@ export function deletePersonComment(commentId: number, opts?: Oazapfts.RequestOp
  */
 export function updatePersonComment(
   commentId: number,
-  updateContent?: UpdateContent,
+  updateContent: UpdateContent,
   opts?: Oazapfts.RequestOpts,
 ) {
   return oazapfts.fetchJson<
@@ -2348,6 +3635,7 @@ export function getPersonComments(personId: number, opts?: Oazapfts.RequestOpts)
           mainID: number;
           reactions?: Reaction[];
           relatedID: number;
+          relatedPhotoID?: number;
           state: number;
           user?: SlimUser;
         } & {
@@ -2371,7 +3659,7 @@ export function getPersonComments(personId: number, opts?: Oazapfts.RequestOpts)
  */
 export function createPersonComment(
   personId: number,
-  body?: CreateReply & TurnstileToken,
+  body: CreateReply & TurnstileToken,
   opts?: Oazapfts.RequestOpts,
 ) {
   return oazapfts.fetchJson<
@@ -2381,6 +3669,10 @@ export function createPersonComment(
           /** new comment id */
           id: number;
         };
+      }
+    | {
+        status: 429;
+        data: ErrorResponse;
       }
     | {
         status: 500;
@@ -2393,6 +3685,268 @@ export function createPersonComment(
       method: 'POST',
       body,
     }),
+  );
+}
+/**
+ * 获取人物关联的目录
+ */
+export function getPersonIndexes(
+  personId: number,
+  {
+    limit,
+    offset,
+  }: {
+    limit?: number;
+    offset?: number;
+  } = {},
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          data: SlimIndex[];
+          /** limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+          total: number;
+        };
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/persons/${encodeURIComponent(personId)}/indexes${QS.query(
+      QS.explode({
+        limit,
+        offset,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
+  );
+}
+/**
+ * 获取人物相册列表
+ */
+export function getPersonPhotos(
+  personId: number,
+  {
+    limit,
+    offset,
+  }: {
+    limit?: number;
+    offset?: number;
+  } = {},
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          data: MonoPhoto[];
+          /** limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+          total: number;
+        };
+      }
+    | {
+        status: 404;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/persons/${encodeURIComponent(personId)}/photos${QS.query(
+      QS.explode({
+        limit,
+        offset,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
+  );
+}
+/**
+ * 获取人物首页相册预览
+ */
+export function getPersonPhotoPreview(
+  personId: number,
+  {
+    limit,
+  }: {
+    limit?: number;
+  } = {},
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          data: MonoPhoto[];
+          /** limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+          total: number;
+        };
+      }
+    | {
+        status: 404;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/persons/${encodeURIComponent(personId)}/photos/preview${QS.query(
+      QS.explode({
+        limit,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
+  );
+}
+/**
+ * 获取人物相册图片
+ */
+export function getPersonPhoto(personId: number, photoId: number, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: MonoPhoto;
+      }
+    | {
+        status: 404;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(`/p1/persons/${encodeURIComponent(personId)}/photos/${encodeURIComponent(photoId)}`, {
+    ...opts,
+  });
+}
+/**
+ * 获取人物相册图片的评论
+ */
+export function getPersonPhotoComments(
+  personId: number,
+  photoId: number,
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: ({
+          content: string;
+          createdAt: number;
+          creatorID: number;
+          id: number;
+          mainID: number;
+          reactions?: Reaction[];
+          relatedID: number;
+          relatedPhotoID?: number;
+          state: number;
+          user?: SlimUser;
+        } & {
+          replies: CommentBase[];
+        })[];
+      }
+    | {
+        status: 404;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(`/p1/persons/${encodeURIComponent(personId)}/photos/${encodeURIComponent(photoId)}/comments`, {
+    ...opts,
+  });
+}
+/**
+ * 创建人物相册图片的评论
+ */
+export function createPersonPhotoComment(
+  personId: number,
+  photoId: number,
+  body: CreateReply & TurnstileToken,
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          /** new comment id */
+          id: number;
+        };
+      }
+    | {
+        status: 404;
+        data: ErrorResponse;
+      }
+    | {
+        status: 429;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/persons/${encodeURIComponent(personId)}/photos/${encodeURIComponent(photoId)}/comments`,
+    oazapfts.json({
+      ...opts,
+      method: 'POST',
+      body,
+    }),
+  );
+}
+/**
+ * 获取人物关联人物
+ */
+export function getPersonRelations(
+  personId: number,
+  {
+    limit,
+    offset,
+  }: {
+    limit?: number;
+    offset?: number;
+  } = {},
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          data: PersonRelation[];
+          /** limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+          total: number;
+        };
+      }
+    | {
+        status: 404;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/persons/${encodeURIComponent(personId)}/relations${QS.query(
+      QS.explode({
+        limit,
+        offset,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
   );
 }
 /**
@@ -2445,10 +3999,139 @@ export function getPersonWorks(
   );
 }
 /**
+ * Get current user privacy settings
+ */
+export function getPrivacy(opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          preferences: {
+            allowNsfw: boolean;
+            canSetNsfwSubject: boolean;
+            showNsfwSubject: boolean;
+          };
+          settings: {
+            commentNotification: CommentNotification;
+            follow: Follow;
+            friendNotification: FriendNotification;
+            mentionNotification: MentionNotification;
+            privateMessage: PrivateMessage;
+            timelineCollectReply: TimelineCollectReply;
+            timelineReply: TimelineReply;
+          };
+        };
+      }
+    | {
+        status: 401;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >('/p1/privacy', {
+    ...opts,
+  });
+}
+/**
+ * Update current user privacy settings
+ */
+export function patchPrivacy(
+  body: {
+    preferences?: {
+      showNsfwSubject?: boolean;
+    };
+    settings?: {
+      commentNotification?: CommentNotification;
+      follow?: Follow;
+      friendNotification?: FriendNotification;
+      mentionNotification?: MentionNotification;
+      privateMessage?: PrivateMessage;
+      timelineCollectReply?: TimelineCollectReply;
+      timelineReply?: TimelineReply;
+    };
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          preferences: {
+            allowNsfw: boolean;
+            canSetNsfwSubject: boolean;
+            showNsfwSubject: boolean;
+          };
+          settings: {
+            commentNotification: CommentNotification;
+            follow: Follow;
+            friendNotification: FriendNotification;
+            mentionNotification: MentionNotification;
+            privateMessage: PrivateMessage;
+            timelineCollectReply: TimelineCollectReply;
+            timelineReply: TimelineReply;
+          };
+        };
+      }
+    | {
+        status: 400;
+        data: ErrorResponse;
+      }
+    | {
+        status: 401;
+        data: ErrorResponse;
+      }
+    | {
+        status: 403;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    '/p1/privacy',
+    oazapfts.json({
+      ...opts,
+      method: 'PATCH',
+      body,
+    }),
+  );
+}
+/**
+ * 报告疑虑
+ */
+export function createReport(createReport: CreateReport, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          message: string;
+        };
+      }
+    | {
+        status: 429;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    '/p1/report',
+    oazapfts.json({
+      ...opts,
+      method: 'POST',
+      body: createReport,
+    }),
+  );
+}
+/**
  * 搜索角色
  */
 export function searchCharacters(
-  searchCharacter?: SearchCharacter,
+  searchCharacter: SearchCharacter,
   {
     limit,
     offset,
@@ -2489,7 +4172,7 @@ export function searchCharacters(
  * 搜索人物
  */
 export function searchPersons(
-  searchPerson?: SearchPerson,
+  searchPerson: SearchPerson,
   {
     limit,
     offset,
@@ -2530,7 +4213,7 @@ export function searchPersons(
  * 搜索条目
  */
 export function searchSubjects(
-  searchSubject?: SearchSubject,
+  searchSubject: SearchSubject,
   {
     limit,
     offset,
@@ -2580,6 +4263,7 @@ export function getSubjects(
     year,
     month,
     tags,
+    tagsCat,
   }: {
     page?: number;
     cat?: number;
@@ -2587,6 +4271,7 @@ export function getSubjects(
     year?: number;
     month?: number;
     tags?: string[];
+    tagsCat?: 'meta' | 'subject';
   } = {},
   opts?: Oazapfts.RequestOpts,
 ) {
@@ -2614,11 +4299,62 @@ export function getSubjects(
         year,
         month,
         tags,
+        tagsCat,
       }),
     )}`,
     {
       ...opts,
     },
+  );
+}
+/**
+ * 取消条目收藏点赞
+ */
+export function unlikeSubjectCollect(collectId: number, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {};
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(`/p1/subjects/-/collects/${encodeURIComponent(collectId)}/like`, {
+    ...opts,
+    method: 'DELETE',
+  });
+}
+/**
+ * 给条目收藏点赞
+ */
+export function likeSubjectCollect(
+  collectId: number,
+  body: {
+    value: number;
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {};
+      }
+    | {
+        status: 429;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/subjects/-/collects/${encodeURIComponent(collectId)}/like`,
+    oazapfts.json({
+      ...opts,
+      method: 'PUT',
+      body,
+    }),
   );
 }
 /**
@@ -2661,7 +4397,7 @@ export function getSubjectPost(postId: number, opts?: Oazapfts.RequestOpts) {
  */
 export function editSubjectPost(
   postId: number,
-  updateContent?: UpdateContent,
+  updateContent: UpdateContent,
   opts?: Oazapfts.RequestOpts,
 ) {
   return oazapfts.fetchJson<
@@ -2680,6 +4416,94 @@ export function editSubjectPost(
       method: 'PUT',
       body: updateContent,
     }),
+  );
+}
+/**
+ * 取消条目讨论回复点赞
+ */
+export function unlikeSubjectPost(postId: number, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {};
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(`/p1/subjects/-/posts/${encodeURIComponent(postId)}/like`, {
+    ...opts,
+    method: 'DELETE',
+  });
+}
+/**
+ * 给条目讨论回复点赞
+ */
+export function likeSubjectPost(
+  postId: number,
+  body: {
+    value: number;
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {};
+      }
+    | {
+        status: 429;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/subjects/-/posts/${encodeURIComponent(postId)}/like`,
+    oazapfts.json({
+      ...opts,
+      method: 'PUT',
+      body,
+    }),
+  );
+}
+/**
+ * 获取最新的条目讨论
+ */
+export function getRecentSubjectTopics(
+  {
+    limit,
+    offset,
+  }: {
+    limit?: number;
+    offset?: number;
+  } = {},
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          data: SubjectTopic[];
+          /** limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+          total: number;
+        };
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/subjects/-/topics${QS.query(
+      QS.explode({
+        limit,
+        offset,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
   );
 }
 /**
@@ -2734,7 +4558,7 @@ export function updateSubjectTopic(
  */
 export function createSubjectReply(
   topicId: number,
-  body?: CreateReply & TurnstileToken,
+  body: CreateReply & TurnstileToken,
   opts?: Oazapfts.RequestOpts,
 ) {
   return oazapfts.fetchJson<
@@ -2743,6 +4567,10 @@ export function createSubjectReply(
         data: {
           id: number;
         };
+      }
+    | {
+        status: 429;
+        data: ErrorResponse;
       }
     | {
         status: 500;
@@ -2817,6 +4645,51 @@ export function getSubjectCharacters(
   );
 }
 /**
+ * 获取条目的收藏用户
+ */
+export function getSubjectCollects(
+  subjectId: number,
+  {
+    $type,
+    mode,
+    limit,
+    offset,
+  }: {
+    $type?: CollectionType;
+    mode?: FilterMode;
+    limit?: number;
+    offset?: number;
+  } = {},
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          data: SubjectCollect[];
+          /** limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+          total: number;
+        };
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/subjects/${encodeURIComponent(subjectId)}/collects${QS.query(
+      QS.explode({
+        type: $type,
+        mode,
+        limit,
+        offset,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
+  );
+}
+/**
  * 获取条目的吐槽箱
  */
 export function getSubjectComments(
@@ -2859,7 +4732,7 @@ export function getSubjectComments(
   );
 }
 /**
- * 获取条目的剧集
+ * 获取条目的章节
  */
 export function getSubjectEpisodes(
   subjectId: number,
@@ -2891,6 +4764,45 @@ export function getSubjectEpisodes(
     `/p1/subjects/${encodeURIComponent(subjectId)}/episodes${QS.query(
       QS.explode({
         type: $type,
+        limit,
+        offset,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
+  );
+}
+/**
+ * 获取条目关联的目录
+ */
+export function getSubjectIndexes(
+  subjectId: number,
+  {
+    limit,
+    offset,
+  }: {
+    limit?: number;
+    offset?: number;
+  } = {},
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          data: SlimIndex[];
+          /** limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+          total: number;
+        };
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/subjects/${encodeURIComponent(subjectId)}/indexes${QS.query(
+      QS.explode({
         limit,
         offset,
       }),
@@ -3148,7 +5060,7 @@ export function getSubjectTopics(
  */
 export function createSubjectTopic(
   subjectId: number,
-  body?: CreateTopic & TurnstileToken,
+  body: CreateTopic & TurnstileToken,
   opts?: Oazapfts.RequestOpts,
 ) {
   return oazapfts.fetchJson<
@@ -3158,6 +5070,10 @@ export function createSubjectTopic(
           /** new topic id */
           id: number;
         };
+      }
+    | {
+        status: 429;
+        data: ErrorResponse;
       }
     | {
         status: 500;
@@ -3181,7 +5097,7 @@ export function getTimeline(
     limit,
     until,
   }: {
-    mode?: TimelineFilterMode;
+    mode?: FilterMode;
     limit?: number;
     until?: number;
   } = {},
@@ -3213,7 +5129,7 @@ export function getTimeline(
  * 发送时间线吐槽
  */
 export function createTimelineSay(
-  body?: CreateContent & TurnstileToken,
+  body: CreateContent & TurnstileToken,
   opts?: Oazapfts.RequestOpts,
 ) {
   return oazapfts.fetchJson<
@@ -3222,6 +5138,10 @@ export function createTimelineSay(
         data: {
           id: number;
         };
+      }
+    | {
+        status: 429;
+        data: ErrorResponse;
       }
     | {
         status: 500;
@@ -3234,6 +5154,44 @@ export function createTimelineSay(
       method: 'POST',
       body,
     }),
+  );
+}
+/**
+ * 时间线事件流 (SSE)
+ */
+export function getTimelineEvents(
+  {
+    cat,
+    mode,
+  }: {
+    cat?: TimelineCat;
+    mode?: FilterMode;
+  } = {},
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          /** 事件类型: 'connected' | 'timeline' */
+          event: string;
+          timeline?: Timeline;
+        };
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/timeline/-/events${QS.query(
+      QS.explode({
+        cat,
+        mode,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
   );
 }
 /**
@@ -3255,6 +5213,56 @@ export function deleteTimeline(timelineId: number, opts?: Oazapfts.RequestOpts) 
   });
 }
 /**
+ * 取消时间线吐槽点赞
+ */
+export function unlikeTimeline(timelineId: number, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {};
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(`/p1/timeline/${encodeURIComponent(timelineId)}/like`, {
+    ...opts,
+    method: 'DELETE',
+  });
+}
+/**
+ * 给时间线吐槽点赞
+ */
+export function likeTimeline(
+  timelineId: number,
+  body: {
+    value: number;
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {};
+      }
+    | {
+        status: 429;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/timeline/${encodeURIComponent(timelineId)}/like`,
+    oazapfts.json({
+      ...opts,
+      method: 'PUT',
+      body,
+    }),
+  );
+}
+/**
  * 获取时间线回复
  */
 export function getTimelineReplies(timelineId: number, opts?: Oazapfts.RequestOpts) {
@@ -3269,6 +5277,7 @@ export function getTimelineReplies(timelineId: number, opts?: Oazapfts.RequestOp
           mainID: number;
           reactions?: Reaction[];
           relatedID: number;
+          relatedPhotoID?: number;
           state: number;
           user?: SlimUser;
         } & {
@@ -3292,7 +5301,7 @@ export function getTimelineReplies(timelineId: number, opts?: Oazapfts.RequestOp
  */
 export function createTimelineReply(
   timelineId: number,
-  body?: CreateReply & TurnstileToken,
+  body: CreateReply & TurnstileToken,
   opts?: Oazapfts.RequestOpts,
 ) {
   return oazapfts.fetchJson<
@@ -3301,6 +5310,10 @@ export function createTimelineReply(
         data: {
           id: number;
         };
+      }
+    | {
+        status: 429;
+        data: ErrorResponse;
       }
     | {
         status: 500;
@@ -3829,6 +5842,351 @@ export function getUserTimeline(
     },
   );
 }
+/**
+ * 创建角色
+ */
+export function postCharacterInfo(
+  body: {
+    /** when header x-admin-token is provided, use this as author id. */
+    authorID?: number;
+    character: {
+      /** base64 encoded raw bytes, 4mb size limit on **decoded** size */
+      img?: string;
+      infobox: string;
+      name: string;
+      summary: string;
+      type: CharacterType;
+    };
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          characterID: number;
+        };
+      }
+    | {
+        status: 400;
+        data: ErrorResponse;
+      }
+    | {
+        status: 401;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    '/p1/wiki/characters',
+    oazapfts.json({
+      ...opts,
+      method: 'POST',
+      body,
+    }),
+  );
+}
+/**
+ * 获取角色-人物关联历史版本 wiki 信息
+ */
+export function getCharacterCastRevisionInfo(revisionId: number, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: CharacterCastRevisionWikiInfo;
+      }
+    | {
+        status: 404;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(`/p1/wiki/characters/-/casts/revisions/${encodeURIComponent(revisionId)}`, {
+    ...opts,
+  });
+}
+/**
+ * 获取角色历史版本 wiki 信息
+ */
+export function getCharacterRevisionInfo(revisionId: number, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: CharacterRevisionWikiInfo;
+      }
+    | {
+        status: 404;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(`/p1/wiki/characters/-/revisions/${encodeURIComponent(revisionId)}`, {
+    ...opts,
+  });
+}
+/**
+ * 获取角色-条目关联历史版本 wiki 信息
+ */
+export function getCharacterSubjectRevisionInfo(revisionId: number, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: CharacterSubjectRevisionWikiInfo;
+      }
+    | {
+        status: 404;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(`/p1/wiki/characters/-/subjects/revisions/${encodeURIComponent(revisionId)}`, {
+    ...opts,
+  });
+}
+/**
+ * 获取角色当前的 wiki 信息
+ */
+export function getCharacterWikiInfo(characterId: number, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: CharacterWikiInfo;
+      }
+    | {
+        status: 401;
+        data: ErrorResponse;
+      }
+    | {
+        status: 404;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(`/p1/wiki/characters/${encodeURIComponent(characterId)}`, {
+    ...opts,
+  });
+}
+/**
+ * 编辑角色
+ */
+export function patchCharacterInfo(
+  characterId: number,
+  body: {
+    /** when header x-admin-token is provided, use this as author id. */
+    authorID?: number;
+    character: {
+      infobox?: string;
+      name?: string;
+      summary?: string;
+    };
+    commitMessage: string;
+    expectedRevision: {
+      infobox?: string;
+      name?: string;
+      summary?: string;
+    };
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {};
+      }
+    | {
+        status: 400;
+        data: ErrorResponse;
+      }
+    | {
+        status: 401;
+        data: ErrorResponse;
+      }
+    | {
+        status: 403;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/wiki/characters/${encodeURIComponent(characterId)}`,
+    oazapfts.json({
+      ...opts,
+      method: 'PATCH',
+      body,
+    }),
+  );
+}
+/**
+ * 获取角色-人物关联 wiki 历史编辑摘要
+ */
+export function characterCastHistorySummary(
+  characterId: number,
+  {
+    limit,
+    offset,
+  }: {
+    limit?: number;
+    offset?: number;
+  } = {},
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          data: RevisionHistory[];
+          /** limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+          total: number;
+        };
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/wiki/characters/${encodeURIComponent(characterId)}/casts/history-summary${QS.query(
+      QS.explode({
+        limit,
+        offset,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
+  );
+}
+/**
+ * 获取角色 wiki 历史编辑摘要
+ */
+export function characterEditHistorySummary(
+  characterId: number,
+  {
+    limit,
+    offset,
+  }: {
+    limit?: number;
+    offset?: number;
+  } = {},
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          data: RevisionHistory[];
+          /** limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+          total: number;
+        };
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/wiki/characters/${encodeURIComponent(characterId)}/history-summary${QS.query(
+      QS.explode({
+        limit,
+        offset,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
+  );
+}
+/**
+ * 上传角色肖像
+ */
+export function uploadCharacterPortrait(
+  characterId: number,
+  body: {
+    /** when header x-admin-token is provided, use this as author id. */
+    authorID?: number;
+    /** base64 encoded raw bytes, 4mb size limit on **decoded** size */
+    img: string;
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          /** image filename */
+          img: string;
+        };
+      }
+    | {
+        status: 400;
+        data: ErrorResponse;
+      }
+    | {
+        status: 403;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/wiki/characters/${encodeURIComponent(characterId)}/portraits`,
+    oazapfts.json({
+      ...opts,
+      method: 'POST',
+      body,
+    }),
+  );
+}
+/**
+ * 获取角色-条目关联 wiki 历史编辑摘要
+ */
+export function characterSubjectHistorySummary(
+  characterId: number,
+  {
+    limit,
+    offset,
+  }: {
+    limit?: number;
+    offset?: number;
+  } = {},
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          data: RevisionHistory[];
+          /** limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+          total: number;
+        };
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/wiki/characters/${encodeURIComponent(characterId)}/subjects/history-summary${QS.query(
+      QS.explode({
+        limit,
+        offset,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
+  );
+}
 export function getEpisodeWikiInfo(episodeId: number, opts?: Oazapfts.RequestOpts) {
   return oazapfts.fetchJson<
     | {
@@ -3850,6 +6208,8 @@ export function getEpisodeWikiInfo(episodeId: number, opts?: Oazapfts.RequestOpt
 export function patchEpisodeWikiInfo(
   episodeId: number,
   body: {
+    /** when header x-admin-token is provided, use this as author id. */
+    authorID?: number;
     commitMessage: string;
     episode: {
       /** YYYY-MM-DD */
@@ -3863,8 +6223,6 @@ export function patchEpisodeWikiInfo(
       summary?: string;
       type?: EpisodeType;
     };
-    /** a optional object to check if input is changed by others
-    if some key is given, and current data in database doesn't match input, subject will not be changed */
     expectedRevision?: {
       date?: string;
       duration?: string;
@@ -3927,7 +6285,125 @@ export function lockSubject(
   );
 }
 /**
- * 获取当前的 wiki 信息
+ * 创建人物
+ */
+export function postPersonInfo(
+  body: {
+    /** when header x-admin-token is provided, use this as author id. */
+    authorID?: number;
+    person: {
+      /** base64 encoded raw bytes, 4mb size limit on **decoded** size */
+      img?: string;
+      infobox: string;
+      name: string;
+      profession?: {
+        actor?: boolean;
+        artist?: boolean;
+        illustrator?: boolean;
+        mangaka?: boolean;
+        producer?: boolean;
+        seiyu?: boolean;
+        writer?: boolean;
+      };
+      summary: string;
+      type: PersonType;
+    };
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          personID: number;
+        };
+      }
+    | {
+        status: 400;
+        data: ErrorResponse;
+      }
+    | {
+        status: 401;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    '/p1/wiki/persons',
+    oazapfts.json({
+      ...opts,
+      method: 'POST',
+      body,
+    }),
+  );
+}
+/**
+ * 获取人物-角色关联历史版本 wiki 信息
+ */
+export function getPersonCastRevisionInfo(revisionId: number, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: PersonCastRevisionWikiInfo;
+      }
+    | {
+        status: 404;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(`/p1/wiki/persons/-/casts/revisions/${encodeURIComponent(revisionId)}`, {
+    ...opts,
+  });
+}
+/**
+ * 获取人物历史版本 wiki 信息
+ */
+export function getPersonRevisionInfo(revisionId: number, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: PersonRevisionWikiInfo;
+      }
+    | {
+        status: 404;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(`/p1/wiki/persons/-/revisions/${encodeURIComponent(revisionId)}`, {
+    ...opts,
+  });
+}
+/**
+ * 获取人物-条目关联历史版本 wiki 信息
+ */
+export function getPersonSubjectRevisionInfo(revisionId: number, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: PersonSubjectRevisionWikiInfo;
+      }
+    | {
+        status: 404;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(`/p1/wiki/persons/-/subjects/revisions/${encodeURIComponent(revisionId)}`, {
+    ...opts,
+  });
+}
+/**
+ * 获取人物当前的 wiki 信息
  */
 export function getPersonWikiInfo(personId: number, opts?: Oazapfts.RequestOpts) {
   return oazapfts.fetchJson<
@@ -3951,9 +6427,14 @@ export function getPersonWikiInfo(personId: number, opts?: Oazapfts.RequestOpts)
     ...opts,
   });
 }
+/**
+ * 编辑人物
+ */
 export function patchPersonInfo(
   personId: number,
   body: {
+    /** when header x-admin-token is provided, use this as author id. */
+    authorID?: number;
     commitMessage: string;
     expectedRevision: {
       infobox?: string;
@@ -3963,6 +6444,15 @@ export function patchPersonInfo(
     person: {
       infobox?: string;
       name?: string;
+      profession?: {
+        actor?: boolean;
+        artist?: boolean;
+        illustrator?: boolean;
+        mangaka?: boolean;
+        producer?: boolean;
+        seiyu?: boolean;
+        writer?: boolean;
+      };
       summary?: string;
     };
   },
@@ -3982,6 +6472,10 @@ export function patchPersonInfo(
         data: ErrorResponse;
       }
     | {
+        status: 403;
+        data: ErrorResponse;
+      }
+    | {
         status: 500;
         data: ErrorResponse;
       }
@@ -3995,9 +6489,240 @@ export function patchPersonInfo(
   );
 }
 /**
+ * 获取人物-角色关联 wiki 历史编辑摘要
+ */
+export function personCastHistorySummary(
+  personId: number,
+  {
+    limit,
+    offset,
+  }: {
+    limit?: number;
+    offset?: number;
+  } = {},
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          data: RevisionHistory[];
+          /** limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+          total: number;
+        };
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/wiki/persons/${encodeURIComponent(personId)}/casts/history-summary${QS.query(
+      QS.explode({
+        limit,
+        offset,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
+  );
+}
+/**
+ * 获取人物 wiki 历史编辑摘要
+ */
+export function personEditHistorySummary(
+  personId: number,
+  {
+    limit,
+    offset,
+  }: {
+    limit?: number;
+    offset?: number;
+  } = {},
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          data: RevisionHistory[];
+          /** limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+          total: number;
+        };
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/wiki/persons/${encodeURIComponent(personId)}/history-summary${QS.query(
+      QS.explode({
+        limit,
+        offset,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
+  );
+}
+/**
+ * 上传人物肖像
+ */
+export function uploadPersonPortrait(
+  personId: number,
+  body: {
+    /** when header x-admin-token is provided, use this as author id. */
+    authorID?: number;
+    /** base64 encoded raw bytes, 4mb size limit on **decoded** size */
+    img: string;
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          /** image filename */
+          img: string;
+        };
+      }
+    | {
+        status: 400;
+        data: ErrorResponse;
+      }
+    | {
+        status: 403;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/wiki/persons/${encodeURIComponent(personId)}/portraits`,
+    oazapfts.json({
+      ...opts,
+      method: 'POST',
+      body,
+    }),
+  );
+}
+/**
+ * 获取人物-条目关联 wiki 历史编辑摘要
+ */
+export function personSubjectHistorySummary(
+  personId: number,
+  {
+    limit,
+    offset,
+  }: {
+    limit?: number;
+    offset?: number;
+  } = {},
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          data: RevisionHistory[];
+          /** limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+          total: number;
+        };
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/wiki/persons/${encodeURIComponent(personId)}/subjects/history-summary${QS.query(
+      QS.explode({
+        limit,
+        offset,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
+  );
+}
+/**
+ * 获取最近两天的角色wiki更新
+ */
+export function getRecentCharacterWiki(since: number, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          createdAt: number;
+          id: number;
+        }[];
+      }
+    | {
+        status: 401;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >('/p1/wiki/recent/characters', {
+    ...opts,
+  });
+}
+/**
+ * 获取最近两天的章节wiki更新
+ */
+export function getRecentEpisodeWiki(since: number, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          createdAt: number;
+          id: number;
+        }[];
+      }
+    | {
+        status: 401;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >('/p1/wiki/recent/episodes', {
+    ...opts,
+  });
+}
+/**
+ * 获取最近两天的人物wiki更新
+ */
+export function getRecentPersonWiki(since: number, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          createdAt: number;
+          id: number;
+        }[];
+      }
+    | {
+        status: 401;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >('/p1/wiki/recent/persons', {
+    ...opts,
+  });
+}
+/**
  * 获取最近两天的wiki更新
  */
-export function getRecentWiki(since: number, opts?: Oazapfts.RequestOpts) {
+export function getRecentSubjectWiki(since: number, opts?: Oazapfts.RequestOpts) {
   return oazapfts.fetchJson<
     | {
         status: 200;
@@ -4011,7 +6736,7 @@ export function getRecentWiki(since: number, opts?: Oazapfts.RequestOpts) {
         status: 500;
         data: ErrorResponse;
       }
-  >('/p1/wiki/recent', {
+  >('/p1/wiki/recent/subjects', {
     ...opts,
   });
 }
@@ -4020,11 +6745,13 @@ export function getRecentWiki(since: number, opts?: Oazapfts.RequestOpts) {
  */
 export function createNewSubject(
   body: {
+    date?: string;
     infobox: string;
     metaTags: string[];
     name: string;
     nsfw: boolean;
     platform: number;
+    series?: boolean;
     summary: string;
     type: SubjectType;
   },
@@ -4059,7 +6786,91 @@ export function createNewSubject(
   );
 }
 /**
- * 获取当前的 wiki 信息
+ * 获取条目-角色关联历史版本 wiki 信息
+ */
+export function getSubjectCharacterRevisionInfo(revisionId: number, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: SubjectCharacterRevisionWikiInfo;
+      }
+    | {
+        status: 404;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(`/p1/wiki/subjects/-/characters/revisions/${encodeURIComponent(revisionId)}`, {
+    ...opts,
+  });
+}
+/**
+ * 获取条目-人物关联历史版本 wiki 信息
+ */
+export function getSubjectPersonRevisionInfo(revisionId: number, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: SubjectPersonRevisionWikiInfo;
+      }
+    | {
+        status: 404;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(`/p1/wiki/subjects/-/persons/revisions/${encodeURIComponent(revisionId)}`, {
+    ...opts,
+  });
+}
+/**
+ * 获取条目关联历史版本 wiki 信息
+ */
+export function getSubjectRelationRevisionInfo(revisionId: number, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: SubjectRelationRevisionWikiInfo;
+      }
+    | {
+        status: 404;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(`/p1/wiki/subjects/-/relations/revisions/${encodeURIComponent(revisionId)}`, {
+    ...opts,
+  });
+}
+/**
+ * 获取条目历史版本 wiki 信息
+ */
+export function getSubjectRevisionInfo(revisionId: number, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: SubjectRevisionWikiInfo;
+      }
+    | {
+        status: 404;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(`/p1/wiki/subjects/-/revisions/${encodeURIComponent(revisionId)}`, {
+    ...opts,
+  });
+}
+/**
+ * 获取条目当前的 wiki 信息
  */
 export function subjectInfo(subjectId: number, opts?: Oazapfts.RequestOpts) {
   return oazapfts.fetchJson<
@@ -4069,6 +6880,10 @@ export function subjectInfo(subjectId: number, opts?: Oazapfts.RequestOpts) {
       }
     | {
         status: 401;
+        data: ErrorResponse;
+      }
+    | {
+        status: 404;
         data: ErrorResponse;
       }
     | {
@@ -4082,14 +6897,15 @@ export function subjectInfo(subjectId: number, opts?: Oazapfts.RequestOpts) {
 export function patchSubjectInfo(
   subjectId: number,
   body: {
+    /** when header x-admin-token is provided, use this as author id. */
+    authorID?: number;
     commitMessage: string;
-    /** a optional object to check if input is changed by others
-    if `infobox` is given, and current data in database doesn't match input, subject will not be changed */
     expectedRevision?: {
-      infobox?: string;
-      metaTags?: string[];
-      name?: string;
-      platform?: number;
+      infobox?: null | string;
+      metaTags?: null | string[];
+      name?: null | string;
+      platform?: null | number;
+      summary?: null | string;
     };
     subject: {
       date?: string;
@@ -4098,6 +6914,7 @@ export function patchSubjectInfo(
       name?: string;
       nsfw?: boolean;
       platform?: number;
+      series?: boolean;
       summary?: string;
     };
   },
@@ -4131,13 +6948,12 @@ export function putSubjectInfo(
   subjectId: number,
   body: {
     commitMessage: string;
-    /** a optional object to check if input is changed by others
-    if `infobox` is given, and current data in database doesn't match input, subject will not be changed */
     expectedRevision?: {
-      infobox?: string;
-      metaTags?: string[];
-      name?: string;
-      platform?: number;
+      infobox?: null | string;
+      metaTags?: null | string[];
+      name?: null | string;
+      platform?: null | number;
+      summary?: null | string;
     };
     subject: SubjectEdit;
   },
@@ -4162,6 +6978,45 @@ export function putSubjectInfo(
       method: 'PUT',
       body,
     }),
+  );
+}
+/**
+ * 获取条目-角色关联 wiki 历史编辑摘要
+ */
+export function subjectCharacterHistorySummary(
+  subjectId: number,
+  {
+    limit,
+    offset,
+  }: {
+    limit?: number;
+    offset?: number;
+  } = {},
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          data: RevisionHistory[];
+          /** limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+          total: number;
+        };
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/wiki/subjects/${encodeURIComponent(subjectId)}/characters/history-summary${QS.query(
+      QS.explode({
+        limit,
+        offset,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
   );
 }
 export function listSubjectCovers(subjectId: number, opts?: Oazapfts.RequestOpts) {
@@ -4220,7 +7075,7 @@ export function uploadSubjectCover(
         data: ErrorResponse;
       }
     | {
-        status: 401;
+        status: 403;
         data: ErrorResponse;
       }
     | {
@@ -4377,13 +7232,27 @@ export function createEpisodes(
   );
 }
 /**
- * 获取当前的 wiki 信息
+ * 获取条目 wiki 历史编辑摘要
  */
-export function subjectEditHistorySummary(subjectId: number, opts?: Oazapfts.RequestOpts) {
+export function subjectEditHistorySummary(
+  subjectId: number,
+  {
+    limit,
+    offset,
+  }: {
+    limit?: number;
+    offset?: number;
+  } = {},
+  opts?: Oazapfts.RequestOpts,
+) {
   return oazapfts.fetchJson<
     | {
         status: 200;
-        data: HistorySummary[];
+        data: {
+          data: RevisionHistory[];
+          /** limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+          total: number;
+        };
       }
     | {
         status: 401;
@@ -4393,9 +7262,95 @@ export function subjectEditHistorySummary(subjectId: number, opts?: Oazapfts.Req
         status: 500;
         data: ErrorResponse;
       }
-  >(`/p1/wiki/subjects/${encodeURIComponent(subjectId)}/history-summary`, {
-    ...opts,
-  });
+  >(
+    `/p1/wiki/subjects/${encodeURIComponent(subjectId)}/history-summary${QS.query(
+      QS.explode({
+        limit,
+        offset,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
+  );
+}
+/**
+ * 获取条目-人物关联 wiki 历史编辑摘要
+ */
+export function subjectPersonHistorySummary(
+  subjectId: number,
+  {
+    limit,
+    offset,
+  }: {
+    limit?: number;
+    offset?: number;
+  } = {},
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          data: RevisionHistory[];
+          /** limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+          total: number;
+        };
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/wiki/subjects/${encodeURIComponent(subjectId)}/persons/history-summary${QS.query(
+      QS.explode({
+        limit,
+        offset,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
+  );
+}
+/**
+ * 获取条目关联 wiki 历史编辑摘要
+ */
+export function subjectRelationHistorySummary(
+  subjectId: number,
+  {
+    limit,
+    offset,
+  }: {
+    limit?: number;
+    offset?: number;
+  } = {},
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          data: RevisionHistory[];
+          /** limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+          total: number;
+        };
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/wiki/subjects/${encodeURIComponent(subjectId)}/relations/history-summary${QS.query(
+      QS.explode({
+        limit,
+        offset,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
+  );
 }
 export function unlockSubject(
   body: {
@@ -4422,6 +7377,135 @@ export function unlockSubject(
     }),
   );
 }
+/**
+ * 获取用户 wiki 角色编辑记录
+ */
+export function getUserContributedCharacters(
+  username: string,
+  {
+    limit,
+    offset,
+  }: {
+    limit?: number;
+    offset?: number;
+  } = {},
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          data: UserCharacterContribution[];
+          /** limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+          total: number;
+        };
+      }
+    | {
+        status: 404;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/wiki/users/${encodeURIComponent(username)}/contributions/characters${QS.query(
+      QS.explode({
+        limit,
+        offset,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
+  );
+}
+/**
+ * 获取用户 wiki 人物编辑记录
+ */
+export function getUserContributedPersons(
+  username: string,
+  {
+    limit,
+    offset,
+  }: {
+    limit?: number;
+    offset?: number;
+  } = {},
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          data: UserPersonContribution[];
+          /** limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+          total: number;
+        };
+      }
+    | {
+        status: 404;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/wiki/users/${encodeURIComponent(username)}/contributions/persons${QS.query(
+      QS.explode({
+        limit,
+        offset,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
+  );
+}
+/**
+ * 获取用户 wiki 条目编辑记录
+ */
+export function getUserContributedSubjects(
+  username: string,
+  {
+    limit,
+    offset,
+  }: {
+    limit?: number;
+    offset?: number;
+  } = {},
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          data: UserSubjectContribution[];
+          /** limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+          total: number;
+        };
+      }
+    | {
+        status: 404;
+        data: ErrorResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/wiki/users/${encodeURIComponent(username)}/contributions/subjects${QS.query(
+      QS.explode({
+        limit,
+        offset,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
+  );
+}
 export enum CollectionType {
   Wish = 1,
   Collect = 2,
@@ -4436,11 +7520,36 @@ export enum SubjectType {
   Game = 4,
   Real = 6,
 }
+export enum CharacterType {
+  Crt = 1,
+  Mecha = 2,
+  Vessel = 3,
+  Org = 4,
+}
+export enum CharacterCastType {
+  Cv = 0,
+  Actor = 2,
+  Dub = 1,
+  ChineseDub = 3,
+  JapaneseDub = 4,
+  EnglishDub = 5,
+  KoreanDub = 6,
+}
+export enum IndexType {
+  User = 0,
+  Public = 1,
+  Award = 2,
+}
 export enum EpisodeCollectionStatus {
   None = 0,
   Wish = 1,
   Done = 2,
   Dropped = 3,
+}
+export enum PersonType {
+  Individual = 1,
+  Company = 2,
+  Group = 3,
 }
 export enum EpisodeType {
   Normal = 0,
@@ -4458,6 +7567,11 @@ export enum GroupSort {
   Created = 'created',
   Updated = 'updated',
 }
+export enum GroupFilterMode {
+  All = 'all',
+  Joined = 'joined',
+  Managed = 'managed',
+}
 export enum GroupTopicFilterMode {
   All = 'all',
   Joined = 'joined',
@@ -4472,6 +7586,79 @@ export enum GroupMemberRole {
   Moderator = 2,
   Blocked = 3,
 }
+export enum IndexRelatedCategory {
+  Subject = 0,
+  Character = 1,
+  Person = 2,
+  Episode = 3,
+  Blog = 4,
+  GroupTopic = 5,
+  SubjectTopic = 6,
+}
+export enum Type {
+  PublicKey = 'public-key',
+}
+export enum CommentNotification {
+  All = 'all',
+  Friends = 'friends',
+  None = 'none',
+}
+export enum Follow {
+  All = 'all',
+  None = 'none',
+}
+export enum FriendNotification {
+  All = 'all',
+  None = 'none',
+}
+export enum MentionNotification {
+  All = 'all',
+  Friends = 'friends',
+  None = 'none',
+}
+export enum PrivateMessage {
+  All = 'all',
+  Friends = 'friends',
+  None = 'none',
+}
+export enum TimelineCollectReply {
+  All = 'all',
+  Friends = 'friends',
+  None = 'none',
+}
+export enum TimelineReply {
+  All = 'all',
+  Friends = 'friends',
+  None = 'none',
+}
+export enum ReportType {
+  User = 6,
+  GroupTopic = 7,
+  GroupReply = 8,
+  SubjectTopic = 9,
+  SubjectReply = 10,
+  EpisodeReply = 11,
+  CharacterReply = 12,
+  PersonReply = 13,
+  Blog = 14,
+  BlogReply = 15,
+  Timeline = 16,
+  TimelineReply = 17,
+  Index = 18,
+  IndexReply = 19,
+}
+export enum ReportReason {
+  Abuse = 1,
+  Spam = 2,
+  Political = 3,
+  Illegal = 4,
+  Privacy = 5,
+  CheatScore = 6,
+  Flame = 7,
+  Advertisement = 8,
+  Spoiler = 9,
+  Other = 99,
+}
 export enum SubjectSearchSort {
   Match = 'match',
   Heat = 'heat',
@@ -4485,7 +7672,7 @@ export enum SubjectBrowseSort {
   Date = 'date',
   Title = 'title',
 }
-export enum TimelineFilterMode {
+export enum FilterMode {
   All = 'all',
   Friends = 'friends',
 }
@@ -4500,14 +7687,6 @@ export enum TimelineCat {
   Mono = 8,
   Doujin = 9,
 }
-export enum TimelineSource {
-  Web = 0,
-  Mobile = 1,
-  OnAir = 2,
-  InTouch = 3,
-  Wp = 4,
-  Api = 5,
-}
 export enum UserHomepageSection {
   Anime = 'anime',
   Game = 'game',
@@ -4519,4 +7698,31 @@ export enum UserHomepageSection {
   Friend = 'friend',
   Group = 'group',
   Index = 'index',
+}
+export enum RevisionType {
+  SubjectEdit = 1,
+  SubjectLock = 103,
+  SubjectUnlock = 104,
+  SubjectMerge = 11,
+  SubjectErase = 12,
+  SubjectRelation = 17,
+  SubjectCharacterRelation = 5,
+  SubjectCastRelation = 6,
+  SubjectPersonRelation = 10,
+  CharacterEdit = 2,
+  CharacterMerge = 13,
+  CharacterErase = 14,
+  CharacterSubjectRelation = 4,
+  CharacterCastRelation = 7,
+  PersonEdit = 3,
+  PersonMerge = 15,
+  PersonErase = 16,
+  PersonCastRelation = 8,
+  PersonSubjectRelation = 9,
+  EpisodeEdit = 18,
+  EpisodeMerge = 181,
+  EpisodeMove = 182,
+  EpisodeLock = 183,
+  EpisodeUnlock = 184,
+  EpisodeErase = 185,
 }

--- a/packages/client/types/index.ts
+++ b/packages/client/types/index.ts
@@ -6,18 +6,17 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** 获取绝交用户列表 */
+    /** 获取当前用户的绝交用户列表 */
     get: operations['getBlocklist'];
     put?: never;
-    /** 将用户添加到绝交列表 */
-    post: operations['addToBlocklist'];
+    post?: never;
     delete?: never;
     options?: never;
     head?: never;
     patch?: never;
     trace?: never;
   };
-  '/p1/blocklist/{id}': {
+  '/p1/blocklist/{username}': {
     parameters: {
       query?: never;
       header?: never;
@@ -25,10 +24,11 @@ export interface paths {
       cookie?: never;
     };
     get?: never;
-    put?: never;
+    /** 与用户绝交 */
+    put: operations['addUserToBlocklist'];
     post?: never;
-    /** 将用户从绝交列表移出 */
-    delete: operations['removeFromBlocklist'];
+    /** 取消与用户绝交 */
+    delete: operations['removeUserFromBlocklist'];
     options?: never;
     head?: never;
     patch?: never;
@@ -225,6 +225,109 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/p1/characters/{characterID}/indexes': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取角色关联的目录 */
+    get: operations['getCharacterIndexes'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/characters/{characterID}/photos': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取角色相册列表 */
+    get: operations['getCharacterPhotos'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/characters/{characterID}/photos/preview': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取角色首页相册预览 */
+    get: operations['getCharacterPhotoPreview'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/characters/{characterID}/photos/{photoID}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取角色相册图片 */
+    get: operations['getCharacterPhoto'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/characters/{characterID}/photos/{photoID}/comments': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取角色相册图片的评论 */
+    get: operations['getCharacterPhotoComments'];
+    put?: never;
+    /** 创建角色相册图片的评论 */
+    post: operations['createCharacterPhotoComment'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/characters/{characterID}/relations': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取角色关联角色 */
+    get: operations['getCharacterRelations'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/p1/clear-notify': {
     parameters: {
       query?: never;
@@ -264,6 +367,24 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/p1/collections/characters/{characterID}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    /** 新增角色收藏 */
+    put: operations['addCharacterCollection'];
+    post?: never;
+    /** 删除角色收藏 */
+    delete: operations['deleteCharacterCollection'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/p1/collections/episodes/{episodeID}': {
     parameters: {
       query?: never;
@@ -298,6 +419,24 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/p1/collections/indexes/{indexID}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    /** 新增目录收藏 */
+    put: operations['addIndexCollection'];
+    post?: never;
+    /** 删除目录收藏 */
+    delete: operations['deleteIndexCollection'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/p1/collections/persons': {
     parameters: {
       query?: never;
@@ -310,6 +449,24 @@ export interface paths {
     put?: never;
     post?: never;
     delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/collections/persons/{personID}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    /** 新增人物收藏 */
+    put: operations['addPersonCollection'];
+    post?: never;
+    /** 删除人物收藏 */
+    delete: operations['deletePersonCollection'];
     options?: never;
     head?: never;
     patch?: never;
@@ -378,11 +535,29 @@ export interface paths {
       cookie?: never;
     };
     get?: never;
-    /** 编辑条目的剧集吐槽 */
+    /** 编辑条目的章节吐槽 */
     put: operations['updateEpisodeComment'];
     post?: never;
-    /** 删除条目的剧集吐槽 */
+    /** 删除条目的章节吐槽 */
     delete: operations['deleteEpisodeComment'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/episodes/-/comments/{commentID}/like': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    /** 给条目的章节吐槽点赞 */
+    put: operations['likeEpisodeComment'];
+    post?: never;
+    /** 取消条目的章节吐槽点赞 */
+    delete: operations['unlikeEpisodeComment'];
     options?: never;
     head?: never;
     patch?: never;
@@ -395,7 +570,7 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** 获取剧集信息 */
+    /** 获取章节信息 */
     get: operations['getEpisode'];
     put?: never;
     post?: never;
@@ -412,10 +587,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** 获取条目的剧集吐槽箱 */
+    /** 获取条目的章节吐槽箱 */
     get: operations['getEpisodeComments'];
     put?: never;
-    /** 创建条目的剧集吐槽 */
+    /** 创建条目的章节吐槽 */
     post: operations['createEpisodeComment'];
     delete?: never;
     options?: never;
@@ -440,6 +615,23 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/p1/friendlist': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取当前用户的好友 ID 列表 */
+    get: operations['getFriendlist'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/p1/friends': {
     parameters: {
       query?: never;
@@ -452,6 +644,24 @@ export interface paths {
     put?: never;
     post?: never;
     delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/friends/{username}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    /** 添加好友 */
+    put: operations['addFriend'];
+    post?: never;
+    /** 取消好友 */
+    delete: operations['removeFriend'];
     options?: never;
     head?: never;
     patch?: never;
@@ -488,6 +698,24 @@ export interface paths {
     post?: never;
     /** 删除小组话题回复 */
     delete: operations['deleteGroupPost'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/groups/-/posts/{postID}/like': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    /** 给小组话题回复点赞 */
+    put: operations['likeGroupPost'];
+    post?: never;
+    /** 取消小组话题回复点赞 */
+    delete: operations['unlikeGroupPost'];
     options?: never;
     head?: never;
     patch?: never;
@@ -597,6 +825,114 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/p1/indexes': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** 创建目录 */
+    post: operations['createIndex'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/indexes/-/comments/{commentID}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    /** 编辑目录的评论 */
+    put: operations['updateIndexComment'];
+    post?: never;
+    /** 删除目录的评论 */
+    delete: operations['deleteIndexComment'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/indexes/{indexID}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取目录详情 */
+    get: operations['getIndex'];
+    put?: never;
+    post?: never;
+    /** 删除目录 */
+    delete: operations['deleteIndex'];
+    options?: never;
+    head?: never;
+    /** 更新目录 */
+    patch: operations['updateIndex'];
+    trace?: never;
+  };
+  '/p1/indexes/{indexID}/comments': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取目录的评论 */
+    get: operations['getIndexComments'];
+    put?: never;
+    /** 创建目录的评论 */
+    post: operations['createIndexComment'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/indexes/{indexID}/related': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取目录的关联内容 */
+    get: operations['getIndexRelated'];
+    /** 添加目录关联内容 */
+    put: operations['putIndexRelated'];
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/indexes/{indexID}/related/{id}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    /** 删除目录关联内容 */
+    delete: operations['deleteIndexRelated'];
+    options?: never;
+    head?: never;
+    /** 更新目录关联内容 */
+    patch: operations['patchIndexRelated'];
+    trace?: never;
+  };
   '/p1/login': {
     parameters: {
       query?: never;
@@ -606,11 +942,13 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** @description 需要 [turnstile](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/)
+    /**
+     * @description 需要 [turnstile](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/)
      *
      *     next.bgm.tv 域名对应的 site-key 为 `0x4AAAAAAABkMYinukE8nzYS`
      *
-     *     dev.bgm38.tv 域名使用测试用的 site-key `1x00000000000000000000AA` */
+     *     dev.bgm38.tv 域名使用测试用的 site-key `1x00000000000000000000AA`
+     */
     post: operations['login'];
     delete?: never;
     options?: never;
@@ -663,6 +1001,44 @@ export interface paths {
     get: operations['listNotice'];
     put?: never;
     post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/passkey/login/options': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * 获取 Passkey 登录选项
+     * @description 获取 WebAuthn authentication options。
+     *     不传 credentials 时（usernameless 模式），浏览器将展示系统账户选择器。
+     */
+    post: operations['passkeyLoginOptions'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/passkey/login/verify': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** 验证 Passkey 登录并签发 session */
+    post: operations['passkeyLoginVerify'];
     delete?: never;
     options?: never;
     head?: never;
@@ -756,6 +1132,109 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/p1/persons/{personID}/indexes': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取人物关联的目录 */
+    get: operations['getPersonIndexes'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/persons/{personID}/photos': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取人物相册列表 */
+    get: operations['getPersonPhotos'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/persons/{personID}/photos/preview': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取人物首页相册预览 */
+    get: operations['getPersonPhotoPreview'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/persons/{personID}/photos/{photoID}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取人物相册图片 */
+    get: operations['getPersonPhoto'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/persons/{personID}/photos/{photoID}/comments': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取人物相册图片的评论 */
+    get: operations['getPersonPhotoComments'];
+    put?: never;
+    /** 创建人物相册图片的评论 */
+    post: operations['createPersonPhotoComment'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/persons/{personID}/relations': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取人物关联人物 */
+    get: operations['getPersonRelations'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/p1/persons/{personID}/works': {
     parameters: {
       query?: never;
@@ -767,6 +1246,41 @@ export interface paths {
     get: operations['getPersonWorks'];
     put?: never;
     post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/privacy': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get current user privacy settings */
+    get: operations['getPrivacy'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    /** Update current user privacy settings */
+    patch: operations['patchPrivacy'];
+    trace?: never;
+  };
+  '/p1/report': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** 报告疑虑 */
+    post: operations['createReport'];
     delete?: never;
     options?: never;
     head?: never;
@@ -841,6 +1355,24 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/p1/subjects/-/collects/{collectID}/like': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    /** 给条目收藏点赞 */
+    put: operations['likeSubjectCollect'];
+    post?: never;
+    /** 取消条目收藏点赞 */
+    delete: operations['unlikeSubjectCollect'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/p1/subjects/-/posts/{postID}': {
     parameters: {
       query?: never;
@@ -855,6 +1387,41 @@ export interface paths {
     post?: never;
     /** 删除条目讨论回复 */
     delete: operations['deleteSubjectPost'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/subjects/-/posts/{postID}/like': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    /** 给条目讨论回复点赞 */
+    put: operations['likeSubjectPost'];
+    post?: never;
+    /** 取消条目讨论回复点赞 */
+    delete: operations['unlikeSubjectPost'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/subjects/-/topics': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取最新的条目讨论 */
+    get: operations['getRecentSubjectTopics'];
+    put?: never;
+    post?: never;
+    delete?: never;
     options?: never;
     head?: never;
     patch?: never;
@@ -929,6 +1496,23 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/p1/subjects/{subjectID}/collects': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取条目的收藏用户 */
+    get: operations['getSubjectCollects'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/p1/subjects/{subjectID}/comments': {
     parameters: {
       query?: never;
@@ -953,8 +1537,25 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** 获取条目的剧集 */
+    /** 获取条目的章节 */
     get: operations['getSubjectEpisodes'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/subjects/{subjectID}/indexes': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取条目关联的目录 */
+    get: operations['getSubjectIndexes'];
     put?: never;
     post?: never;
     delete?: never;
@@ -1084,6 +1685,26 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/p1/timeline/-/events': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * 时间线事件流 (SSE)
+     * @description 这是一个 SSE (Server-Sent Events) 流，不是普通的 JSON 响应。客户端需要使用 EventSource 或类似的 SSE 客户端来订阅此接口。每个事件以 `data: {...}\n\n` 格式发送。
+     */
+    get: operations['getTimelineEvents'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/p1/timeline/{timelineID}': {
     parameters: {
       query?: never;
@@ -1096,6 +1717,24 @@ export interface paths {
     post?: never;
     /** 删除时间线 */
     delete: operations['deleteTimeline'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/timeline/{timelineID}/like': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    /** 给时间线吐槽点赞 */
+    put: operations['likeTimeline'];
+    post?: never;
+    /** 取消时间线吐槽点赞 */
+    delete: operations['unlikeTimeline'];
     options?: never;
     head?: never;
     patch?: never;
@@ -1360,6 +1999,160 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/p1/wiki/characters': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** 创建角色 */
+    post: operations['postCharacterInfo'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/wiki/characters/-/casts/revisions/{revisionID}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取角色-人物关联历史版本 wiki 信息 */
+    get: operations['getCharacterCastRevisionInfo'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/wiki/characters/-/revisions/{revisionID}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取角色历史版本 wiki 信息 */
+    get: operations['getCharacterRevisionInfo'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/wiki/characters/-/subjects/revisions/{revisionID}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取角色-条目关联历史版本 wiki 信息 */
+    get: operations['getCharacterSubjectRevisionInfo'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/wiki/characters/{characterID}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取角色当前的 wiki 信息 */
+    get: operations['getCharacterWikiInfo'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    /** 编辑角色 */
+    patch: operations['patchCharacterInfo'];
+    trace?: never;
+  };
+  '/p1/wiki/characters/{characterID}/casts/history-summary': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取角色-人物关联 wiki 历史编辑摘要 */
+    get: operations['characterCastHistorySummary'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/wiki/characters/{characterID}/history-summary': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取角色 wiki 历史编辑摘要 */
+    get: operations['characterEditHistorySummary'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/wiki/characters/{characterID}/portraits': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** 上传角色肖像 */
+    post: operations['uploadCharacterPortrait'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/wiki/characters/{characterID}/subjects/history-summary': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取角色-条目关联 wiki 历史编辑摘要 */
+    get: operations['characterSubjectHistorySummary'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/p1/wiki/ep/{episodeID}': {
     parameters: {
       query?: never;
@@ -1392,6 +2185,74 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/p1/wiki/persons': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** 创建人物 */
+    post: operations['postPersonInfo'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/wiki/persons/-/casts/revisions/{revisionID}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取人物-角色关联历史版本 wiki 信息 */
+    get: operations['getPersonCastRevisionInfo'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/wiki/persons/-/revisions/{revisionID}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取人物历史版本 wiki 信息 */
+    get: operations['getPersonRevisionInfo'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/wiki/persons/-/subjects/revisions/{revisionID}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取人物-条目关联历史版本 wiki 信息 */
+    get: operations['getPersonSubjectRevisionInfo'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/p1/wiki/persons/{personID}': {
     parameters: {
       query?: never;
@@ -1399,17 +2260,137 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** @description 获取当前的 wiki 信息 */
+    /** 获取人物当前的 wiki 信息 */
     get: operations['getPersonWikiInfo'];
     put?: never;
     post?: never;
     delete?: never;
     options?: never;
     head?: never;
+    /** 编辑人物 */
     patch: operations['patchPersonInfo'];
     trace?: never;
   };
-  '/p1/wiki/recent': {
+  '/p1/wiki/persons/{personID}/casts/history-summary': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取人物-角色关联 wiki 历史编辑摘要 */
+    get: operations['personCastHistorySummary'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/wiki/persons/{personID}/history-summary': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取人物 wiki 历史编辑摘要 */
+    get: operations['personEditHistorySummary'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/wiki/persons/{personID}/portraits': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** 上传人物肖像 */
+    post: operations['uploadPersonPortrait'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/wiki/persons/{personID}/subjects/history-summary': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取人物-条目关联 wiki 历史编辑摘要 */
+    get: operations['personSubjectHistorySummary'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/wiki/recent/characters': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description 获取最近两天的角色wiki更新 */
+    get: operations['getRecentCharacterWiki'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/wiki/recent/episodes': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description 获取最近两天的章节wiki更新 */
+    get: operations['getRecentEpisodeWiki'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/wiki/recent/persons': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description 获取最近两天的人物wiki更新 */
+    get: operations['getRecentPersonWiki'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/wiki/recent/subjects': {
     parameters: {
       query?: never;
       header?: never;
@@ -1417,7 +2398,7 @@ export interface paths {
       cookie?: never;
     };
     /** @description 获取最近两天的wiki更新 */
-    get: operations['getRecentWiki'];
+    get: operations['getRecentSubjectWiki'];
     put?: never;
     post?: never;
     delete?: never;
@@ -1435,8 +2416,76 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** @description 创建新条目 */
+    /** 创建新条目 */
     post: operations['createNewSubject'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/wiki/subjects/-/characters/revisions/{revisionID}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取条目-角色关联历史版本 wiki 信息 */
+    get: operations['getSubjectCharacterRevisionInfo'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/wiki/subjects/-/persons/revisions/{revisionID}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取条目-人物关联历史版本 wiki 信息 */
+    get: operations['getSubjectPersonRevisionInfo'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/wiki/subjects/-/relations/revisions/{revisionID}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取条目关联历史版本 wiki 信息 */
+    get: operations['getSubjectRelationRevisionInfo'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/wiki/subjects/-/revisions/{revisionID}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取条目历史版本 wiki 信息 */
+    get: operations['getSubjectRevisionInfo'];
+    put?: never;
+    post?: never;
     delete?: never;
     options?: never;
     head?: never;
@@ -1450,7 +2499,7 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** @description 获取当前的 wiki 信息 */
+    /** 获取条目当前的 wiki 信息 */
     get: operations['subjectInfo'];
     /** @description 需要 `subjectWikiEdit` 权限 */
     put: operations['putSubjectInfo'];
@@ -1459,6 +2508,23 @@ export interface paths {
     options?: never;
     head?: never;
     patch: operations['patchSubjectInfo'];
+    trace?: never;
+  };
+  '/p1/wiki/subjects/{subjectID}/characters/history-summary': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取条目-角色关联 wiki 历史编辑摘要 */
+    get: operations['subjectCharacterHistorySummary'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
     trace?: never;
   };
   '/p1/wiki/subjects/{subjectID}/covers': {
@@ -1533,8 +2599,42 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** @description 获取当前的 wiki 信息 */
+    /** 获取条目 wiki 历史编辑摘要 */
     get: operations['subjectEditHistorySummary'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/wiki/subjects/{subjectID}/persons/history-summary': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取条目-人物关联 wiki 历史编辑摘要 */
+    get: operations['subjectPersonHistorySummary'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/wiki/subjects/{subjectID}/relations/history-summary': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取条目关联 wiki 历史编辑摘要 */
+    get: operations['subjectRelationHistorySummary'];
     put?: never;
     post?: never;
     delete?: never;
@@ -1553,6 +2653,57 @@ export interface paths {
     get?: never;
     put?: never;
     post: operations['unlockSubject'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/wiki/users/{username}/contributions/characters': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取用户 wiki 角色编辑记录 */
+    get: operations['getUserContributedCharacters'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/wiki/users/{username}/contributions/persons': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取用户 wiki 人物编辑记录 */
+    get: operations['getUserContributedPersons'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/p1/wiki/users/{username}/contributions/subjects': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 获取用户 wiki 条目编辑记录 */
+    get: operations['getUserContributedSubjects'];
+    put?: never;
+    post?: never;
     delete?: never;
     options?: never;
     head?: never;
@@ -1583,6 +2734,7 @@ export interface components {
       tags: string[];
       title: string;
       type: number;
+      uid: number;
       updatedAt: number;
       user: components['schemas']['SlimUser'];
       views: number;
@@ -1619,22 +2771,80 @@ export interface components {
       nameCN: string;
       nsfw: boolean;
       redirect: number;
-      role: number;
+      role: components['schemas']['CharacterType'];
+      summary: string;
+    };
+    CharacterCast: {
+      person: components['schemas']['SlimPerson'];
+      relation: components['schemas']['CharacterCastType'];
+      summary: string;
+    };
+    CharacterCastRevisionWikiInfo: {
+      person: {
+        id: number;
+        name: string;
+        nameCN: string;
+      };
+      subject: {
+        id: number;
+        name: string;
+        nameCN: string;
+        typeID: components['schemas']['SubjectType'];
+      };
+    }[];
+    /**
+     * @description Character cast relation type
+     *       - 0 = CV
+     *       - 1 = Dub
+     *       - 2 = Actor
+     *       - 3 = Chinese dub
+     *       - 4 = Japanese dub
+     *       - 5 = English dub
+     *       - 6 = Korean dub
+     * @enum {integer}
+     */
+    CharacterCastType: 0 | 2 | 1 | 3 | 4 | 5 | 6;
+    CharacterCreate: {
+      /**
+       * Format: byte
+       * @description base64 encoded raw bytes, 4mb size limit on **decoded** size
+       */
+      img?: string;
+      infobox: string;
+      name: string;
+      summary: string;
+      type: components['schemas']['CharacterType'];
+    };
+    CharacterEdit: {
+      infobox: string;
+      name: string;
       summary: string;
     };
     CharacterRelation: {
       character: components['schemas']['SlimCharacter'];
-      /** @description 角色关系: 任职于,从属,聘用,嫁给... */
-      relation: number;
+      comment: string;
+      ended: boolean;
+      relation: components['schemas']['PersonRelationType'];
+      spoiler: boolean;
+    };
+    CharacterRevisionWikiInfo: {
+      extra: {
+        img?: string;
+      };
+      infobox: string;
+      name: string;
+      summary: string;
     };
     CharacterSearchFilter: {
-      /** @description 无权限的用户会直接忽略此字段，不会返回 R18 条目。
+      /**
+       * @description 无权限的用户会直接忽略此字段，不会返回 R18 条目。
        *     `null` 或者 `true` 会返回包含 R18 的所有搜索结果。
-       *     `false` 只会返回非 R18 条目。 */
+       *     `false` 只会返回非 R18 条目。
+       */
       nsfw?: boolean;
     };
     CharacterSubject: {
-      actors: components['schemas']['SlimPerson'][];
+      casts: components['schemas']['CharacterCast'][];
       subject: components['schemas']['SlimSubject'];
       type: number;
     };
@@ -1642,11 +2852,44 @@ export interface components {
       subject: components['schemas']['SlimSubject'];
       type: number;
     };
+    CharacterSubjectRevisionWikiInfo: {
+      order: number;
+      subject: {
+        id: number;
+        name: string;
+        nameCN: string;
+        typeID: components['schemas']['SubjectType'];
+      };
+      type: number;
+    }[];
+    /**
+     * @description 角色类型
+     *       - 1 = 角色
+     *       - 2 = 机体
+     *       - 3 = 舰船
+     *       - 4 = 组织机构
+     * @enum {integer}
+     */
+    CharacterType: 1 | 2 | 3 | 4;
+    CharacterWikiInfo: {
+      id: number;
+      infobox: string;
+      locked: boolean;
+      name: string;
+      redirect: number;
+      summary: string;
+    };
     CollectSubject: {
       /** @description 评价 */
       comment?: string;
       /** @description 仅自己可见 */
       private?: boolean;
+      /**
+       * @description 是否自动完成条目进度，仅在 `type` 为 `看过` 时有效，并且不会产生对应的时间线记录：
+       *               - 书籍条目会检查总的话数和卷数，并更新收藏进度到最新;
+       *               - 动画和三次元会标记所有正片章节为已完成，并同时更新收藏进度
+       */
+      progress?: boolean;
       /** @description 评分，0 表示删除评分 */
       rate?: number;
       tags?: string[];
@@ -1670,6 +2913,7 @@ export interface components {
       mainID: number;
       reactions?: components['schemas']['Reaction'][];
       relatedID: number;
+      relatedPhotoID?: number;
       state: number;
       user?: components['schemas']['SlimUser'];
     } & {
@@ -1683,11 +2927,29 @@ export interface components {
       mainID: number;
       reactions?: components['schemas']['Reaction'][];
       relatedID: number;
+      relatedPhotoID?: number;
       state: number;
       user?: components['schemas']['SlimUser'];
     };
     CreateContent: {
       content: string;
+    };
+    /** CreateIndex */
+    CreateIndex: {
+      /** @description 目录描述 */
+      desc: string;
+      /** @description 仅自己可见 */
+      private?: boolean;
+      /** @description 目录标题 */
+      title: string;
+    };
+    /** CreateIndexRelated */
+    CreateIndexRelated: {
+      award?: string;
+      cat: components['schemas']['IndexRelatedCategory'];
+      comment?: string;
+      order?: number;
+      sid: number;
     };
     CreateReply: {
       content: string;
@@ -1697,6 +2959,15 @@ export interface components {
        */
       replyTo: number;
     };
+    /** CreateReport */
+    CreateReport: {
+      /** @description 举报说明（可选） */
+      comment?: string;
+      /** @description 被举报对象的 ID */
+      id: number;
+      type: components['schemas']['ReportType'];
+      value: components['schemas']['ReportReason'];
+    };
     CreateTopic: {
       /** @description bbcode */
       content: string;
@@ -1705,21 +2976,24 @@ export interface components {
     /** Episode */
     Episode: {
       airdate: string;
+      collection?: {
+        status: components['schemas']['EpisodeCollectionStatus'];
+        updatedAt?: number;
+      };
       comment: number;
-      desc?: string;
+      desc: string;
       disc: number;
       duration: string;
       id: number;
       name: string;
       nameCN: string;
       sort: number;
-      status?: components['schemas']['EpisodeCollectionStatus'];
       subject?: components['schemas']['SlimSubject'];
       subjectID: number;
       type: components['schemas']['EpisodeType'];
     };
     /**
-     * @description 剧集收藏状态
+     * @description 章节收藏状态
      *       - 0 = 撤消/删除
      *       - 1 = 想看
      *       - 2 = 看过
@@ -1806,6 +3080,13 @@ export interface components {
       message: string;
       statusCode: number;
     };
+    /**
+     * @description 过滤模式
+     *       - all = 全站
+     *       - friends = 好友
+     * @enum {string}
+     */
+    FilterMode: 'all' | 'friends';
     /** Friend */
     Friend: {
       createdAt: number;
@@ -1824,12 +3105,21 @@ export interface components {
       icon: components['schemas']['Avatar'];
       id: number;
       members: number;
+      membership?: components['schemas']['GroupMember'];
       name: string;
       nsfw: boolean;
       posts: number;
       title: string;
       topics: number;
     };
+    /**
+     * @description 小组过滤模式
+     *       - all = 所有小组
+     *       - joined = 我加入的小组
+     *       - managed = 我管理的小组
+     * @enum {string}
+     */
+    GroupFilterMode: 'all' | 'joined' | 'managed';
     /** GroupMember */
     GroupMember: {
       joinedAt: number;
@@ -1860,8 +3150,7 @@ export interface components {
      */
     GroupSort: 'posts' | 'topics' | 'members' | 'created' | 'updated';
     /** GroupTopic */
-    GroupTopic: components['schemas']['TopicBase'] & {
-      creator: components['schemas']['SlimUser'];
+    GroupTopic: components['schemas']['Topic'] & {
       group: components['schemas']['SlimGroup'];
       replies: components['schemas']['Reply'][];
     };
@@ -1874,34 +3163,79 @@ export interface components {
      * @enum {string}
      */
     GroupTopicFilterMode: 'all' | 'joined' | 'created' | 'replied';
-    HistorySummary: {
-      commitMessage: string;
-      /** @description unix timestamp seconds */
-      createdAt: number;
-      creator: {
-        username: string;
-      };
-      /** @description 修改类型。`1` 正常修改， `11` 合并，`103` 锁定/解锁 `104` 未知 */
-      type: number;
-    };
     /** Index */
     Index: {
+      award: number;
       collectedAt?: number;
       collects: number;
       createdAt: number;
       desc: string;
       id: number;
+      private: boolean;
       replies: number;
       stats: components['schemas']['IndexStats'];
       title: string;
       total: number;
-      type: number;
+      type: components['schemas']['IndexType'];
+      uid: number;
       updatedAt: number;
+      user?: components['schemas']['SlimUser'];
     };
+    /** IndexRelated */
+    IndexRelated: {
+      award: string;
+      blog?: components['schemas']['SlimBlogEntry'];
+      cat: components['schemas']['IndexRelatedCategory'];
+      character?: components['schemas']['SlimCharacter'];
+      comment: string;
+      createdAt: number;
+      episode?: components['schemas']['Episode'];
+      groupTopic?: components['schemas']['GroupTopic'];
+      id: number;
+      order: number;
+      person?: components['schemas']['SlimPerson'];
+      rid: number;
+      sid: number;
+      subject?: components['schemas']['SlimSubject'];
+      subjectTopic?: components['schemas']['SubjectTopic'];
+      type: number;
+    };
+    /**
+     * @description 目录关联类型
+     *       - 0 = 条目
+     *       - 1 = 角色
+     *       - 2 = 人物
+     *       - 3 = 章节
+     *       - 4 = 日志
+     *       - 5 = 小组话题
+     *       - 6 = 条目讨论
+     * @enum {integer}
+     */
+    IndexRelatedCategory: 0 | 1 | 2 | 3 | 4 | 5 | 6;
     /** IndexStats */
     IndexStats: {
-      [key: string]: number;
+      blog?: number;
+      character?: number;
+      episode?: number;
+      groupTopic?: number;
+      person?: number;
+      subject: {
+        anime?: number;
+        book?: number;
+        game?: number;
+        music?: number;
+        real?: number;
+      };
+      subjectTopic?: number;
     };
+    /**
+     * @description 目录类型
+     *       - 0 = 用户
+     *       - 1 = 公共
+     *       - 2 = TBA
+     * @enum {integer}
+     */
+    IndexType: 0 | 1 | 2;
     /** Infobox */
     Infobox: {
       key: string;
@@ -1923,36 +3257,53 @@ export interface components {
       k?: string;
       v: string;
     };
-    /** @example {
+    /**
+     * @example {
      *       "email": "treeholechan@gmail.com",
      *       "password": "lovemeplease",
      *       "turnstileToken": "10000000-aaaa-bbbb-cccc-000000000001"
-     *     } */
+     *     }
+     */
     LoginRequestBody: {
       email: string;
       password: string;
       turnstileToken: string;
     };
+    /** MonoPhoto */
+    MonoPhoto: {
+      comment: string;
+      createdAt: number;
+      creatorID: number;
+      id: number;
+      images: components['schemas']['MonoPhotoImages'];
+      lastPost: number;
+      mainID: number;
+      spoiler: boolean;
+      tags: string[];
+      target: string;
+      title: string;
+      type: number;
+      updatedAt: number;
+      user?: components['schemas']['SlimUser'];
+    };
+    /** MonoPhotoImages */
+    MonoPhotoImages: {
+      common: string;
+      grid: string;
+      large: string;
+      medium: string;
+      small: string;
+    };
+    /** Notice */
     Notice: {
-      /** @description unix timestamp in seconds */
       createdAt: number;
       id: number;
-      postID: number;
-      /** SlimUser */
-      sender: {
-        avatar: components['schemas']['Avatar'];
-        group: number;
-        /** @example 1 */
-        id: number;
-        joinedAt: number;
-        /** @example Sai🖖 */
-        nickname: string;
-        sign: string;
-        /** @example sai */
-        username: string;
-      };
+      /** @description 对应的 topicID, episodeID, userID ... */
+      mainID: number;
+      /** @description 对应的 postID ... */
+      relatedID: number;
+      sender: components['schemas']['SlimUser'];
       title: string;
-      topicID: number;
       /** @description 查看 `./lib/notify.ts` _settings */
       type: number;
       unread: boolean;
@@ -1981,8 +3332,21 @@ export interface components {
       nsfw: boolean;
       redirect: number;
       summary: string;
-      type: number;
+      type: components['schemas']['PersonType'];
     };
+    PersonCastRevisionWikiInfo: {
+      character: {
+        id: number;
+        name: string;
+        nameCN: string;
+      };
+      subject: {
+        id: number;
+        name: string;
+        nameCN: string;
+        typeID: components['schemas']['SubjectType'];
+      };
+    }[];
     PersonCharacter: {
       character: components['schemas']['SlimCharacter'];
       relations: components['schemas']['CharacterSubjectRelation'][];
@@ -1990,6 +3354,40 @@ export interface components {
     PersonCollect: {
       createdAt: number;
       user: components['schemas']['SlimUser'];
+    };
+    PersonCreate: {
+      /**
+       * Format: byte
+       * @description base64 encoded raw bytes, 4mb size limit on **decoded** size
+       */
+      img?: string;
+      infobox: string;
+      name: string;
+      profession?: {
+        actor?: boolean;
+        artist?: boolean;
+        illustrator?: boolean;
+        mangaka?: boolean;
+        producer?: boolean;
+        seiyu?: boolean;
+        writer?: boolean;
+      };
+      summary: string;
+      type: components['schemas']['PersonType'];
+    };
+    PersonEdit: {
+      infobox: string;
+      name: string;
+      profession: {
+        actor?: boolean;
+        artist?: boolean;
+        illustrator?: boolean;
+        mangaka?: boolean;
+        producer?: boolean;
+        seiyu?: boolean;
+        writer?: boolean;
+      };
+      summary: string;
     };
     /** PersonImages */
     PersonImages: {
@@ -1999,19 +3397,74 @@ export interface components {
       small: string;
     };
     PersonRelation: {
+      comment: string;
+      ended: boolean;
       person: components['schemas']['SlimPerson'];
-      /** @description 人物关系: 任职于,从属,聘用,嫁给... */
-      relation: number;
+      relation: components['schemas']['PersonRelationType'];
+      spoiler: boolean;
+    };
+    PersonRelationType: {
+      cn: string;
+      desc: string;
+      id: number;
+      primary?: boolean;
+      skipViceVersa?: boolean;
+      viceVersaTo?: number;
+    };
+    PersonRevisionWikiInfo: {
+      extra: {
+        img?: string;
+      };
+      infobox: string;
+      name: string;
+      profession: {
+        actor?: boolean;
+        artist?: boolean;
+        illustrator?: boolean;
+        mangaka?: boolean;
+        producer?: boolean;
+        seiyu?: boolean;
+        writer?: boolean;
+      };
+      summary: string;
     };
     PersonSearchFilter: {
       career?: string[];
     };
+    PersonSubjectRevisionWikiInfo: {
+      position: number;
+      subject: {
+        id: number;
+        name: string;
+        nameCN: string;
+        typeID: components['schemas']['SubjectType'];
+      };
+    }[];
+    /**
+     * @description 人物类型
+     *       - 1 = 个人
+     *       - 2 = 公司
+     *       - 3 = 组合
+     * @enum {integer}
+     */
+    PersonType: 1 | 2 | 3;
     PersonWikiInfo: {
       id: number;
       infobox: string;
+      locked: boolean;
       name: string;
+      profession: {
+        actor?: boolean;
+        artist?: boolean;
+        illustrator?: boolean;
+        mangaka?: boolean;
+        producer?: boolean;
+        seiyu?: boolean;
+        writer?: boolean;
+      };
+      redirect: number;
       summary: string;
-      typeID: components['schemas']['SubjectType'];
+      typeID: components['schemas']['PersonType'];
     };
     PersonWork: {
       positions: components['schemas']['SubjectStaffPosition'][];
@@ -2030,9 +3483,6 @@ export interface components {
     /** Profile */
     Profile: {
       avatar: components['schemas']['Avatar'];
-      bio: string;
-      blocklist: number[];
-      friendIDs: number[];
       group: number;
       id: number;
       joinedAt: number;
@@ -2072,6 +3522,109 @@ export interface components {
       reactions?: components['schemas']['Reaction'][];
       state: number;
     };
+    /**
+     * @description 举报原因
+     *       - 1 = 辱骂、人身攻击
+     *       - 2 = 刷屏、无关内容
+     *       - 3 = 政治相关
+     *       - 4 = 违法信息
+     *       - 5 = 泄露隐私
+     *       - 6 = 涉嫌刷分
+     *       - 7 = 引战
+     *       - 8 = 广告
+     *       - 9 = 剧透
+     *       - 99 = 其他
+     * @enum {integer}
+     */
+    ReportReason: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 99;
+    /**
+     * @description 举报类型
+     *       - 6 = 用户
+     *       - 7 = 小组话题
+     *       - 8 = 小组回复
+     *       - 9 = 条目话题
+     *       - 10 = 条目回复
+     *       - 11 = 章节回复
+     *       - 12 = 角色回复
+     *       - 13 = 人物回复
+     *       - 14 = 日志
+     *       - 15 = 日志回复
+     *       - 16 = 时间线
+     *       - 17 = 时间线回复
+     *       - 18 = 目录
+     *       - 19 = 目录回复
+     * @enum {integer}
+     */
+    ReportType: 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19;
+    RevisionHistory: {
+      commitMessage: string;
+      /** @description unix timestamp seconds */
+      createdAt: number;
+      creator: {
+        nickname: string;
+        username: string;
+      };
+      id: number;
+      type: components['schemas']['RevisionType'];
+    };
+    /**
+     * @description 修订类型
+     *       - 1 = 条目编辑
+     *       - 103 = 条目锁定
+     *       - 104 = 条目解锁
+     *       - 11 = 条目合体
+     *       - 12 = 条目删除
+     *       - 17 = 条目关联
+     *       - 5 = 条目->角色关联
+     *       - 6 = 条目->声优关联
+     *       - 10 = 条目->人物关联
+     *
+     *       - 2 = 角色编辑
+     *       - 13 = 角色合体
+     *       - 14 = 角色删除
+     *       - 4 = 角色->条目关联
+     *       - 7 = 角色->声优关联
+     *
+     *       - 3 = 人物编辑
+     *       - 15 = 人物合体
+     *       - 16 = 人物删除
+     *       - 8 = 人物->声优关联
+     *       - 9 = 人物->条目关联
+     *
+     *       - 18 = 章节编辑
+     *       - 181 = 章节合体
+     *       - 182 = 章节移动
+     *       - 183 = 章节锁定
+     *       - 184 = 章节解锁
+     *       - 185 = 章节删除
+     * @enum {integer}
+     */
+    RevisionType:
+      | 1
+      | 103
+      | 104
+      | 11
+      | 12
+      | 17
+      | 5
+      | 6
+      | 10
+      | 2
+      | 13
+      | 14
+      | 4
+      | 7
+      | 3
+      | 15
+      | 16
+      | 8
+      | 9
+      | 18
+      | 181
+      | 182
+      | 183
+      | 184
+      | 185;
     SearchCharacter: {
       filter?: components['schemas']['CharacterSearchFilter'];
       /** @description 搜索关键词 */
@@ -2106,6 +3659,7 @@ export interface components {
       type: number;
       uid: number;
       updatedAt: number;
+      user?: components['schemas']['SlimUser'];
     };
     /** SlimCharacter */
     SlimCharacter: {
@@ -2135,12 +3689,22 @@ export interface components {
     SlimIndex: {
       createdAt: number;
       id: number;
+      private: boolean;
+      stats: components['schemas']['IndexStats'];
       title: string;
       total: number;
-      type: number;
+      type: components['schemas']['IndexType'];
+      uid: number;
+      updatedAt: number;
+      user?: components['schemas']['SlimUser'];
     };
     /** SlimPerson */
     SlimPerson: {
+      /**
+       * @description 职业
+       * @example producer
+       */
+      career: string[];
       comment: number;
       id: number;
       images?: components['schemas']['PersonImages'];
@@ -2163,6 +3727,7 @@ export interface components {
      *         "small": "https://lain.bgm.tv/pic/cover/s/c9/f0/8_wK0z3.jpg"
      *       },
      *       "locked": false,
+     *       "metaTags": [],
      *       "name": "コードギアス 反逆のルルーシュR2",
      *       "nameCN": "Code Geass 反叛的鲁路修R2",
      *       "nsfw": false,
@@ -2175,6 +3740,7 @@ export interface components {
       info: string;
       interest?: components['schemas']['SlimSubjectInterest'];
       locked: boolean;
+      metaTags: string[];
       name: string;
       nameCN: string;
       nsfw: boolean;
@@ -2184,6 +3750,7 @@ export interface components {
     /** SlimSubjectInterest */
     SlimSubjectInterest: {
       comment: string;
+      id: number;
       rate: number;
       tags: string[];
       type: components['schemas']['CollectionType'];
@@ -2288,7 +3855,7 @@ export interface components {
      *         ],
      *         "官方网站": [
      *           {
-     *             "v": "http://www.geass.jp/r2/"
+     *             "v": "https://www.geass.jp/r2/"
      *           }
      *         ],
      *         "导演": [
@@ -2438,22 +4005,38 @@ export interface components {
      */
     SubjectBrowseSort: 'rank' | 'trends' | 'collects' | 'date' | 'title';
     SubjectCharacter: {
-      actors: components['schemas']['SlimPerson'][];
+      casts: components['schemas']['CharacterCast'][];
       character: components['schemas']['SlimCharacter'];
       order: number;
       type: number;
+    };
+    SubjectCharacterRevisionWikiInfo: {
+      character: {
+        id: number;
+        name: string;
+        nameCN: string;
+      };
+      order: number;
+      type: number;
+    }[];
+    /** SubjectCollect */
+    SubjectCollect: {
+      interest: components['schemas']['SlimSubjectInterest'];
+      user: components['schemas']['SlimUser'];
     };
     /** SubjectCollection */
     SubjectCollection: {
       [key: string]: number;
     };
-    /** @example {
-     *       "infobox": "{{Infobox animanga/TVAnime\n|中文名= 沙盒\n|别名={\n}\n|话数= 7\n|放送开始= 0000-10-06\n|放送星期= \n|官方网站= \n|播放电视台= \n|其他电视台= \n|播放结束= \n|其他= \n|Copyright= \n|平台={\n[龟壳]\n[Xbox Series S]\n[Xbox Series X]\n[Xbox Series X/S]\n[PC]\n[Xbox Series X|S]\n}\n}}",
+    /**
+     * @example {
+     *       "infobox": "{{Infobox animanga/TVAnime\n|中文名= 沙盒\n|别名={\n}\n|话数= 7\n|放送开始= 0000-10-06\n|放送星期=\n|官方网站=\n|播放电视台=\n|其他电视台=\n|播放结束=\n|其他=\n|Copyright=\n|平台={\n[龟壳]\n[Xbox Series S]\n[Xbox Series X]\n[Xbox Series X/S]\n[PC]\n[Xbox Series X|S]\n}\n}}",
      *       "name": "沙盒",
      *       "nsfw": false,
      *       "platform": 0,
      *       "summary": "本条目是一个沙盒，可以用于尝试bgm功能。\n\n普通维基人可以随意编辑条目信息以及相关关联查看编辑效果，但是请不要完全删除沙盒说明并且不要关联非沙盒条目/人物/角色。\n\nhttps://bgm.tv/group/topic/366812#post_1923517"
-     *     } */
+     *     }
+     */
     SubjectEdit: {
       /** @example 0000-00-00 */
       date?: string;
@@ -2462,6 +4045,7 @@ export interface components {
       name: string;
       nsfw: boolean;
       platform: number;
+      series?: boolean;
       summary: string;
     };
     /** SubjectImages */
@@ -2476,6 +4060,7 @@ export interface components {
     SubjectInterest: {
       comment: string;
       epStatus: number;
+      id: number;
       private: boolean;
       rate: number;
       tags: string[];
@@ -2494,14 +4079,25 @@ export interface components {
       user: components['schemas']['SlimUser'];
     };
     SubjectNew: {
+      /** @example 0000-00-00 */
+      date?: string;
       infobox: string;
       metaTags: string[];
       name: string;
       nsfw: boolean;
       platform: number;
+      series?: boolean;
       summary: string;
       type: components['schemas']['SubjectType'];
     };
+    SubjectPersonRevisionWikiInfo: {
+      person: {
+        id: number;
+        name: string;
+        nameCN: string;
+      };
+      position: number;
+    }[];
     /** SubjectPlatform */
     SubjectPlatform: {
       alias: string;
@@ -2541,6 +4137,16 @@ export interface components {
       relation: components['schemas']['SubjectRelationType'];
       subject: components['schemas']['SlimSubject'];
     };
+    SubjectRelationRevisionWikiInfo: {
+      order: number;
+      subject: {
+        id: number;
+        name: string;
+        nameCN: string;
+        typeID: components['schemas']['SubjectType'];
+      };
+      type: number;
+    }[];
     SubjectRelationType: {
       cn: string;
       desc: string;
@@ -2554,12 +4160,21 @@ export interface components {
       id: number;
       user: components['schemas']['SlimUser'];
     };
+    SubjectRevisionWikiInfo: {
+      id: number;
+      infobox: string;
+      metaTags: string[];
+      name: string;
+      summary: string;
+    };
     SubjectSearchFilter: {
       date?: string[];
       metaTags?: string[];
-      /** @description 无权限的用户会直接忽略此字段，不会返回 R18 条目。
+      /**
+       * @description 无权限的用户会直接忽略此字段，不会返回 R18 条目。
        *     `null` 或者 `true` 会返回包含 R18 的所有搜索结果。
-       *     `false` 只会返回非 R18 条目。 */
+       *     `false` 只会返回非 R18 条目。
+       */
       nsfw?: boolean;
       rank?: string[];
       rating?: string[];
@@ -2597,8 +4212,7 @@ export interface components {
       name: string;
     };
     /** SubjectTopic */
-    SubjectTopic: components['schemas']['TopicBase'] & {
-      creator: components['schemas']['SlimUser'];
+    SubjectTopic: components['schemas']['Topic'] & {
       replies: components['schemas']['Reply'][];
       subject: components['schemas']['SlimSubject'];
     };
@@ -2618,10 +4232,13 @@ export interface components {
       availablePlatform: components['schemas']['WikiPlatform'][];
       id: number;
       infobox: string;
+      locked: boolean;
       metaTags: string[];
       name: string;
       nsfw: boolean;
       platform: number;
+      redirect: number;
+      series?: boolean;
       summary: string;
       typeID: components['schemas']['SubjectType'];
     };
@@ -2632,6 +4249,7 @@ export interface components {
       createdAt: number;
       id: number;
       memo: components['schemas']['TimelineMemo'];
+      reactions?: components['schemas']['Reaction'][];
       replies: number;
       source: components['schemas']['TimelineSource'];
       type: number;
@@ -2652,13 +4270,6 @@ export interface components {
      * @enum {integer}
      */
     TimelineCat: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
-    /**
-     * @description 时间线过滤模式
-     *       - all = 全站
-     *       - friends = 好友
-     * @enum {string}
-     */
-    TimelineFilterMode: 'all' | 'friends';
     /** TimelineMemo */
     TimelineMemo: {
       blog?: components['schemas']['SlimBlogEntry'];
@@ -2695,39 +4306,29 @@ export interface components {
       subject?: {
         collectID?: number;
         comment: string;
-        rate: number;
-        reactions?: components['schemas']['Reaction'][];
+        rate?: number;
         subject: components['schemas']['SlimSubject'];
       }[];
       wiki?: {
         subject?: components['schemas']['SlimSubject'];
       };
     };
-    /**
-     * @description 时间线来源
-     *       - 0 = 网站
-     *       - 1 = 移动端
-     *       - 2 = https://bgm.tv/onair
-     *       - 3 = https://netaba.re/
-     *       - 4 = WP
-     *       - 5 = API
-     * @enum {integer}
-     */
-    TimelineSource: 0 | 1 | 2 | 3 | 4 | 5;
-    /** Topic */
-    Topic: components['schemas']['TopicBase'] & {
-      creator?: components['schemas']['SlimUser'];
-      replies: number;
+    /** TimelineSource */
+    TimelineSource: {
+      name: string;
+      url?: string;
     };
-    /** TopicBase */
-    TopicBase: {
+    /** Topic */
+    Topic: {
       /** @description 发帖时间，unix time stamp in seconds */
       createdAt: number;
+      creator?: components['schemas']['SlimUser'];
       creatorID: number;
       display: number;
       id: number;
       /** @description 小组/条目ID */
       parentID: number;
+      replyCount: number;
       state: number;
       title: string;
       /** @description 最后回复时间，unix time stamp in seconds */
@@ -2738,9 +4339,11 @@ export interface components {
       subject: components['schemas']['SlimSubject'];
     };
     TurnstileToken: {
-      /** @description 需要 [turnstile](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/)
+      /**
+       * @description 需要 [turnstile](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/)
        *     next.bgm.tv 域名对应的 site-key 为 `0x4AAAAAAABkMYinukE8nzYS`
-       *     dev.bgm38.tv 域名使用测试用的 site-key `1x00000000000000000000AA` */
+       *     dev.bgm38.tv 域名使用测试用的 site-key `1x00000000000000000000AA`
+       */
       turnstileToken: string;
     };
     UpdateContent: {
@@ -2750,6 +4353,20 @@ export interface components {
       /** @description 是否批量更新(看到当前章节), 批量更新时 type 无效 */
       batch?: boolean;
       type?: components['schemas']['EpisodeCollectionStatus'];
+    };
+    /** UpdateIndex */
+    UpdateIndex: {
+      /** @description 目录描述 */
+      desc?: string;
+      /** @description 仅自己可见 */
+      private?: boolean;
+      /** @description 目录标题 */
+      title?: string;
+    };
+    /** UpdateIndexRelated */
+    UpdateIndexRelated: {
+      comment: string;
+      order: number;
     };
     UpdateSubjectProgress: {
       /** @description 书籍条目章节进度 */
@@ -2786,6 +4403,16 @@ export interface components {
       stats: components['schemas']['UserStats'];
       /** @example sai */
       username: string;
+    };
+    UserCharacterContribution: {
+      characterID: number;
+      commitMessage: string;
+      /** @description unix timestamp seconds */
+      createdAt: number;
+      id: number;
+      name: string;
+      /** @description 2 = 角色编辑 */
+      type: number;
     };
     /** UserHomepage */
     UserHomepage: {
@@ -2825,6 +4452,16 @@ export interface components {
       title: string;
       url: string;
     };
+    UserPersonContribution: {
+      commitMessage: string;
+      /** @description unix timestamp seconds */
+      createdAt: number;
+      id: number;
+      name: string;
+      personID: number;
+      /** @description 3 = 人物编辑，15 = 合并，16 = 删除 */
+      type: number;
+    };
     /** UserStats */
     UserStats: {
       blog: number;
@@ -2839,6 +4476,16 @@ export interface components {
       [key: string]: {
         [key: string]: number;
       };
+    };
+    UserSubjectContribution: {
+      commitMessage: string;
+      /** @description unix timestamp seconds */
+      createdAt: number;
+      id: number;
+      name: string;
+      subjectID: number;
+      /** @description 修改类型。`1` 正常修改， `11` 合并，`103` 锁定/解锁 `104` 未知 */
+      type: number;
     };
     WikiPlatform: {
       id: number;
@@ -2885,49 +4532,12 @@ export interface operations {
       };
     };
   };
-  addToBlocklist: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': {
-          id: number;
-        };
-      };
-    };
-    responses: {
-      /** @description Default Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            blocklist: number[];
-          };
-        };
-      };
-      /** @description 意料之外的服务器错误 */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  removeFromBlocklist: {
+  addUserToBlocklist: {
     parameters: {
       query?: never;
       header?: never;
       path: {
-        id: number;
+        username: string;
       };
       cookie?: never;
     };
@@ -2942,6 +4552,57 @@ export interface operations {
           'application/json': {
             blocklist: number[];
           };
+        };
+      };
+      /** @description default error response type */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  removeUserFromBlocklist: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        username: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            blocklist: number[];
+          };
+        };
+      };
+      /** @description default error response type */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
         };
       };
       /** @description 意料之外的服务器错误 */
@@ -2964,7 +4625,7 @@ export interface operations {
       };
       cookie?: never;
     };
-    requestBody?: {
+    requestBody: {
       content: {
         'application/json': components['schemas']['UpdateContent'];
       };
@@ -3077,6 +4738,7 @@ export interface operations {
             mainID: number;
             reactions?: components['schemas']['Reaction'][];
             relatedID: number;
+            relatedPhotoID?: number;
             state: number;
             user?: components['schemas']['SlimUser'];
           } & {
@@ -3113,7 +4775,7 @@ export interface operations {
       };
       cookie?: never;
     };
-    requestBody?: {
+    requestBody: {
       content: {
         'application/json': components['schemas']['CreateReply'] &
           components['schemas']['TurnstileToken'];
@@ -3130,6 +4792,15 @@ export interface operations {
             /** @description new comment id */
             id: number;
           };
+        };
+      };
+      /** @description default error response type */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
         };
       };
       /** @description 意料之外的服务器错误 */
@@ -3252,7 +4923,7 @@ export interface operations {
       };
       cookie?: never;
     };
-    requestBody?: {
+    requestBody: {
       content: {
         'application/json': components['schemas']['UpdateContent'];
       };
@@ -3475,6 +5146,7 @@ export interface operations {
             mainID: number;
             reactions?: components['schemas']['Reaction'][];
             relatedID: number;
+            relatedPhotoID?: number;
             state: number;
             user?: components['schemas']['SlimUser'];
           } & {
@@ -3511,7 +5183,7 @@ export interface operations {
       };
       cookie?: never;
     };
-    requestBody?: {
+    requestBody: {
       content: {
         'application/json': components['schemas']['CreateReply'] &
           components['schemas']['TurnstileToken'];
@@ -3528,6 +5200,353 @@ export interface operations {
             /** @description new comment id */
             id: number;
           };
+        };
+      };
+      /** @description default error response type */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getCharacterIndexes: {
+    parameters: {
+      query?: {
+        /** @description max 100 */
+        limit?: number;
+        /** @description min 0 */
+        offset?: number;
+      };
+      header?: never;
+      path: {
+        characterID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: components['schemas']['SlimIndex'][];
+            /** @description limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+            total: number;
+          };
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getCharacterPhotos: {
+    parameters: {
+      query?: {
+        /** @description max 100 */
+        limit?: number;
+        /** @description min 0 */
+        offset?: number;
+      };
+      header?: never;
+      path: {
+        characterID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: components['schemas']['MonoPhoto'][];
+            /** @description limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+            total: number;
+          };
+        };
+      };
+      /** @description default error response type */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getCharacterPhotoPreview: {
+    parameters: {
+      query?: {
+        /** @description max 20 */
+        limit?: number;
+      };
+      header?: never;
+      path: {
+        characterID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: components['schemas']['MonoPhoto'][];
+            /** @description limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+            total: number;
+          };
+        };
+      };
+      /** @description default error response type */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getCharacterPhoto: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        characterID: number;
+        photoID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['MonoPhoto'];
+        };
+      };
+      /** @description default error response type */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getCharacterPhotoComments: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        characterID: number;
+        photoID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': ({
+            content: string;
+            createdAt: number;
+            creatorID: number;
+            id: number;
+            mainID: number;
+            reactions?: components['schemas']['Reaction'][];
+            relatedID: number;
+            relatedPhotoID?: number;
+            state: number;
+            user?: components['schemas']['SlimUser'];
+          } & {
+            replies: components['schemas']['CommentBase'][];
+          })[];
+        };
+      };
+      /** @description default error response type */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  createCharacterPhotoComment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        characterID: number;
+        photoID: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['CreateReply'] &
+          components['schemas']['TurnstileToken'];
+      };
+    };
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            /** @description new comment id */
+            id: number;
+          };
+        };
+      };
+      /** @description default error response type */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description default error response type */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getCharacterRelations: {
+    parameters: {
+      query?: {
+        /** @description max 100 */
+        limit?: number;
+        /** @description min 0 */
+        offset?: number;
+      };
+      header?: never;
+      path: {
+        characterID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: components['schemas']['CharacterRelation'][];
+            /** @description limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+            total: number;
+          };
+        };
+      };
+      /** @description default error response type */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
         };
       };
       /** @description 意料之外的服务器错误 */
@@ -3548,7 +5567,7 @@ export interface operations {
       path?: never;
       cookie?: never;
     };
-    requestBody?: {
+    requestBody: {
       content: {
         'application/json': {
           id?: number[];
@@ -3556,20 +5575,13 @@ export interface operations {
       };
     };
     responses: {
-      /** @description 没有返回值 */
+      /** @description Default Response */
       200: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
-      };
-      /** @description 未登录 */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
         content: {
-          'application/json': components['schemas']['ErrorResponse'];
+          'application/json': Record<string, never>;
         };
       };
       /** @description 意料之外的服务器错误 */
@@ -3621,6 +5633,86 @@ export interface operations {
       };
     };
   };
+  addCharacterCollection: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        characterID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': Record<string, never>;
+        };
+      };
+      /** @description default error response type */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  deleteCharacterCollection: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        characterID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': Record<string, never>;
+        };
+      };
+      /** @description default error response type */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
   updateEpisodeProgress: {
     parameters: {
       query?: never;
@@ -3630,7 +5722,7 @@ export interface operations {
       };
       cookie?: never;
     };
-    requestBody?: {
+    requestBody: {
       content: {
         'application/json': components['schemas']['UpdateEpisodeProgress'];
       };
@@ -3643,6 +5735,15 @@ export interface operations {
         };
         content: {
           'application/json': Record<string, never>;
+        };
+      };
+      /** @description default error response type */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
         };
       };
       /** @description 意料之外的服务器错误 */
@@ -3694,6 +5795,86 @@ export interface operations {
       };
     };
   };
+  addIndexCollection: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        indexID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': Record<string, never>;
+        };
+      };
+      /** @description default error response type */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  deleteIndexCollection: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        indexID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': Record<string, never>;
+        };
+      };
+      /** @description default error response type */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
   getMyPersonCollections: {
     parameters: {
       query?: {
@@ -3719,6 +5900,86 @@ export interface operations {
             /** @description limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
             total: number;
           };
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  addPersonCollection: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        personID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': Record<string, never>;
+        };
+      };
+      /** @description default error response type */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  deletePersonCollection: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        personID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': Record<string, never>;
+        };
+      };
+      /** @description default error response type */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
         };
       };
       /** @description 意料之外的服务器错误 */
@@ -3783,7 +6044,7 @@ export interface operations {
       };
       cookie?: never;
     };
-    requestBody?: {
+    requestBody: {
       content: {
         'application/json': components['schemas']['CollectSubject'];
       };
@@ -3796,6 +6057,15 @@ export interface operations {
         };
         content: {
           'application/json': Record<string, never>;
+        };
+      };
+      /** @description default error response type */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
         };
       };
       /** @description 意料之外的服务器错误 */
@@ -3818,7 +6088,7 @@ export interface operations {
       };
       cookie?: never;
     };
-    requestBody?: {
+    requestBody: {
       content: {
         'application/json': components['schemas']['UpdateSubjectProgress'];
       };
@@ -3831,6 +6101,15 @@ export interface operations {
         };
         content: {
           'application/json': Record<string, never>;
+        };
+      };
+      /** @description default error response type */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
         };
       };
       /** @description 意料之外的服务器错误 */
@@ -3882,7 +6161,7 @@ export interface operations {
       };
       cookie?: never;
     };
-    requestBody?: {
+    requestBody: {
       content: {
         'application/json': components['schemas']['UpdateContent'];
       };
@@ -3909,6 +6188,83 @@ export interface operations {
     };
   };
   deleteEpisodeComment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        commentID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': Record<string, never>;
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  likeEpisodeComment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        commentID: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': {
+          value: number;
+        };
+      };
+    };
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': Record<string, never>;
+        };
+      };
+      /** @description default error response type */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  unlikeEpisodeComment: {
     parameters: {
       query?: never;
       header?: never;
@@ -3995,6 +6351,7 @@ export interface operations {
             mainID: number;
             reactions?: components['schemas']['Reaction'][];
             relatedID: number;
+            relatedPhotoID?: number;
             state: number;
             user?: components['schemas']['SlimUser'];
           } & {
@@ -4022,7 +6379,7 @@ export interface operations {
       };
       cookie?: never;
     };
-    requestBody?: {
+    requestBody: {
       content: {
         'application/json': components['schemas']['CreateReply'] &
           components['schemas']['TurnstileToken'];
@@ -4039,6 +6396,15 @@ export interface operations {
             /** @description new comment id */
             id: number;
           };
+        };
+      };
+      /** @description default error response type */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
         };
       };
       /** @description 意料之外的服务器错误 */
@@ -4076,6 +6442,37 @@ export interface operations {
             data: components['schemas']['Friend'][];
             /** @description limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
             total: number;
+          };
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getFriendlist: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            friendlist: number[];
           };
         };
       };
@@ -4128,9 +6525,90 @@ export interface operations {
       };
     };
   };
+  addFriend: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        username: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': Record<string, never>;
+        };
+      };
+      /** @description default error response type */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  removeFriend: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        username: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': Record<string, never>;
+        };
+      };
+      /** @description default error response type */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
   getGroups: {
     parameters: {
       query: {
+        mode?: components['schemas']['GroupFilterMode'];
         sort: components['schemas']['GroupSort'];
         limit?: number;
         offset?: number;
@@ -4205,7 +6683,7 @@ export interface operations {
       };
       cookie?: never;
     };
-    requestBody?: {
+    requestBody: {
       content: {
         'application/json': components['schemas']['UpdateContent'];
       };
@@ -4262,10 +6740,86 @@ export interface operations {
       };
     };
   };
+  likeGroupPost: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        postID: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': {
+          value: number;
+        };
+      };
+    };
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': Record<string, never>;
+        };
+      };
+      /** @description default error response type */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  unlikeGroupPost: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        postID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': Record<string, never>;
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
   getRecentGroupTopics: {
     parameters: {
       query: {
-        /** @description 登录时默认为 joined, 未登录或没有加入小组时始终为 all */
         mode: components['schemas']['GroupTopicFilterMode'];
         limit?: number;
         offset?: number;
@@ -4276,6 +6830,19 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: components['schemas']['GroupTopic'][];
+            /** @description limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+            total: number;
+          };
+        };
+      };
       /** @description 意料之外的服务器错误 */
       500: {
         headers: {
@@ -4327,7 +6894,7 @@ export interface operations {
       };
       cookie?: never;
     };
-    requestBody?: {
+    requestBody: {
       content: {
         'application/json': components['schemas']['UpdateTopic'];
       };
@@ -4362,7 +6929,7 @@ export interface operations {
       };
       cookie?: never;
     };
-    requestBody?: {
+    requestBody: {
       content: {
         'application/json': components['schemas']['CreateReply'] &
           components['schemas']['TurnstileToken'];
@@ -4378,6 +6945,15 @@ export interface operations {
           'application/json': {
             id: number;
           };
+        };
+      };
+      /** @description default error response type */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
         };
       };
       /** @description 意料之外的服务器错误 */
@@ -4508,7 +7084,7 @@ export interface operations {
       };
       cookie?: never;
     };
-    requestBody?: {
+    requestBody: {
       content: {
         'application/json': components['schemas']['CreateTopic'] &
           components['schemas']['TurnstileToken'];
@@ -4525,6 +7101,461 @@ export interface operations {
             /** @description new topic id */
             id: number;
           };
+        };
+      };
+      /** @description default error response type */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  createIndex: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['CreateIndex'];
+      };
+    };
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            id: number;
+          };
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  updateIndexComment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        commentID: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['UpdateContent'];
+      };
+    };
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': Record<string, never>;
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  deleteIndexComment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        commentID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': Record<string, never>;
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getIndex: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        indexID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Index'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  deleteIndex: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        indexID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': Record<string, never>;
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  updateIndex: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        indexID: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['UpdateIndex'];
+      };
+    };
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': Record<string, never>;
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getIndexComments: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        indexID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': ({
+            content: string;
+            createdAt: number;
+            creatorID: number;
+            id: number;
+            mainID: number;
+            reactions?: components['schemas']['Reaction'][];
+            relatedID: number;
+            relatedPhotoID?: number;
+            state: number;
+            user?: components['schemas']['SlimUser'];
+          } & {
+            replies: components['schemas']['CommentBase'][];
+          })[];
+        };
+      };
+      /** @description default error response type */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  createIndexComment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        indexID: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['CreateReply'] &
+          components['schemas']['TurnstileToken'];
+      };
+    };
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            /** @description new comment id */
+            id: number;
+          };
+        };
+      };
+      /** @description default error response type */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getIndexRelated: {
+    parameters: {
+      query?: {
+        cat?: components['schemas']['IndexRelatedCategory'];
+        type?: components['schemas']['SubjectType'];
+        /** @description max 100 */
+        limit?: number;
+        /** @description min 0 */
+        offset?: number;
+      };
+      header?: never;
+      path: {
+        indexID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: components['schemas']['IndexRelated'][];
+            /** @description limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+            total: number;
+          };
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  putIndexRelated: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        indexID: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['CreateIndexRelated'];
+      };
+    };
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            id: number;
+          };
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  deleteIndexRelated: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        indexID: number;
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': Record<string, never>;
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  patchIndexRelated: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        indexID: number;
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['UpdateIndexRelated'];
+      };
+    };
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': Record<string, never>;
         };
       };
       /** @description 意料之外的服务器错误 */
@@ -4545,7 +7576,7 @@ export interface operations {
       path?: never;
       cookie?: never;
     };
-    requestBody?: {
+    requestBody: {
       content: {
         'application/json': components['schemas']['LoginRequestBody'];
       };
@@ -4619,7 +7650,7 @@ export interface operations {
       path?: never;
       cookie?: never;
     };
-    requestBody?: {
+    requestBody: {
       content: {
         'application/json': Record<string, never>;
       };
@@ -4718,13 +7749,99 @@ export interface operations {
           };
         };
       };
-      /** @description 未登录 */
-      401: {
+      /** @description 意料之外的服务器错误 */
+      500: {
         headers: {
           [name: string]: unknown;
         };
         content: {
           'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  passkeyLoginOptions: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': {
+          credentials?: {
+            credentialId: string;
+            transports?: string[];
+          }[];
+        };
+      };
+    };
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            challenge: string;
+            options: unknown;
+            rpId: string;
+          };
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  passkeyLoginVerify: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': {
+          /** @description 之前 options 返回的 challenge */
+          challenge: string;
+          credential: {
+            clientExtensionResults: {
+              [key: string]: unknown;
+            };
+            id: string;
+            rawId: string;
+            response: {
+              authenticatorData: string;
+              clientDataJSON: string;
+              signature: string;
+              userHandle?: string;
+            };
+            /** @enum {string} */
+            type: 'public-key';
+          } & {
+            [key: string]: unknown;
+          };
+        };
+      };
+    };
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
         };
       };
       /** @description 意料之外的服务器错误 */
@@ -4747,7 +7864,7 @@ export interface operations {
       };
       cookie?: never;
     };
-    requestBody?: {
+    requestBody: {
       content: {
         'application/json': components['schemas']['UpdateContent'];
       };
@@ -4970,6 +8087,7 @@ export interface operations {
             mainID: number;
             reactions?: components['schemas']['Reaction'][];
             relatedID: number;
+            relatedPhotoID?: number;
             state: number;
             user?: components['schemas']['SlimUser'];
           } & {
@@ -5006,7 +8124,7 @@ export interface operations {
       };
       cookie?: never;
     };
-    requestBody?: {
+    requestBody: {
       content: {
         'application/json': components['schemas']['CreateReply'] &
           components['schemas']['TurnstileToken'];
@@ -5023,6 +8141,353 @@ export interface operations {
             /** @description new comment id */
             id: number;
           };
+        };
+      };
+      /** @description default error response type */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getPersonIndexes: {
+    parameters: {
+      query?: {
+        /** @description max 100 */
+        limit?: number;
+        /** @description min 0 */
+        offset?: number;
+      };
+      header?: never;
+      path: {
+        personID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: components['schemas']['SlimIndex'][];
+            /** @description limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+            total: number;
+          };
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getPersonPhotos: {
+    parameters: {
+      query?: {
+        /** @description max 100 */
+        limit?: number;
+        /** @description min 0 */
+        offset?: number;
+      };
+      header?: never;
+      path: {
+        personID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: components['schemas']['MonoPhoto'][];
+            /** @description limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+            total: number;
+          };
+        };
+      };
+      /** @description default error response type */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getPersonPhotoPreview: {
+    parameters: {
+      query?: {
+        /** @description max 20 */
+        limit?: number;
+      };
+      header?: never;
+      path: {
+        personID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: components['schemas']['MonoPhoto'][];
+            /** @description limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+            total: number;
+          };
+        };
+      };
+      /** @description default error response type */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getPersonPhoto: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        personID: number;
+        photoID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['MonoPhoto'];
+        };
+      };
+      /** @description default error response type */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getPersonPhotoComments: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        personID: number;
+        photoID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': ({
+            content: string;
+            createdAt: number;
+            creatorID: number;
+            id: number;
+            mainID: number;
+            reactions?: components['schemas']['Reaction'][];
+            relatedID: number;
+            relatedPhotoID?: number;
+            state: number;
+            user?: components['schemas']['SlimUser'];
+          } & {
+            replies: components['schemas']['CommentBase'][];
+          })[];
+        };
+      };
+      /** @description default error response type */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  createPersonPhotoComment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        personID: number;
+        photoID: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['CreateReply'] &
+          components['schemas']['TurnstileToken'];
+      };
+    };
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            /** @description new comment id */
+            id: number;
+          };
+        };
+      };
+      /** @description default error response type */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description default error response type */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getPersonRelations: {
+    parameters: {
+      query?: {
+        /** @description max 100 */
+        limit?: number;
+        /** @description min 0 */
+        offset?: number;
+      };
+      header?: never;
+      path: {
+        personID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: components['schemas']['PersonRelation'][];
+            /** @description limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+            total: number;
+          };
+        };
+      };
+      /** @description default error response type */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
         };
       };
       /** @description 意料之外的服务器错误 */
@@ -5088,6 +8553,212 @@ export interface operations {
       };
     };
   };
+  getPrivacy: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            preferences: {
+              allowNsfw: boolean;
+              canSetNsfwSubject: boolean;
+              showNsfwSubject: boolean;
+            };
+            settings: {
+              /** @enum {string} */
+              commentNotification: 'all' | 'friends' | 'none';
+              /** @enum {string} */
+              follow: 'all' | 'none';
+              /** @enum {string} */
+              friendNotification: 'all' | 'none';
+              /** @enum {string} */
+              mentionNotification: 'all' | 'friends' | 'none';
+              /** @enum {string} */
+              privateMessage: 'all' | 'friends' | 'none';
+              /** @enum {string} */
+              timelineCollectReply: 'all' | 'friends' | 'none';
+              /** @enum {string} */
+              timelineReply: 'all' | 'friends' | 'none';
+            };
+          };
+        };
+      };
+      /** @description default error response type */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  patchPrivacy: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': {
+          preferences?: {
+            showNsfwSubject?: boolean;
+          };
+          settings?: {
+            /** @enum {string} */
+            commentNotification?: 'all' | 'friends' | 'none';
+            /** @enum {string} */
+            follow?: 'all' | 'none';
+            /** @enum {string} */
+            friendNotification?: 'all' | 'none';
+            /** @enum {string} */
+            mentionNotification?: 'all' | 'friends' | 'none';
+            /** @enum {string} */
+            privateMessage?: 'all' | 'friends' | 'none';
+            /** @enum {string} */
+            timelineCollectReply?: 'all' | 'friends' | 'none';
+            /** @enum {string} */
+            timelineReply?: 'all' | 'friends' | 'none';
+          };
+        };
+      };
+    };
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            preferences: {
+              allowNsfw: boolean;
+              canSetNsfwSubject: boolean;
+              showNsfwSubject: boolean;
+            };
+            settings: {
+              /** @enum {string} */
+              commentNotification: 'all' | 'friends' | 'none';
+              /** @enum {string} */
+              follow: 'all' | 'none';
+              /** @enum {string} */
+              friendNotification: 'all' | 'none';
+              /** @enum {string} */
+              mentionNotification: 'all' | 'friends' | 'none';
+              /** @enum {string} */
+              privateMessage: 'all' | 'friends' | 'none';
+              /** @enum {string} */
+              timelineCollectReply: 'all' | 'friends' | 'none';
+              /** @enum {string} */
+              timelineReply: 'all' | 'friends' | 'none';
+            };
+          };
+        };
+      };
+      /** @description default error response type */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description default error response type */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description default error response type */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  createReport: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['CreateReport'];
+      };
+    };
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            message: string;
+          };
+        };
+      };
+      /** @description default error response type */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
   searchCharacters: {
     parameters: {
       query?: {
@@ -5100,7 +8771,7 @@ export interface operations {
       path?: never;
       cookie?: never;
     };
-    requestBody?: {
+    requestBody: {
       content: {
         'application/json': components['schemas']['SearchCharacter'];
       };
@@ -5142,7 +8813,7 @@ export interface operations {
       path?: never;
       cookie?: never;
     };
-    requestBody?: {
+    requestBody: {
       content: {
         'application/json': components['schemas']['SearchPerson'];
       };
@@ -5184,7 +8855,7 @@ export interface operations {
       path?: never;
       cookie?: never;
     };
-    requestBody?: {
+    requestBody: {
       content: {
         'application/json': components['schemas']['SearchSubject'];
       };
@@ -5230,6 +8901,8 @@ export interface operations {
         /** @description 月份 */
         month?: number;
         tags?: string[];
+        /** @description tags 过滤类别：meta=wiki 标签（默认），subject=用户标签 */
+        tagsCat?: 'meta' | 'subject';
       };
       header?: never;
       path?: never;
@@ -5248,6 +8921,83 @@ export interface operations {
             /** @description limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
             total: number;
           };
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  likeSubjectCollect: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        collectID: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': {
+          value: number;
+        };
+      };
+    };
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': Record<string, never>;
+        };
+      };
+      /** @description default error response type */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  unlikeSubjectCollect: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        collectID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': Record<string, never>;
         };
       };
       /** @description 意料之外的服务器错误 */
@@ -5301,7 +9051,7 @@ export interface operations {
       };
       cookie?: never;
     };
-    requestBody?: {
+    requestBody: {
       content: {
         'application/json': components['schemas']['UpdateContent'];
       };
@@ -5345,6 +9095,121 @@ export interface operations {
         };
         content: {
           'application/json': Record<string, never>;
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  likeSubjectPost: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        postID: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': {
+          value: number;
+        };
+      };
+    };
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': Record<string, never>;
+        };
+      };
+      /** @description default error response type */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  unlikeSubjectPost: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        postID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': Record<string, never>;
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getRecentSubjectTopics: {
+    parameters: {
+      query?: {
+        /** @description max 100 */
+        limit?: number;
+        /** @description min 0 */
+        offset?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: components['schemas']['SubjectTopic'][];
+            /** @description limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+            total: number;
+          };
         };
       };
       /** @description 意料之外的服务器错误 */
@@ -5437,7 +9302,7 @@ export interface operations {
       };
       cookie?: never;
     };
-    requestBody?: {
+    requestBody: {
       content: {
         'application/json': components['schemas']['CreateReply'] &
           components['schemas']['TurnstileToken'];
@@ -5453,6 +9318,15 @@ export interface operations {
           'application/json': {
             id: number;
           };
+        };
+      };
+      /** @description default error response type */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
         };
       };
       /** @description 意料之外的服务器错误 */
@@ -5539,6 +9413,48 @@ export interface operations {
       };
     };
   };
+  getSubjectCollects: {
+    parameters: {
+      query?: {
+        type?: components['schemas']['CollectionType'];
+        mode?: components['schemas']['FilterMode'];
+        /** @description max 100 */
+        limit?: number;
+        /** @description min 0 */
+        offset?: number;
+      };
+      header?: never;
+      path: {
+        subjectID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: components['schemas']['SubjectCollect'][];
+            /** @description limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+            total: number;
+          };
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
   getSubjectComments: {
     parameters: {
       query?: {
@@ -5605,6 +9521,46 @@ export interface operations {
         content: {
           'application/json': {
             data: components['schemas']['Episode'][];
+            /** @description limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+            total: number;
+          };
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getSubjectIndexes: {
+    parameters: {
+      query?: {
+        /** @description max 100 */
+        limit?: number;
+        /** @description min 0 */
+        offset?: number;
+      };
+      header?: never;
+      path: {
+        subjectID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: components['schemas']['SlimIndex'][];
             /** @description limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
             total: number;
           };
@@ -5875,7 +9831,7 @@ export interface operations {
       };
       cookie?: never;
     };
-    requestBody?: {
+    requestBody: {
       content: {
         'application/json': components['schemas']['CreateTopic'] &
           components['schemas']['TurnstileToken'];
@@ -5894,6 +9850,15 @@ export interface operations {
           };
         };
       };
+      /** @description default error response type */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
       /** @description 意料之外的服务器错误 */
       500: {
         headers: {
@@ -5908,8 +9873,7 @@ export interface operations {
   getTimeline: {
     parameters: {
       query?: {
-        /** @description 登录时默认为 friends, 未登录或没有好友时始终为 all */
-        mode?: components['schemas']['TimelineFilterMode'];
+        mode?: components['schemas']['FilterMode'];
         /** @description min 1, max 20 */
         limit?: number;
         /** @description max timeline id to fetch from */
@@ -5948,7 +9912,7 @@ export interface operations {
       path?: never;
       cookie?: never;
     };
-    requestBody?: {
+    requestBody: {
       content: {
         'application/json': components['schemas']['CreateContent'] &
           components['schemas']['TurnstileToken'];
@@ -5966,6 +9930,51 @@ export interface operations {
           };
         };
       };
+      /** @description default error response type */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getTimelineEvents: {
+    parameters: {
+      query?: {
+        cat?: components['schemas']['TimelineCat'];
+        mode?: components['schemas']['FilterMode'];
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description SSE 事件数据 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            /** @description 事件类型: 'connected' | 'timeline' */
+            event: string;
+            timeline?: components['schemas']['Timeline'];
+          };
+        };
+      };
       /** @description 意料之外的服务器错误 */
       500: {
         headers: {
@@ -5978,6 +9987,83 @@ export interface operations {
     };
   };
   deleteTimeline: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        timelineID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': Record<string, never>;
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  likeTimeline: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        timelineID: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': {
+          value: number;
+        };
+      };
+    };
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': Record<string, never>;
+        };
+      };
+      /** @description default error response type */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  unlikeTimeline: {
     parameters: {
       query?: never;
       header?: never;
@@ -6033,6 +10119,7 @@ export interface operations {
             mainID: number;
             reactions?: components['schemas']['Reaction'][];
             relatedID: number;
+            relatedPhotoID?: number;
             state: number;
             user?: components['schemas']['SlimUser'];
           } & {
@@ -6069,7 +10156,7 @@ export interface operations {
       };
       cookie?: never;
     };
-    requestBody?: {
+    requestBody: {
       content: {
         'application/json': components['schemas']['CreateReply'] &
           components['schemas']['TurnstileToken'];
@@ -6085,6 +10172,15 @@ export interface operations {
           'application/json': {
             id: number;
           };
+        };
+      };
+      /** @description default error response type */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
         };
       };
       /** @description 意料之外的服务器错误 */
@@ -6627,6 +10723,503 @@ export interface operations {
       };
     };
   };
+  postCharacterInfo: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': {
+          /** @description when header x-admin-token is provided, use this as author id. */
+          authorID?: number;
+          character: {
+            /**
+             * Format: byte
+             * @description base64 encoded raw bytes, 4mb size limit on **decoded** size
+             */
+            img?: string;
+            infobox: string;
+            name: string;
+            summary: string;
+            type: components['schemas']['CharacterType'];
+          };
+        };
+      };
+    };
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            characterID: number;
+          };
+        };
+      };
+      /** @description default error response type */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description default error response type */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getCharacterCastRevisionInfo: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        revisionID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['CharacterCastRevisionWikiInfo'];
+        };
+      };
+      /** @description default error response type */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getCharacterRevisionInfo: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        revisionID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['CharacterRevisionWikiInfo'];
+        };
+      };
+      /** @description default error response type */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getCharacterSubjectRevisionInfo: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        revisionID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['CharacterSubjectRevisionWikiInfo'];
+        };
+      };
+      /** @description default error response type */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getCharacterWikiInfo: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        characterID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['CharacterWikiInfo'];
+        };
+      };
+      /** @description default error response type */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description default error response type */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  patchCharacterInfo: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        characterID: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': {
+          /** @description when header x-admin-token is provided, use this as author id. */
+          authorID?: number;
+          character: {
+            infobox?: string;
+            name?: string;
+            summary?: string;
+          };
+          commitMessage: string;
+          /** @default {} */
+          expectedRevision: {
+            infobox?: string;
+            name?: string;
+            summary?: string;
+          };
+        };
+      };
+    };
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': Record<string, never>;
+        };
+      };
+      /** @description default error response type */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description default error response type */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description default error response type */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  characterCastHistorySummary: {
+    parameters: {
+      query?: {
+        /** @description max 100 */
+        limit?: number;
+        /** @description min 0 */
+        offset?: number;
+      };
+      header?: never;
+      path: {
+        characterID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: components['schemas']['RevisionHistory'][];
+            /** @description limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+            total: number;
+          };
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  characterEditHistorySummary: {
+    parameters: {
+      query?: {
+        /** @description max 100 */
+        limit?: number;
+        /** @description min 0 */
+        offset?: number;
+      };
+      header?: never;
+      path: {
+        characterID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: components['schemas']['RevisionHistory'][];
+            /** @description limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+            total: number;
+          };
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  uploadCharacterPortrait: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        characterID: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': {
+          /** @description when header x-admin-token is provided, use this as author id. */
+          authorID?: number;
+          /**
+           * Format: byte
+           * @description base64 encoded raw bytes, 4mb size limit on **decoded** size
+           */
+          img: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            /** @description image filename */
+            img: string;
+          };
+        };
+      };
+      /** @description default error response type */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description default error response type */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  characterSubjectHistorySummary: {
+    parameters: {
+      query?: {
+        /** @description max 100 */
+        limit?: number;
+        /** @description min 0 */
+        offset?: number;
+      };
+      header?: never;
+      path: {
+        characterID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: components['schemas']['RevisionHistory'][];
+            /** @description limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+            total: number;
+          };
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
   getEpisodeWikiInfo: {
     parameters: {
       query?: never;
@@ -6678,7 +11271,8 @@ export interface operations {
     };
     requestBody: {
       content: {
-        /** @example {
+        /**
+         * @example {
          *       "commitMessage": "why this episode is edited",
          *       "episode": {
          *         "date": "2022-01-20",
@@ -6693,8 +11287,11 @@ export interface operations {
          *         "name": "old name",
          *         "nameCN": "old cn name"
          *       }
-         *     } */
+         *     }
+         */
         'application/json': {
+          /** @description when header x-admin-token is provided, use this as author id. */
+          authorID?: number;
           commitMessage: string;
           episode: {
             /**
@@ -6712,8 +11309,6 @@ export interface operations {
             summary?: string;
             type?: components['schemas']['EpisodeType'];
           };
-          /** @description a optional object to check if input is changed by others
-           *     if some key is given, and current data in database doesn't match input, subject will not be changed */
           expectedRevision?: {
             date?: string;
             duration?: string;
@@ -6800,6 +11395,202 @@ export interface operations {
       };
     };
   };
+  postPersonInfo: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': {
+          /** @description when header x-admin-token is provided, use this as author id. */
+          authorID?: number;
+          person: {
+            /**
+             * Format: byte
+             * @description base64 encoded raw bytes, 4mb size limit on **decoded** size
+             */
+            img?: string;
+            infobox: string;
+            name: string;
+            profession?: {
+              actor?: boolean;
+              artist?: boolean;
+              illustrator?: boolean;
+              mangaka?: boolean;
+              producer?: boolean;
+              seiyu?: boolean;
+              writer?: boolean;
+            };
+            summary: string;
+            type: components['schemas']['PersonType'];
+          };
+        };
+      };
+    };
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            personID: number;
+          };
+        };
+      };
+      /** @description default error response type */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description default error response type */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getPersonCastRevisionInfo: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        revisionID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['PersonCastRevisionWikiInfo'];
+        };
+      };
+      /** @description default error response type */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getPersonRevisionInfo: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        revisionID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['PersonRevisionWikiInfo'];
+        };
+      };
+      /** @description default error response type */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getPersonSubjectRevisionInfo: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        revisionID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['PersonSubjectRevisionWikiInfo'];
+        };
+      };
+      /** @description default error response type */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
   getPersonWikiInfo: {
     parameters: {
       query?: never;
@@ -6829,7 +11620,7 @@ export interface operations {
           'application/json': components['schemas']['ErrorResponse'];
         };
       };
-      /** @description 角色不存在 */
+      /** @description 人物不存在 */
       404: {
         headers: {
           [name: string]: unknown;
@@ -6861,6 +11652,8 @@ export interface operations {
     requestBody: {
       content: {
         'application/json': {
+          /** @description when header x-admin-token is provided, use this as author id. */
+          authorID?: number;
           commitMessage: string;
           /** @default {} */
           expectedRevision: {
@@ -6871,6 +11664,15 @@ export interface operations {
           person: {
             infobox?: string;
             name?: string;
+            profession?: {
+              actor?: boolean;
+              artist?: boolean;
+              illustrator?: boolean;
+              mangaka?: boolean;
+              producer?: boolean;
+              seiyu?: boolean;
+              writer?: boolean;
+            };
             summary?: string;
           };
         };
@@ -6904,6 +11706,15 @@ export interface operations {
           'application/json': components['schemas']['ErrorResponse'];
         };
       };
+      /** @description default error response type */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
       /** @description 意料之外的服务器错误 */
       500: {
         headers: {
@@ -6915,14 +11726,344 @@ export interface operations {
       };
     };
   };
-  getRecentWiki: {
+  personCastHistorySummary: {
+    parameters: {
+      query?: {
+        /** @description max 100 */
+        limit?: number;
+        /** @description min 0 */
+        offset?: number;
+      };
+      header?: never;
+      path: {
+        personID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: components['schemas']['RevisionHistory'][];
+            /** @description limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+            total: number;
+          };
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  personEditHistorySummary: {
+    parameters: {
+      query?: {
+        /** @description max 100 */
+        limit?: number;
+        /** @description min 0 */
+        offset?: number;
+      };
+      header?: never;
+      path: {
+        personID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: components['schemas']['RevisionHistory'][];
+            /** @description limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+            total: number;
+          };
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  uploadPersonPortrait: {
     parameters: {
       query?: never;
       header?: never;
       path: {
-        /** @description unix time stamp, only return last update time >= since
+        personID: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': {
+          /** @description when header x-admin-token is provided, use this as author id. */
+          authorID?: number;
+          /**
+           * Format: byte
+           * @description base64 encoded raw bytes, 4mb size limit on **decoded** size
+           */
+          img: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            /** @description image filename */
+            img: string;
+          };
+        };
+      };
+      /** @description default error response type */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description default error response type */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  personSubjectHistorySummary: {
+    parameters: {
+      query?: {
+        /** @description max 100 */
+        limit?: number;
+        /** @description min 0 */
+        offset?: number;
+      };
+      header?: never;
+      path: {
+        personID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: components['schemas']['RevisionHistory'][];
+            /** @description limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+            total: number;
+          };
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getRecentCharacterWiki: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /**
+         * @description unix time stamp, only return last update time >= since
          *
-         *     only allow recent 2 days */
+         *     only allow recent 2 days
+         */
+        since: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            createdAt: number;
+            id: number;
+          }[];
+        };
+      };
+      /** @description default error response type */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getRecentEpisodeWiki: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /**
+         * @description unix time stamp, only return last update time >= since
+         *
+         *     only allow recent 2 days
+         */
+        since: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            createdAt: number;
+            id: number;
+          }[];
+        };
+      };
+      /** @description default error response type */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getRecentPersonWiki: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /**
+         * @description unix time stamp, only return last update time >= since
+         *
+         *     only allow recent 2 days
+         */
+        since: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            createdAt: number;
+            id: number;
+          }[];
+        };
+      };
+      /** @description default error response type */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getRecentSubjectWiki: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /**
+         * @description unix time stamp, only return last update time >= since
+         *
+         *     only allow recent 2 days
+         */
         since: number;
       };
       cookie?: never;
@@ -6968,11 +12109,14 @@ export interface operations {
     requestBody: {
       content: {
         'application/json': {
+          /** @example 0000-00-00 */
+          date?: string;
           infobox: string;
           metaTags: string[];
           name: string;
           nsfw: boolean;
           platform: number;
+          series?: boolean;
           summary: string;
           type: components['schemas']['SubjectType'];
         };
@@ -7001,6 +12145,166 @@ export interface operations {
       };
       /** @description default error response type */
       401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getSubjectCharacterRevisionInfo: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        revisionID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['SubjectCharacterRevisionWikiInfo'];
+        };
+      };
+      /** @description default error response type */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getSubjectPersonRevisionInfo: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        revisionID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['SubjectPersonRevisionWikiInfo'];
+        };
+      };
+      /** @description default error response type */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getSubjectRelationRevisionInfo: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        revisionID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['SubjectRelationRevisionWikiInfo'];
+        };
+      };
+      /** @description default error response type */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getSubjectRevisionInfo: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        revisionID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['SubjectRevisionWikiInfo'];
+        };
+      };
+      /** @description default error response type */
+      404: {
         headers: {
           [name: string]: unknown;
         };
@@ -7048,6 +12352,15 @@ export interface operations {
           'application/json': components['schemas']['ErrorResponse'];
         };
       };
+      /** @description default error response type */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
       /** @description 意料之外的服务器错误 */
       500: {
         headers: {
@@ -7070,25 +12383,26 @@ export interface operations {
     };
     requestBody: {
       content: {
-        /** @example {
+        /**
+         * @example {
          *       "commitMessage": "修正笔误",
          *       "subject": {
-         *         "infobox": "{{Infobox animanga/TVAnime\n|中文名= 沙盒\n|别名={\n}\n|话数= 7\n|放送开始= 0000-10-06\n|放送星期= \n|官方网站= \n|播放电视台= \n|其他电视台= \n|播放结束= \n|其他= \n|Copyright= \n|平台={\n[龟壳]\n[Xbox Series S]\n[Xbox Series X]\n[Xbox Series X/S]\n[PC]\n[Xbox Series X|S]\n}\n}}",
+         *         "infobox": "{{Infobox animanga/TVAnime\n|中文名= 沙盒\n|别名={\n}\n|话数= 7\n|放送开始= 0000-10-06\n|放送星期=\n|官方网站=\n|播放电视台=\n|其他电视台=\n|播放结束=\n|其他=\n|Copyright=\n|平台={\n[龟壳]\n[Xbox Series S]\n[Xbox Series X]\n[Xbox Series X/S]\n[PC]\n[Xbox Series X|S]\n}\n}}",
          *         "name": "沙盒",
          *         "nsfw": false,
          *         "platform": 0,
          *         "summary": "本条目是一个沙盒，可以用于尝试bgm功能。\n\n普通维基人可以随意编辑条目信息以及相关关联查看编辑效果，但是请不要完全删除沙盒说明并且不要关联非沙盒条目/人物/角色。\n\nhttps://bgm.tv/group/topic/366812#post_1923517"
          *       }
-         *     } */
+         *     }
+         */
         'application/json': {
           commitMessage: string;
-          /** @description a optional object to check if input is changed by others
-           *     if `infobox` is given, and current data in database doesn't match input, subject will not be changed */
           expectedRevision?: {
-            infobox?: string;
-            metaTags?: string[];
-            name?: string;
-            platform?: number;
+            infobox?: null | string;
+            metaTags?: null | string[];
+            name?: null | string;
+            platform?: null | number;
+            summary?: null | string;
           };
           subject: components['schemas']['SubjectEdit'];
         };
@@ -7133,29 +12447,25 @@ export interface operations {
     };
     requestBody: {
       content: {
-        /** @example {
+        /**
+         * @example {
          *       "commitMessage": "修正笔误",
          *       "subject": {
-         *         "infobox": "{{Infobox animanga/TVAnime\n|中文名= 沙盒\n|别名={\n}\n|话数= 7\n|放送开始= 0000-10-06\n|放送星期= \n|官方网站= \n|播放电视台= \n|其他电视台= \n|播放结束= \n|其他= \n|Copyright= \n|平台={\n[龟壳]\n[Xbox Series S]\n[Xbox Series X]\n[Xbox Series X/S]\n[PC]\n[Xbox Series X|S]\n}\n}}"
+         *         "infobox": "{{Infobox animanga/TVAnime\n|中文名= 沙盒\n|别名={\n}\n|话数= 7\n|放送开始= 0000-10-06\n|放送星期=\n|官方网站=\n|播放电视台=\n|其他电视台=\n|播放结束=\n|其他=\n|Copyright=\n|平台={\n[龟壳]\n[Xbox Series S]\n[Xbox Series X]\n[Xbox Series X/S]\n[PC]\n[Xbox Series X|S]\n}\n}}"
          *       }
-         *     } */
+         *     }
+         */
         'application/json': {
+          /** @description when header x-admin-token is provided, use this as author id. */
+          authorID?: number;
           commitMessage: string;
-          /** @description a optional object to check if input is changed by others
-           *     if `infobox` is given, and current data in database doesn't match input, subject will not be changed */
           expectedRevision?: {
-            infobox?: string;
-            metaTags?: string[];
-            name?: string;
-            platform?: number;
+            infobox?: null | string;
+            metaTags?: null | string[];
+            name?: null | string;
+            platform?: null | number;
+            summary?: null | string;
           };
-          /** @example {
-           *       "infobox": "{{Infobox animanga/TVAnime\n|中文名= 沙盒\n|别名={\n}\n|话数= 7\n|放送开始= 0000-10-06\n|放送星期= \n|官方网站= \n|播放电视台= \n|其他电视台= \n|播放结束= \n|其他= \n|Copyright= \n|平台={\n[龟壳]\n[Xbox Series S]\n[Xbox Series X]\n[Xbox Series X/S]\n[PC]\n[Xbox Series X|S]\n}\n}}",
-           *       "name": "沙盒",
-           *       "nsfw": false,
-           *       "platform": 0,
-           *       "summary": "本条目是一个沙盒，可以用于尝试bgm功能。\n\n普通维基人可以随意编辑条目信息以及相关关联查看编辑效果，但是请不要完全删除沙盒说明并且不要关联非沙盒条目/人物/角色。\n\nhttps://bgm.tv/group/topic/366812#post_1923517"
-           *     } */
           subject: {
             /** @example 0000-00-00 */
             date?: string;
@@ -7164,6 +12474,7 @@ export interface operations {
             name?: string;
             nsfw?: boolean;
             platform?: number;
+            series?: boolean;
             summary?: string;
           };
         };
@@ -7184,6 +12495,46 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  subjectCharacterHistorySummary: {
+    parameters: {
+      query?: {
+        /** @description max 100 */
+        limit?: number;
+        /** @description min 0 */
+        offset?: number;
+      };
+      header?: never;
+      path: {
+        subjectID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: components['schemas']['RevisionHistory'][];
+            /** @description limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+            total: number;
+          };
         };
       };
       /** @description 意料之外的服务器错误 */
@@ -7294,7 +12645,7 @@ export interface operations {
         };
       };
       /** @description default error response type */
-      401: {
+      403: {
         headers: {
           [name: string]: unknown;
         };
@@ -7509,7 +12860,12 @@ export interface operations {
   };
   subjectEditHistorySummary: {
     parameters: {
-      query?: never;
+      query?: {
+        /** @description max 100 */
+        limit?: number;
+        /** @description min 0 */
+        offset?: number;
+      };
       header?: never;
       path: {
         subjectID: number;
@@ -7524,7 +12880,11 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          'application/json': components['schemas']['HistorySummary'][];
+          'application/json': {
+            data: components['schemas']['RevisionHistory'][];
+            /** @description limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+            total: number;
+          };
         };
       };
       /** @description default error response type */
@@ -7534,6 +12894,86 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  subjectPersonHistorySummary: {
+    parameters: {
+      query?: {
+        /** @description max 100 */
+        limit?: number;
+        /** @description min 0 */
+        offset?: number;
+      };
+      header?: never;
+      path: {
+        subjectID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: components['schemas']['RevisionHistory'][];
+            /** @description limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+            total: number;
+          };
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  subjectRelationHistorySummary: {
+    parameters: {
+      query?: {
+        /** @description max 100 */
+        limit?: number;
+        /** @description min 0 */
+        offset?: number;
+      };
+      header?: never;
+      path: {
+        subjectID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: components['schemas']['RevisionHistory'][];
+            /** @description limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+            total: number;
+          };
         };
       };
       /** @description 意料之外的服务器错误 */
@@ -7571,6 +13011,153 @@ export interface operations {
         };
         content: {
           'application/json': Record<string, never>;
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getUserContributedCharacters: {
+    parameters: {
+      query?: {
+        /** @description max 100 */
+        limit?: number;
+        /** @description min 0 */
+        offset?: number;
+      };
+      header?: never;
+      path: {
+        username: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: components['schemas']['UserCharacterContribution'][];
+            /** @description limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+            total: number;
+          };
+        };
+      };
+      /** @description default error response type */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getUserContributedPersons: {
+    parameters: {
+      query?: {
+        /** @description max 100 */
+        limit?: number;
+        /** @description min 0 */
+        offset?: number;
+      };
+      header?: never;
+      path: {
+        username: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: components['schemas']['UserPersonContribution'][];
+            /** @description limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+            total: number;
+          };
+        };
+      };
+      /** @description default error response type */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getUserContributedSubjects: {
+    parameters: {
+      query?: {
+        /** @description max 100 */
+        limit?: number;
+        /** @description min 0 */
+        offset?: number;
+      };
+      header?: never;
+      path: {
+        username: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: components['schemas']['UserSubjectContribution'][];
+            /** @description limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+            total: number;
+          };
+        };
+      };
+      /** @description default error response type */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
         };
       };
       /** @description 意料之外的服务器错误 */

--- a/packages/website/src/pages/index/group/[name]/__tests__/fixtures/recent-topics.json
+++ b/packages/website/src/pages/index/group/[name]/__tests__/fixtures/recent-topics.json
@@ -9,7 +9,7 @@
       "updatedAt": 1662283112,
       "state": 2,
       "display": 1,
-      "replies": 2,
+      "replyCount": 2,
       "creator": {
         "id": 287622,
         "username": "trim21",
@@ -32,7 +32,7 @@
       "updatedAt": 1687677475,
       "state": 0,
       "display": 1,
-      "replies": 41,
+      "replyCount": 41,
       "creator": {
         "id": 287622,
         "username": "trim21",

--- a/packages/website/src/pages/index/group/[name]/components/TopicsTable.tsx
+++ b/packages/website/src/pages/index/group/[name]/components/TopicsTable.tsx
@@ -36,7 +36,7 @@ const TopicsTable: React.FC<{ topics: Topic[] }> = ({ topics }) => {
                   {topic.creator?.nickname}
                 </Typography.Link>
               </td>
-              <td className={styles.replies}>{topic.replies}</td>
+              <td className={styles.replies}>{topic.replyCount}</td>
               <td className={styles.updateTime}>
                 {dayjs(topic.updatedAt * 1000).format('YYYY-M-D')}
               </td>

--- a/packages/website/src/pages/index/group/topic/[id]/components/GroupTopicHeader.tsx
+++ b/packages/website/src/pages/index/group/topic/[id]/components/GroupTopicHeader.tsx
@@ -10,7 +10,7 @@ import styles from './GroupTopicHeader.module.less';
 interface Header {
   title: string;
   createdAt: number;
-  creator: SlimUser;
+  creator?: SlimUser;
   group: SlimGroup;
   id: number;
 }
@@ -21,12 +21,12 @@ const CommentInfo = Topic.CommentInfo;
 const GroupTopicHeader: FC<Header> = ({ title, createdAt, creator, group, id }) => {
   return (
     <div className={styles.groupTopicHeader}>
-      <Avatar src={creator.avatar.large} size='medium' />
+      <Avatar src={creator?.avatar.large ?? ''} size='medium' />
       <div className={styles.headerMain}>
         <span className={styles.navBar}>
           <div>
-            <Link to={getUserProfileLink(creator.username)} isExternal>
-              {creator.nickname}
+            <Link to={getUserProfileLink(creator?.username ?? '')} isExternal>
+              {creator?.nickname}
             </Link>
             <span>发表于</span>
             <Link to={`/group/${group.name}`}>{group.title}</Link>

--- a/packages/website/src/pages/index/notifications/index.tsx
+++ b/packages/website/src/pages/index/notifications/index.tsx
@@ -22,7 +22,7 @@ const NotificationPageTabs = [
 ];
 
 function NoticeItem({ notice }: { notice: ozaClient.Notice }) {
-  const { id, type, title, postID, topicID, sender, createdAt, unread } = notice;
+  const { id, type, title, mainID, relatedID, sender, createdAt, unread } = notice;
 
   const setting = settings[type];
 
@@ -49,7 +49,7 @@ function NoticeItem({ notice }: { notice: ozaClient.Notice }) {
       <span className={style.noticeItemBody}>
         {setting.prefix}
         <Typography.Link
-          to={`${setting.url}/${topicID}${setting.append ?? ''}${setting.anchor}${postID}`}
+          to={`${setting.url}/${mainID}${setting.append ?? ''}${setting.anchor}${relatedID}`}
           onClick={() => {
             ozaClient.clearNotice({
               id: [id],

--- a/packages/website/src/pages/index/subject/[id]/wiki.tsx
+++ b/packages/website/src/pages/index/subject/[id]/wiki.tsx
@@ -12,8 +12,8 @@ import WikiLayout from './components/WikiLayout';
 interface WikiContext {
   subjectId: number;
   subjectWikiInfo: ozaClient.SubjectWikiInfo;
-  subjectEditHistory: ozaClient.HistorySummary[];
-  mutateHistory: KeyedMutator<ozaClient.HistorySummary[]>;
+  subjectEditHistory: ozaClient.RevisionHistory[];
+  mutateHistory: KeyedMutator<ozaClient.RevisionHistory[]>;
 }
 
 const WikiPage = ({ subjectId }: { subjectId: number }) => {
@@ -27,7 +27,7 @@ const WikiPage = ({ subjectId }: { subjectId: number }) => {
 
   const { data: history, mutate: mutateHistory } = useSWR(
     `/wiki/subjects/${subjectId}/history`,
-    async () => ok(ozaClient.subjectEditHistorySummary(subjectId)),
+    async () => (await ok(ozaClient.subjectEditHistorySummary(subjectId, { limit: 20 }))).data,
     {
       suspense: true,
     },


### PR DESCRIPTION
更新 private API SDK 至最新定义，并修复受影响的调用点。

## 变更

- `packages/client/api.yaml`：同步 `bangumi/dev-docs` 最新 openapi 定义（8852 → 14062 行）
- `packages/client/client.ts` / `types/index.ts`：由 oazapfts / openapi-typescript 重新生成
- 修复 API 变更带来的调用点问题：
  - `Topic.replies` → `Topic.replyCount`
  - `GroupTopicHeader` 的 `creator` 改为可选
  - `Notice.postID/topicID` → `mainID/relatedID`
  - `HistorySummary` → `RevisionHistory`，`subjectEditHistorySummary` 适配分页参数
  - 测试 fixture 同步 `replyCount`

## 验证

- [x] `pnpm type-check`
- [x] `pnpm lint`
- [x] `pnpm test`（37 files / 229 tests）
- [x] `pnpm prettier:check`
- [x] `pnpm build --mode stage`

close #750
close #751