### PR TITLE
feat: add subject home page

### DIFF
--- a/packages/client/api.json
+++ b/packages/client/api.json
@@ -3929,6 +3929,81 @@
           }
         }
       },
+      "SubjectHomeResponse": {
+        "type": "object",
+        "required": [
+          "subject",
+          "episodes",
+          "characters",
+          "staff",
+          "relations",
+          "recs",
+          "comments",
+          "reviews",
+          "indexes",
+          "topics"
+        ],
+        "properties": {
+          "subject": {
+            "$ref": "#/components/schemas/Subject"
+          },
+          "episodes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Episode"
+            }
+          },
+          "characters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SubjectCharacter"
+            }
+          },
+          "staff": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SubjectStaff"
+            }
+          },
+          "relations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SubjectRelation"
+            }
+          },
+          "recs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SubjectRec"
+            }
+          },
+          "comments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SubjectInterestComment"
+            }
+          },
+          "reviews": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SubjectReview"
+            }
+          },
+          "indexes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SlimIndex"
+            }
+          },
+          "topics": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Topic"
+            }
+          }
+        },
+        "title": "SubjectHomeResponse"
+      },
       "TrendingSubject": {
         "type": "object",
         "required": ["subject", "count"],
@@ -13990,6 +14065,52 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "意料之外的服务器错误",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/p1/subjects/{subjectID}/home": {
+      "get": {
+        "operationId": "getSubjectHome",
+        "summary": "获取条目首页数据",
+        "tags": ["subject"],
+        "description": "聚合条目详情页所需的全部数据：条目信息、章节、角色、制作人员、相关条目、推荐、吐槽、相关日志、收录与讨论。已登录时返回个人收藏状态与章节观看状态。各个区块独立计算，单个区块失败时返回空数据，不影响其他区块。",
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer"
+            },
+            "in": "path",
+            "name": "subjectID",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "CookiesSession": [],
+            "HTTPBearer": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubjectHomeResponse"
                 }
               }
             }

--- a/packages/client/client.ts
+++ b/packages/client/client.ts
@@ -799,6 +799,18 @@ export type SubjectCollect = {
   user: SlimUser;
   interest: SlimSubjectInterest;
 };
+export type SubjectHomeResponse = {
+  subject: Subject;
+  episodes: Episode[];
+  characters: SubjectCharacter[];
+  staff: SubjectStaff[];
+  relations: SubjectRelation[];
+  recs: SubjectRec[];
+  comments: SubjectInterestComment[];
+  reviews: SubjectReview[];
+  indexes: SlimIndex[];
+  topics: Topic[];
+};
 export type CreateContent = {
   content: string;
 };
@@ -5158,6 +5170,23 @@ export function createSubjectReply(
       body,
     }),
   );
+}
+/**
+ * 获取条目首页数据
+ */
+export function getSubjectHome(subjectId: number, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: SubjectHomeResponse;
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(`/p1/subjects/${encodeURIComponent(subjectId)}/home`, {
+    ...opts,
+  });
 }
 /**
  * 获取时间线

--- a/packages/client/types/index.ts
+++ b/packages/client/types/index.ts
@@ -1707,6 +1707,26 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/p1/subjects/{subjectID}/home': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * 获取条目首页数据
+     * @description 聚合条目详情页所需的全部数据：条目信息、章节、角色、制作人员、相关条目、推荐、吐槽、相关日志、收录与讨论。已登录时返回个人收藏状态与章节观看状态。各个区块独立计算，单个区块失败时返回空数据，不影响其他区块。
+     */
+    get: operations['getSubjectHome'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/p1/timeline': {
     parameters: {
       query?: never;
@@ -4321,6 +4341,19 @@ export interface components {
       famousGroups: components['schemas']['SlimGroup'][];
       hotSubjectTopics: components['schemas']['SubjectTopic'][];
       calendar: components['schemas']['Calendar'];
+    };
+    /** SubjectHomeResponse */
+    SubjectHomeResponse: {
+      subject: components['schemas']['Subject'];
+      episodes: components['schemas']['Episode'][];
+      characters: components['schemas']['SubjectCharacter'][];
+      staff: components['schemas']['SubjectStaff'][];
+      relations: components['schemas']['SubjectRelation'][];
+      recs: components['schemas']['SubjectRec'][];
+      comments: components['schemas']['SubjectInterestComment'][];
+      reviews: components['schemas']['SubjectReview'][];
+      indexes: components['schemas']['SlimIndex'][];
+      topics: components['schemas']['Topic'][];
     };
     TrendingSubject: {
       subject: components['schemas']['SlimSubject'];
@@ -9956,6 +9989,37 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getSubjectHome: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        subjectID: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['SubjectHomeResponse'];
         };
       };
       /** @description 意料之外的服务器错误 */

--- a/packages/website/src/hooks/use-subject-home.ts
+++ b/packages/website/src/hooks/use-subject-home.ts
@@ -1,0 +1,20 @@
+import { ok } from '@oazapfts/runtime';
+import useSWR from 'swr';
+
+import { ozaClient } from '@bangumi/client';
+import type { SubjectHomeResponse } from '@bangumi/client/client';
+
+export function useSubjectHome(subjectID: number): {
+  data: SubjectHomeResponse | undefined;
+  mutate: () => Promise<unknown>;
+} {
+  const { data, mutate } = useSWR(
+    `subject-home ${subjectID}`,
+    async () => ok(ozaClient.getSubjectHome(subjectID)),
+    {
+      suspense: true,
+    },
+  );
+
+  return { data, mutate };
+}

--- a/packages/website/src/mocks/fixtures/p1/subjects/12/home-GET.json
+++ b/packages/website/src/mocks/fixtures/p1/subjects/12/home-GET.json
@@ -1,0 +1,284 @@
+{
+  "subject": {
+    "id": 12,
+    "type": 2,
+    "name": "Test Anime",
+    "nameCN": "测试动画",
+    "images": {
+      "large": "https://lain.bgm.tv/pic/cover/l/00/00/12.jpg",
+      "common": "https://lain.bgm.tv/pic/cover/c/00/00/12.jpg",
+      "medium": "https://lain.bgm.tv/pic/cover/m/00/00/12.jpg",
+      "small": "https://lain.bgm.tv/pic/cover/s/00/00/12.jpg",
+      "grid": "https://lain.bgm.tv/pic/cover/g/00/00/12.jpg"
+    },
+    "info": "",
+    "infobox": [
+      { "key": "中文名", "values": [{ "v": "测试动画" }] },
+      { "key": "话数", "values": [{ "v": "12" }] },
+      { "key": "放送开始", "values": [{ "v": "2026年4月1日" }] }
+    ],
+    "summary": "这是一个用于测试的动画条目。",
+    "locked": false,
+    "metaTags": [],
+    "nsfw": false,
+    "rating": {
+      "rank": 100,
+      "total": 4321,
+      "count": [100, 90, 80, 70, 60, 50, 40, 30, 20, 10],
+      "score": 8.1
+    },
+    "collection": { "1": 100, "2": 2000, "3": 1500, "4": 300, "5": 200 },
+    "eps": 12,
+    "volumes": 0,
+    "series": false,
+    "seriesEntry": 0,
+    "redirect": 0,
+    "platform": { "id": 1, "type": "tv", "typeCN": "TV", "alias": "TV" },
+    "airtime": { "year": 2026, "month": 4, "date": "04-01", "weekday": 3 },
+    "tags": [
+      { "name": "科幻", "count": 100 },
+      { "name": "日常", "count": 80 }
+    ],
+    "interest": null
+  },
+  "episodes": [
+    {
+      "id": 100,
+      "type": 0,
+      "sort": 1,
+      "name": "第1话",
+      "nameCN": "",
+      "airdate": "2026-04-01",
+      "duration": "24m",
+      "disc": 0,
+      "desc": "",
+      "comment": 0,
+      "subjectID": 12,
+      "collection": { "status": 2 }
+    },
+    {
+      "id": 101,
+      "type": 0,
+      "sort": 2,
+      "name": "第2话",
+      "nameCN": "",
+      "airdate": "2026-04-08",
+      "duration": "24m",
+      "disc": 0,
+      "desc": "",
+      "comment": 0,
+      "subjectID": 12
+    }
+  ],
+  "characters": [
+    {
+      "character": {
+        "id": 5,
+        "name": "Test Character",
+        "nameCN": "测试角色",
+        "role": 1,
+        "info": "",
+        "images": {
+          "large": "https://lain.bgm.tv/pic/crt/l/00/00/05.jpg",
+          "medium": "https://lain.bgm.tv/pic/crt/m/00/00/05.jpg",
+          "small": "https://lain.bgm.tv/pic/crt/s/00/00/05.jpg",
+          "grid": "https://lain.bgm.tv/pic/crt/g/00/00/05.jpg"
+        },
+        "comment": 10,
+        "lock": false,
+        "nsfw": false
+      },
+      "casts": [
+        {
+          "person": {
+            "id": 8,
+            "name": "Test CV",
+            "nameCN": "测试声优",
+            "type": 1,
+            "info": "",
+            "career": ["声优"],
+            "images": {
+              "large": "https://lain.bgm.tv/pic/prsn/l/00/00/08.jpg",
+              "medium": "https://lain.bgm.tv/pic/prsn/m/00/00/08.jpg",
+              "small": "https://lain.bgm.tv/pic/prsn/s/00/00/08.jpg",
+              "grid": "https://lain.bgm.tv/pic/prsn/g/00/00/08.jpg"
+            },
+            "comment": 1,
+            "lock": false,
+            "nsfw": false
+          },
+          "relation": 0,
+          "summary": ""
+        }
+      ],
+      "type": 1,
+      "order": 1
+    }
+  ],
+  "staff": [],
+  "relations": [
+    {
+      "subject": {
+        "id": 13,
+        "type": 2,
+        "name": "Test Anime 2",
+        "nameCN": "测试动画2",
+        "images": {
+          "large": "https://lain.bgm.tv/pic/cover/l/00/00/13.jpg",
+          "common": "https://lain.bgm.tv/pic/cover/c/00/00/13.jpg",
+          "medium": "https://lain.bgm.tv/pic/cover/m/00/00/13.jpg",
+          "small": "https://lain.bgm.tv/pic/cover/s/00/00/13.jpg",
+          "grid": "https://lain.bgm.tv/pic/cover/g/00/00/13.jpg"
+        },
+        "info": "",
+        "locked": false,
+        "metaTags": [],
+        "nsfw": false,
+        "rating": { "rank": 0, "total": 0, "count": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], "score": 0 }
+      },
+      "relation": { "id": 1, "en": "续集", "cn": "续集", "jp": "続編", "desc": "" },
+      "order": 1
+    }
+  ],
+  "recs": [
+    {
+      "subject": {
+        "id": 14,
+        "type": 2,
+        "name": "Recommended Anime",
+        "nameCN": "推荐动画",
+        "images": {
+          "large": "https://lain.bgm.tv/pic/cover/l/00/00/14.jpg",
+          "common": "https://lain.bgm.tv/pic/cover/c/00/00/14.jpg",
+          "medium": "https://lain.bgm.tv/pic/cover/m/00/00/14.jpg",
+          "small": "https://lain.bgm.tv/pic/cover/s/00/00/14.jpg",
+          "grid": "https://lain.bgm.tv/pic/cover/g/00/00/14.jpg"
+        },
+        "info": "",
+        "locked": false,
+        "metaTags": [],
+        "nsfw": false,
+        "rating": { "rank": 0, "total": 0, "count": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], "score": 0 }
+      },
+      "sim": 0.9,
+      "count": 10
+    }
+  ],
+  "comments": [
+    {
+      "id": 1,
+      "user": {
+        "id": 382951,
+        "username": "382951",
+        "nickname": "树洞酱",
+        "avatar": {
+          "large": "https://lain.bgm.tv/pic/user/l/000/38/29/382951.jpg",
+          "medium": "https://lain.bgm.tv/pic/user/m/000/38/29/382951.jpg",
+          "small": "https://lain.bgm.tv/pic/user/s/000/38/29/382951.jpg"
+        },
+        "group": 10,
+        "joinedAt": 1500000000,
+        "sign": ""
+      },
+      "type": 3,
+      "rate": 8,
+      "comment": "这部动画很好看！",
+      "updatedAt": 1775000000
+    }
+  ],
+  "reviews": [
+    {
+      "id": 1,
+      "user": {
+        "id": 382951,
+        "username": "382951",
+        "nickname": "树洞酱",
+        "avatar": {
+          "large": "https://lain.bgm.tv/pic/user/l/000/38/29/382951.jpg",
+          "medium": "https://lain.bgm.tv/pic/user/m/000/38/29/382951.jpg",
+          "small": "https://lain.bgm.tv/pic/user/s/000/38/29/382951.jpg"
+        },
+        "group": 10,
+        "joinedAt": 1500000000,
+        "sign": ""
+      },
+      "entry": {
+        "id": 5,
+        "type": 1,
+        "uid": 382951,
+        "user": {
+          "id": 382951,
+          "username": "382951",
+          "nickname": "树洞酱",
+          "avatar": {
+            "large": "https://lain.bgm.tv/pic/user/l/000/38/29/382951.jpg",
+            "medium": "https://lain.bgm.tv/pic/user/m/000/38/29/382951.jpg",
+            "small": "https://lain.bgm.tv/pic/user/s/000/38/29/382951.jpg"
+          },
+          "group": 10,
+          "joinedAt": 1500000000,
+          "sign": ""
+        },
+        "title": "测试动画长评",
+        "icon": "",
+        "summary": "这是一篇长评",
+        "replies": 0,
+        "public": true,
+        "createdAt": 1774000000,
+        "updatedAt": 1774500000
+      }
+    }
+  ],
+  "indexes": [
+    {
+      "id": 3,
+      "title": "测试目录",
+      "uid": 382951,
+      "user": {
+        "id": 382951,
+        "username": "382951",
+        "nickname": "树洞酱",
+        "avatar": {
+          "large": "https://lain.bgm.tv/pic/user/l/000/38/29/382951.jpg",
+          "medium": "https://lain.bgm.tv/pic/user/m/000/38/29/382951.jpg",
+          "small": "https://lain.bgm.tv/pic/user/s/000/38/29/382951.jpg"
+        },
+        "group": 10,
+        "joinedAt": 1500000000,
+        "sign": ""
+      },
+      "type": 1,
+      "private": false,
+      "total": 10,
+      "stats": { "ncollect": 0, "nsubject": 10 },
+      "createdAt": 1700000000,
+      "updatedAt": 1774000000
+    }
+  ],
+  "topics": [
+    {
+      "id": 50,
+      "title": "讨论版测试话题",
+      "creator": {
+        "id": 382951,
+        "username": "382951",
+        "nickname": "树洞酱",
+        "avatar": {
+          "large": "https://lain.bgm.tv/pic/user/l/000/38/29/382951.jpg",
+          "medium": "https://lain.bgm.tv/pic/user/m/000/38/29/382951.jpg",
+          "small": "https://lain.bgm.tv/pic/user/s/000/38/29/382951.jpg"
+        },
+        "group": 10,
+        "joinedAt": 1500000000,
+        "sign": ""
+      },
+      "creatorID": 382951,
+      "parentID": 12,
+      "replyCount": 5,
+      "state": 0,
+      "display": 1,
+      "createdAt": 1773000000,
+      "updatedAt": 1774000000
+    }
+  ]
+}

--- a/packages/website/src/pages/index/subject/[id]/SubjectDetail.spec.tsx
+++ b/packages/website/src/pages/index/subject/[id]/SubjectDetail.spec.tsx
@@ -1,0 +1,70 @@
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import React from 'react';
+
+import type { SubjectHomeResponse } from '@bangumi/client/client';
+import { server as mockServer } from '@bangumi/website/mocks/server';
+import { renderPage } from '@bangumi/website/utils/test-utils';
+
+import fixture from '../../../../mocks/fixtures/p1/subjects/12/home-GET.json';
+import SubjectDetail from './components/SubjectDetail';
+
+const homeData = fixture as unknown as SubjectHomeResponse;
+
+describe('SubjectDetail', () => {
+  const setup = () => {
+    mockServer.use(
+      http.get('http://localhost:3000/p1/subjects/12/home', () => {
+        return HttpResponse.json(homeData, { status: 200 });
+      }),
+    );
+  };
+
+  const renderSubject = async () => {
+    await act(async () => {
+      renderPage(<SubjectDetail data={homeData} />);
+    });
+  };
+
+  it('should render all blocks', async () => {
+    setup();
+    await renderSubject();
+
+    // header 标题
+    expect(await screen.findByText('Test Anime')).toBeInTheDocument();
+    // 左栏：信息框 / 目录 / 收藏统计
+    expect(await screen.findByText(/中文名/)).toBeInTheDocument();
+    expect(await screen.findByText('推荐本条目的目录')).toBeInTheDocument();
+    expect(await screen.findByText(/人看过/)).toBeInTheDocument();
+    // 右栏：ep / 标签 / 收藏盒
+    expect(await screen.findByText('章节列表')).toBeInTheDocument();
+    expect(await screen.findByText('标签')).toBeInTheDocument();
+    expect(await screen.findByText('收藏盒')).toBeInTheDocument();
+    // 右栏：角色 / 关联 / 推荐 / 评论 / 讨论 / 吐槽
+    expect(await screen.findByText('角色介绍')).toBeInTheDocument();
+    expect(await screen.findByText('关联条目')).toBeInTheDocument();
+    expect(await screen.findByText('喜欢这部作品的会员大概会喜欢')).toBeInTheDocument();
+    expect(await screen.findByText('测试动画长评')).toBeInTheDocument();
+    expect(await screen.findByText('讨论版测试话题')).toBeInTheDocument();
+    expect(await screen.findByText('这部动画很好看！')).toBeInTheDocument();
+  });
+
+  it('should collect subject when not collected', async () => {
+    setup();
+    let patchedBody: unknown = null;
+    mockServer.use(
+      http.put('http://localhost:3000/p1/collections/subjects/12', async ({ request }) => {
+        patchedBody = await request.json();
+        return HttpResponse.json({}, { status: 200 });
+      }),
+    );
+
+    await renderSubject();
+
+    fireEvent.click(await screen.findByRole('button', { name: '在看' }));
+
+    await waitFor(() => {
+      expect(patchedBody).toEqual({ type: 3 });
+    });
+  });
+});

--- a/packages/website/src/pages/index/subject/[id]/components/CollectionPanel.module.less
+++ b/packages/website/src/pages/index/subject/[id]/components/CollectionPanel.module.less
@@ -1,0 +1,191 @@
+@import '@bangumi/design/theme/base';
+
+.interestNow {
+  font-size: 14px;
+  margin: 0 0 8px;
+}
+
+.modifyBtn {
+  border: none;
+  background: none;
+  color: @blue-100;
+  cursor: pointer;
+  font-size: 12px;
+  margin-left: 8px;
+  padding: 0;
+
+  &:disabled {
+    color: @gray-60;
+    cursor: default;
+  }
+}
+
+.myRate {
+  font-size: 12px;
+  color: @gray-60;
+  margin: 0 0 4px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.myComment {
+  font-size: 13px;
+  margin: 4px 0 0;
+  color: @gray-100;
+  word-break: break-all;
+  white-space: pre-wrap;
+}
+
+.collectButtons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.collectBtn {
+  padding: 4px 12px;
+  border: 1px solid @blue-100;
+  color: @blue-100;
+  background: #fff;
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 13px;
+
+  &:hover {
+    background: @blue-100;
+    color: #fff;
+  }
+
+  &:disabled {
+    border-color: @gray-10;
+    color: @gray-60;
+    cursor: default;
+    background: #fff;
+  }
+}
+
+.editForm {
+  margin-top: 10px;
+  border-top: 1px solid @gray-10;
+  padding-top: 10px;
+}
+
+.formRow {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 0 0 8px;
+  font-size: 13px;
+}
+
+.formLabel {
+  flex: none;
+  color: @gray-60;
+  padding-top: 2px;
+}
+
+.typeOptions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.typeOption {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+}
+
+.rateStars {
+  display: flex;
+  gap: 2px;
+}
+
+.rateStar {
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 18px;
+  color: @gray-10;
+  padding: 0;
+  line-height: 1;
+}
+
+.rateStarFilled {
+  color: @pink-wish;
+}
+
+.rateValue {
+  color: @gray-60;
+  font-size: 12px;
+  padding-top: 2px;
+}
+
+.commentInput {
+  flex: 1;
+  min-width: 0;
+  padding: 6px;
+  border: 1px solid @gray-10;
+  border-radius: 3px;
+  font-size: 13px;
+  resize: vertical;
+}
+
+.formActions {
+  text-align: right;
+}
+
+.rating {
+  margin-top: 12px;
+  border-top: 1px solid @gray-10;
+  padding-top: 10px;
+}
+
+.scoreBlock {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.score {
+  font-size: 24px;
+  font-weight: bold;
+  color: @gray-100;
+}
+
+.rankDesc {
+  font-size: 12px;
+  color: @gray-60;
+}
+
+.ratingChart {
+  margin-top: 8px;
+}
+
+.votes {
+  font-size: 12px;
+  color: @gray-60;
+}
+
+.chart {
+  list-style: none;
+  margin: 4px 0 0;
+  padding: 0;
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  height: 40px;
+}
+
+.chartItem {
+  flex: 1;
+  display: flex;
+  align-items: flex-end;
+}
+
+.chartBar {
+  width: 100%;
+  background: @blue-doing;
+  border-radius: 1px 1px 0 0;
+}

--- a/packages/website/src/pages/index/subject/[id]/components/CollectionPanel.tsx
+++ b/packages/website/src/pages/index/subject/[id]/components/CollectionPanel.tsx
@@ -1,0 +1,212 @@
+import { ok } from '@oazapfts/runtime';
+import React, { useEffect, useState } from 'react';
+
+import { ozaClient } from '@bangumi/client';
+import type { Subject } from '@bangumi/client/client';
+import { CollectionType } from '@bangumi/client/client';
+import { Button, toast, Typography } from '@bangumi/design';
+import { useSubjectHome } from '@bangumi/website/hooks/use-subject-home';
+
+import styles from './CollectionPanel.module.less';
+import { COLLECT_DESC } from './subject-common';
+import SubjectSection from './SubjectSection';
+
+const { Link } = Typography;
+
+const COLLECT_OPTIONS: { type: CollectionType; label: string }[] = [
+  { type: CollectionType.Wish, label: '想看' },
+  { type: CollectionType.Collect, label: '看过' },
+  { type: CollectionType.Doing, label: '在看' },
+  { type: CollectionType.OnHold, label: '搁置' },
+  { type: CollectionType.Dropped, label: '抛弃' },
+];
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return '操作失败，请稍后再试';
+}
+
+/** 可点击评分星星（1-10 分，每颗星 2 分） */
+function ClickableRate({ value, onChange }: { value: number; onChange: (value: number) => void }) {
+  return (
+    <div className={styles.rateStars}>
+      {[1, 2, 3, 4, 5].map((i) => (
+        <button
+          key={i}
+          type='button'
+          className={`${styles.rateStar} ${value >= i * 2 ? styles.rateStarFilled : ''}`}
+          onClick={() => onChange(i * 2)}
+          title={`${i * 2} 分`}
+        >
+          ★
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * 收藏盒：我的收藏状态 + 收藏操作 + 全局评分，对齐 PHP panel_interest
+ */
+const CollectionPanel: React.FC<{ subject: Subject }> = ({ subject }) => {
+  const { mutate } = useSubjectHome(subject.id);
+  const interest = subject.interest;
+
+  const [editing, setEditing] = useState(false);
+  const [sending, setSending] = useState(false);
+  const [type, setType] = useState<CollectionType | undefined>(interest?.type);
+  const [rate, setRate] = useState(interest?.rate ?? 0);
+  const [comment, setComment] = useState(interest?.comment ?? '');
+
+  useEffect(() => {
+    setType(interest?.type);
+    setRate(interest?.rate ?? 0);
+    setComment(interest?.comment ?? '');
+  }, [interest]);
+
+  const submit = async () => {
+    if (type == null) {
+      toast('请选择收藏状态', { type: 'error' });
+      return;
+    }
+    setSending(true);
+    try {
+      await ok(
+        ozaClient.updateSubjectCollection(subject.id, {
+          type,
+          rate,
+          comment: comment.trim() === '' ? undefined : comment.trim(),
+        }),
+      );
+      await mutate();
+      setEditing(false);
+    } catch (error) {
+      toast(getErrorMessage(error), { type: 'error' });
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const rating = subject.rating;
+  const maxRateCount = Math.max(...rating.count, 1);
+
+  return (
+    <SubjectSection title='收藏盒'>
+      {interest != null ? (
+        <div>
+          <p className={styles.interestNow}>
+            我{COLLECT_DESC[interest.type]}这部作品
+            <button
+              type='button'
+              className={styles.modifyBtn}
+              onClick={() => setEditing(!editing)}
+              disabled={sending}
+            >
+              {editing ? '取消' : '修改'}
+            </button>
+          </p>
+          {!editing && interest.rate > 0 && (
+            <p className={styles.myRate}>
+              我的评价：
+              <ClickableRate value={interest.rate} onChange={() => undefined} />
+            </p>
+          )}
+          {!editing && interest.comment != null && interest.comment !== '' && (
+            <p className={styles.myComment}>{interest.comment}</p>
+          )}
+        </div>
+      ) : (
+        <div className={styles.collectButtons}>
+          {COLLECT_OPTIONS.map((option) => (
+            <button
+              key={option.type}
+              type='button'
+              className={styles.collectBtn}
+              disabled={sending}
+              onClick={async () => {
+                setSending(true);
+                try {
+                  await ok(ozaClient.updateSubjectCollection(subject.id, { type: option.type }));
+                  await mutate();
+                } catch (error) {
+                  toast(getErrorMessage(error), { type: 'error' });
+                } finally {
+                  setSending(false);
+                }
+              }}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {editing && (
+        <div className={styles.editForm}>
+          <div className={styles.formRow}>
+            <span className={styles.formLabel}>收藏状态</span>
+            <div className={styles.typeOptions}>
+              {COLLECT_OPTIONS.map((option) => (
+                <label key={option.type} className={styles.typeOption}>
+                  <input
+                    type='radio'
+                    name='collect-type'
+                    checked={type === option.type}
+                    onChange={() => setType(option.type)}
+                  />
+                  {option.label}
+                </label>
+              ))}
+            </div>
+          </div>
+          <div className={styles.formRow}>
+            <span className={styles.formLabel}>评分</span>
+            <ClickableRate value={rate} onChange={setRate} />
+            {rate > 0 && <span className={styles.rateValue}>{rate} 分</span>}
+          </div>
+          <div className={styles.formRow}>
+            <span className={styles.formLabel}>吐槽</span>
+            <textarea
+              className={styles.commentInput}
+              value={comment}
+              onChange={(e) => setComment(e.target.value)}
+              rows={3}
+              placeholder='说点什么...'
+            />
+          </div>
+          <div className={styles.formActions}>
+            <Button type='primary' onClick={() => void submit()} disabled={sending} size='small'>
+              保存
+            </Button>
+          </div>
+        </div>
+      )}
+
+      <div className={styles.rating}>
+        <Link to={`https://bgm.tv/subject/${subject.id}/stats`} isExternal>
+          <div className={styles.scoreBlock}>
+            <span className={styles.score}>{rating.score.toFixed(1)}</span>
+            <span className={styles.rankDesc}>{rating.rank === 0 ? '--' : `#${rating.rank}`}</span>
+          </div>
+        </Link>
+        <div className={styles.ratingChart}>
+          <div className={styles.votes}>{rating.total} votes</div>
+          <ul className={styles.chart}>
+            {rating.count.map((count, i) => (
+              <li key={i} className={styles.chartItem} title={`${i + 1}分: ${count}人`}>
+                <span
+                  className={styles.chartBar}
+                  style={{ height: `${Math.round((count / maxRateCount) * 100)}%` }}
+                />
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </SubjectSection>
+  );
+};
+
+export default CollectionPanel;

--- a/packages/website/src/pages/index/subject/[id]/components/SubjectDetail.module.less
+++ b/packages/website/src/pages/index/subject/[id]/components/SubjectDetail.module.less
@@ -1,0 +1,134 @@
+@import '@bangumi/design/theme/base';
+
+.page {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* Header */
+.header {
+  margin: 0 0 20px;
+}
+
+.name {
+  font-size: 22px;
+  font-weight: bold;
+  margin: 0 0 8px;
+}
+
+.nameCn {
+  font-size: 14px;
+  color: @gray-60;
+  margin-left: 8px;
+}
+
+.platform {
+  font-size: 12px;
+  color: @gray-60;
+  margin-left: 8px;
+}
+
+.tabs {
+  border-bottom: 1px solid @gray-10;
+}
+
+/* 布局 */
+.columns {
+  display: flex;
+  align-items: flex-start;
+  gap: 20px;
+}
+
+.columnLeft {
+  flex: 0 0 220px;
+  width: 220px;
+}
+
+.columnRight {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+@media (max-width: @md) {
+  .columns {
+    flex-direction: column;
+  }
+
+  .columnLeft {
+    flex: none;
+    width: 100%;
+  }
+}
+
+/* 左栏：信息框 */
+.infobox {
+  background: #fff;
+  border: 1px solid @gray-10;
+  border-radius: 3px;
+  margin: 0 0 20px;
+  padding: 12px;
+}
+
+.coverWrapper {
+  text-align: center;
+  margin: 0 0 12px;
+}
+
+.cover {
+  max-width: 100%;
+  border-radius: 3px;
+}
+
+.infoList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-size: 12px;
+  line-height: 1.8;
+  word-break: break-all;
+}
+
+.tip {
+  color: @gray-60;
+}
+
+/* 左栏：侧栏面板（目录/收藏统计） */
+.sidePanel {
+  background: #fff;
+  border: 1px solid @gray-10;
+  border-radius: 3px;
+  margin: 0 0 20px;
+  padding: 12px;
+}
+
+.sidePanelTitle {
+  font-size: 13px;
+  font-weight: normal;
+  margin: 0 0 8px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid @gray-10;
+}
+
+.indexList,
+.collectStats {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-size: 12px;
+  line-height: 1.8;
+}
+
+.indexList li {
+  padding: 4px 0;
+}
+
+.indexTitle {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.indexBy {
+  color: @gray-60;
+}

--- a/packages/website/src/pages/index/subject/[id]/components/SubjectDetail.tsx
+++ b/packages/website/src/pages/index/subject/[id]/components/SubjectDetail.tsx
@@ -1,0 +1,225 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+
+import type { SlimIndex, Subject, SubjectHomeResponse } from '@bangumi/client/client';
+import { CollectionType, SubjectType } from '@bangumi/client/client';
+import { Tab, Typography } from '@bangumi/design';
+
+import styles from './SubjectDetail.module.less';
+import { SubjectBlocks } from './SubjectDetailBlocks';
+
+const { Link } = Typography;
+
+const COLLECT_DESC: Record<CollectionType, string> = {
+  [CollectionType.Wish]: '想看',
+  [CollectionType.Collect]: '看过',
+  [CollectionType.Doing]: '在看',
+  [CollectionType.OnHold]: '搁置',
+  [CollectionType.Dropped]: '抛弃',
+};
+
+/** 收藏动词：看/读/听/玩 */
+function collectVerb(subjectType: number): string {
+  switch (subjectType) {
+    case 1:
+      return '读';
+    case 3:
+      return '听';
+    case 4:
+      return '玩';
+    default:
+      return '看';
+  }
+}
+
+/** 条目标题与导航 tabs，对齐 PHP subject_header */
+function SubjectHeader({ subject }: { subject: Subject }) {
+  const showEpTab =
+    subject.type === SubjectType.Anime ||
+    subject.type === SubjectType.Music ||
+    subject.type === SubjectType.Real;
+  const epLabel = subject.type === SubjectType.Music ? '曲目' : '章节';
+
+  const tabs: { key: string; label: string; to: string; external: boolean }[] = [
+    { key: 'overview', label: '概览', to: `/subject/${subject.id}`, external: false },
+    { key: 'ep', label: epLabel, to: `/subject/${subject.id}/ep`, external: true },
+    { key: 'characters', label: '角色', to: `/subject/${subject.id}/characters`, external: true },
+    {
+      key: 'persons',
+      label: '制作人员',
+      to: `/subject/${subject.id}/persons?group=position`,
+      external: true,
+    },
+    { key: 'relations', label: '关联', to: `/subject/${subject.id}/relations`, external: true },
+    { key: 'comments', label: '吐槽', to: `/subject/${subject.id}/comments`, external: true },
+    { key: 'reviews', label: '评论', to: `/subject/${subject.id}/reviews`, external: true },
+    { key: 'board', label: '讨论版', to: `/subject/${subject.id}/board`, external: true },
+    { key: 'stats', label: '透视', to: `/subject/${subject.id}/stats`, external: true },
+    { key: 'wiki', label: 'Wiki', to: `/subject/${subject.id}/wiki/edit`, external: false },
+  ];
+
+  return (
+    <div className={styles.header}>
+      <h1 className={styles.name}>
+        <Link to={`/subject/${subject.id}`} title={subject.nameCN}>
+          {subject.name}
+        </Link>
+        {subject.nameCN != null && subject.nameCN !== '' && (
+          <small className={styles.nameCn}>{subject.nameCN}</small>
+        )}
+        {subject.platform.typeCN != null && subject.platform.typeCN !== '' && (
+          <small className={styles.platform}>{subject.platform.typeCN}</small>
+        )}
+        {subject.series && <small className={styles.platform}>系列</small>}
+      </h1>
+      <div className={styles.tabs}>
+        <Tab.Group type='borderless'>
+          {tabs
+            .filter((tab) => tab.key !== 'ep' || showEpTab)
+            .map((tab) =>
+              tab.external ? (
+                <Link
+                  key={tab.key}
+                  to={`https://bgm.tv${tab.to}`}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                >
+                  <Tab.Item isActive={false}>{tab.label}</Tab.Item>
+                </Link>
+              ) : (
+                <NavLink to={tab.to} key={tab.key}>
+                  {({ isActive }) => <Tab.Item isActive={isActive}>{tab.label}</Tab.Item>}
+                </NavLink>
+              ),
+            )}
+        </Tab.Group>
+      </div>
+    </div>
+  );
+}
+
+/** 左栏：封面与信息框，对齐 PHP subject_infobox */
+function SubjectInfobox({ subject }: { subject: Subject }) {
+  return (
+    <div className={styles.infobox}>
+      {subject.images?.large != null && (
+        <div className={styles.coverWrapper}>
+          <Link
+            to={subject.images.large}
+            isExternal
+            target='_blank'
+            rel='noopener noreferrer'
+            title={`${subject.name} ${subject.nameCN}`}
+          >
+            <img src={subject.images.large} className={styles.cover} alt={subject.name} />
+          </Link>
+        </div>
+      )}
+      <ul className={styles.infoList}>
+        {subject.infobox.map((item) => (
+          <li key={item.key}>
+            <span className={styles.tip}>{item.key}: </span>
+            <span>
+              {item.values.map((v, i) => (
+                <span key={i}>
+                  {v.k != null && v.k !== '' && <span className={styles.tip}>{v.k}</span>}
+                  {v.v}
+                  {i < item.values.length - 1 && ' / '}
+                </span>
+              ))}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+/** 左栏：推荐本条目的目录，对齐 PHP panel_subject_index */
+function SubjectIndexes({ indexes }: { indexes: SlimIndex[] }) {
+  if (indexes.length === 0) {
+    return null;
+  }
+  return (
+    <div className={styles.sidePanel}>
+      <h2 className={styles.sidePanelTitle}>推荐本条目的目录</h2>
+      <ul className={styles.indexList}>
+        {indexes.slice(0, 5).map((index) => (
+          <li key={index.id}>
+            <Link
+              to={`https://bgm.tv/index/${index.id}`}
+              target='_blank'
+              rel='noopener noreferrer'
+              className={styles.indexTitle}
+              title={index.title}
+            >
+              {index.title}
+            </Link>
+            <small className={styles.indexBy}>
+              by{' '}
+              <Link
+                to={`https://bgm.tv/user/${index.user?.username ?? ''}`}
+                target='_blank'
+                rel='noopener noreferrer'
+              >
+                {index.user?.nickname ?? ''}
+              </Link>
+            </small>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+/** 左栏：各收藏类型人数统计（panel_collect 简化版，聚合 API 未提供收藏者列表） */
+function SubjectCollectStats({ subject }: { subject: Subject }) {
+  const counts = Object.entries(subject.collection)
+    .map(([key, count]) => ({ type: Number(key) as CollectionType, count }))
+    .filter((entry) => COLLECT_DESC[entry.type] != null)
+    .sort((a, b) => a.type - b.type);
+
+  if (counts.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={styles.sidePanel}>
+      <h2 className={styles.sidePanelTitle}>谁{collectVerb(subject.type)}这部作品?</h2>
+      <ul className={styles.collectStats}>
+        {counts.map((entry) => (
+          <li key={entry.type}>
+            <Link
+              to={`https://bgm.tv/subject/${subject.id}/collections?filter=${entry.type}`}
+              target='_blank'
+              rel='noopener noreferrer'
+            >
+              {entry.count}人{COLLECT_DESC[entry.type]}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+const SubjectDetail: React.FC<{ data: SubjectHomeResponse }> = ({ data }) => {
+  const { subject } = data;
+  return (
+    <main className={styles.page}>
+      <SubjectHeader subject={subject} />
+      <div className={styles.columns}>
+        <div className={styles.columnLeft}>
+          <SubjectInfobox subject={subject} />
+          <SubjectIndexes indexes={data.indexes} />
+          <SubjectCollectStats subject={subject} />
+        </div>
+        <div className={styles.columnRight}>
+          <SubjectBlocks data={data} />
+        </div>
+      </div>
+    </main>
+  );
+};
+
+export default SubjectDetail;

--- a/packages/website/src/pages/index/subject/[id]/components/SubjectDetailBlocks.module.less
+++ b/packages/website/src/pages/index/subject/[id]/components/SubjectDetailBlocks.module.less
@@ -1,0 +1,265 @@
+@import '@bangumi/design/theme/base';
+
+/* 章节/曲目 */
+.musicList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.musicList li {
+  display: flex;
+  gap: 8px;
+  padding: 4px 0;
+  font-size: 13px;
+  line-height: 1.6;
+  border-bottom: 1px solid @gray-10;
+
+  &:last-child {
+    border-bottom: none;
+  }
+}
+
+.musicSort {
+  color: @gray-60;
+  flex: none;
+}
+
+.musicName {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.musicDuration {
+  color: @gray-60;
+  flex: none;
+}
+
+.epSubtitle {
+  font-size: 12px;
+  color: @gray-60;
+  margin: 8px 0 4px;
+}
+
+.epGrid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.epBtn {
+  display: inline-block;
+  min-width: 28px;
+  padding: 3px 5px;
+  text-align: center;
+  border: 1px solid @gray-10;
+  border-radius: 3px;
+  font-size: 12px;
+  color: @gray-100;
+}
+
+.epDone {
+  background: @blue-doing;
+  border-color: @blue-doing;
+  color: #fff;
+}
+
+/* 简介 */
+.summary {
+  font-size: 13px;
+  line-height: 1.8;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+/* 标签 */
+.tagList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.tagList li {
+  padding: 2px 8px;
+  border: 1px solid @gray-10;
+  border-radius: 10px;
+  font-size: 12px;
+}
+
+/* 封面网格（角色/关联/推荐） */
+.coverGrid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: flex-end;
+}
+
+.coverItem {
+  width: 72px;
+  text-align: center;
+  position: relative;
+}
+
+.coverLink {
+  display: block;
+}
+
+.cover {
+  width: 72px;
+  height: 96px;
+  object-fit: cover;
+  border-radius: 3px;
+  background: @gray-10;
+}
+
+.coverTitle {
+  margin: 4px 0 0;
+  font-size: 12px;
+  line-height: 1.4;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.coverInfo {
+  margin: 0;
+  font-size: 11px;
+  color: @gray-60;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.relationSep {
+  display: block;
+  width: 100%;
+  font-size: 13px;
+  color: @gray-60;
+  margin: 6px 0 0;
+}
+
+/* 文本列表（评论/日志） */
+.textList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.textList li {
+  padding: 6px 0;
+  border-bottom: 1px solid @gray-10;
+
+  &:last-child {
+    border-bottom: none;
+  }
+}
+
+.textTitle {
+  font-size: 13px;
+  word-break: break-all;
+}
+
+.textInfo {
+  margin: 4px 0 0;
+  font-size: 12px;
+  color: @gray-60;
+
+  span {
+    margin-left: 8px;
+  }
+}
+
+/* 讨论版 */
+.topicTable {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.topicTable tr {
+  border-bottom: 1px solid @gray-10;
+}
+
+.topicSubject {
+  padding: 6px 4px;
+  text-align: left;
+  max-width: 0;
+
+  a {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+.topicInfo {
+  padding: 6px 4px;
+  width: 16%;
+  text-align: right;
+  color: @gray-60;
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.topicMore {
+  padding: 6px 4px;
+  text-align: right;
+}
+
+/* 吐槽 */
+.commentList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.commentList > li {
+  display: flex;
+  gap: 8px;
+  padding: 8px 0;
+  border-bottom: 1px solid @gray-10;
+
+  &:last-child {
+    border-bottom: none;
+  }
+}
+
+.commentInfo {
+  min-width: 0;
+  flex: 1;
+}
+
+.commentHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: 13px;
+}
+
+.commentMeta {
+  color: @gray-60;
+  font-size: 12px;
+}
+
+.commentText {
+  margin: 4px 0 0;
+  font-size: 13px;
+  line-height: 1.6;
+  color: @gray-100;
+  word-break: break-all;
+  white-space: pre-wrap;
+}

--- a/packages/website/src/pages/index/subject/[id]/components/SubjectDetailBlocks.tsx
+++ b/packages/website/src/pages/index/subject/[id]/components/SubjectDetailBlocks.tsx
@@ -1,0 +1,461 @@
+import classNames from 'classnames';
+import dayjs from 'dayjs';
+import React from 'react';
+
+import type {
+  Episode,
+  Subject,
+  SubjectHomeResponse,
+  SubjectInterestComment,
+  SubjectRec,
+  SubjectRelation,
+  SubjectReview,
+  Topic,
+} from '@bangumi/client/client';
+import { EpisodeCollectionStatus, EpisodeType, SubjectType } from '@bangumi/client/client';
+import { Avatar, Rate, Typography } from '@bangumi/design';
+import { getUserProfileLink } from '@bangumi/utils/pages';
+
+import CollectionPanel from './CollectionPanel';
+import { CAST_TYPE_DESC, COLLECT_DESC } from './subject-common';
+import styles from './SubjectDetailBlocks.module.less';
+import SubjectSection from './SubjectSection';
+
+const { Link } = Typography;
+
+/** 章节/曲目列表，对齐 PHP subject_box_prg */
+function EpListSection({ subject, episodes }: { subject: Subject; episodes: Episode[] }) {
+  const isAnimeLike = subject.type === SubjectType.Anime || subject.type === SubjectType.Real;
+  const isMusic = subject.type === SubjectType.Music;
+
+  if ((!isAnimeLike && !isMusic) || episodes.length === 0) {
+    return null;
+  }
+
+  if (isMusic) {
+    return (
+      <SubjectSection title='曲目列表'>
+        <ul className={styles.musicList}>
+          {episodes.map((ep) => (
+            <li key={ep.id}>
+              <span className={styles.musicSort}>{ep.sort}.</span>
+              <span className={styles.musicName} title={ep.name}>
+                {ep.name || ep.nameCN}
+              </span>
+              <small className={styles.musicDuration}>{ep.duration}</small>
+            </li>
+          ))}
+        </ul>
+      </SubjectSection>
+    );
+  }
+
+  const normals = episodes.filter((ep) => ep.type === EpisodeType.Normal);
+  const specials = episodes.filter((ep) => ep.type === EpisodeType.Special);
+
+  const renderEpGrid = (list: Episode[]) => (
+    <ul className={styles.epGrid}>
+      {list.map((ep) => {
+        const done = ep.collection?.status === EpisodeCollectionStatus.Done;
+        return (
+          <li key={ep.id}>
+            <Link
+              to={`https://bgm.tv/ep/${ep.id}`}
+              target='_blank'
+              rel='noopener noreferrer'
+              className={classNames(styles.epBtn, done ? styles.epDone : undefined)}
+              title={`ep.${ep.sort} ${ep.name || ep.nameCN}`}
+            >
+              {String(ep.sort).padStart(2, '0')}
+            </Link>
+          </li>
+        );
+      })}
+    </ul>
+  );
+
+  return (
+    <SubjectSection
+      title='章节列表'
+      extra={
+        <Link
+          to={`https://bgm.tv/subject/${subject.id}/ep`}
+          target='_blank'
+          rel='noopener noreferrer'
+        >
+          [全部]
+        </Link>
+      }
+    >
+      {renderEpGrid(normals)}
+      {specials.length > 0 && (
+        <>
+          <div className={styles.epSubtitle}>SP</div>
+          {renderEpGrid(specials)}
+        </>
+      )}
+    </SubjectSection>
+  );
+}
+
+/** 简介，对齐 PHP subject_summary */
+function SummarySection({ summary }: { summary: string }) {
+  return (
+    <SubjectSection>
+      <div className={styles.summary}>{summary}</div>
+    </SubjectSection>
+  );
+}
+
+/** 标签，对齐 PHP subject_box_tag */
+function TagsSection({ tags }: { tags: Subject['tags'] }) {
+  if (tags.length === 0) {
+    return null;
+  }
+  return (
+    <SubjectSection title='标签'>
+      <ul className={styles.tagList}>
+        {tags.map((tag) => (
+          <li key={tag.name}>
+            <Link
+              to={`https://bgm.tv/subject/tag/${encodeURIComponent(tag.name)}`}
+              target='_blank'
+              rel='noopener noreferrer'
+            >
+              {tag.name} ({tag.count})
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </SubjectSection>
+  );
+}
+
+/** 角色介绍，对齐 PHP subject_box_character */
+function CharactersSection({
+  subjectId,
+  characters,
+}: {
+  subjectId: number;
+  characters: SubjectHomeResponse['characters'];
+}) {
+  if (characters.length === 0) {
+    return null;
+  }
+  return (
+    <SubjectSection
+      title='角色介绍'
+      extra={
+        <Link
+          to={`https://bgm.tv/subject/${subjectId}/characters`}
+          target='_blank'
+          rel='noopener noreferrer'
+        >
+          更多角色 »
+        </Link>
+      }
+    >
+      <ul className={styles.coverGrid}>
+        {characters.map(({ character, casts }) => (
+          <li key={character.id} className={styles.coverItem}>
+            <Link
+              to={`https://bgm.tv/character/${character.id}`}
+              target='_blank'
+              rel='noopener noreferrer'
+              className={styles.coverLink}
+              title={character.nameCN || character.name}
+            >
+              <img src={character.images?.grid} className={styles.cover} loading='lazy' alt='' />
+            </Link>
+            <p className={styles.coverTitle}>
+              <Link
+                to={`https://bgm.tv/character/${character.id}`}
+                target='_blank'
+                rel='noopener noreferrer'
+              >
+                {character.nameCN || character.name}
+              </Link>
+            </p>
+            {casts.map((cast) => (
+              <p key={cast.person.id} className={styles.coverInfo}>
+                <span>{CAST_TYPE_DESC[cast.relation] ?? '出演'}</span>{' '}
+                <Link
+                  to={`https://bgm.tv/person/${cast.person.id}`}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                >
+                  {cast.person.name}
+                </Link>
+              </p>
+            ))}
+          </li>
+        ))}
+      </ul>
+    </SubjectSection>
+  );
+}
+
+/** 关联条目，对齐 PHP block_relation */
+function RelationsSection({
+  subjectId,
+  relations,
+}: {
+  subjectId: number;
+  relations: SubjectRelation[];
+}) {
+  if (relations.length === 0) {
+    return null;
+  }
+  let lastRelationId: number | null = null;
+
+  return (
+    <SubjectSection
+      title='关联条目'
+      extra={
+        <Link
+          to={`https://bgm.tv/subject/${subjectId}/relations`}
+          target='_blank'
+          rel='noopener noreferrer'
+        >
+          更多关联 »
+        </Link>
+      }
+    >
+      <ul className={styles.coverGrid}>
+        {relations.map(({ subject, relation }) => {
+          const showSep = relation.id !== lastRelationId;
+          lastRelationId = relation.id;
+          return (
+            <li key={subject.id} className={styles.coverItem}>
+              {showSep && <span className={styles.relationSep}>{relation.cn}</span>}
+              <Link
+                to={`https://bgm.tv/subject/${subject.id}`}
+                target='_blank'
+                rel='noopener noreferrer'
+                className={styles.coverLink}
+                title={subject.nameCN || subject.name}
+              >
+                <img src={subject.images?.grid} className={styles.cover} loading='lazy' alt='' />
+              </Link>
+              <p className={styles.coverTitle}>
+                <Link
+                  to={`https://bgm.tv/subject/${subject.id}`}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                >
+                  {subject.name}
+                </Link>
+              </p>
+            </li>
+          );
+        })}
+      </ul>
+    </SubjectSection>
+  );
+}
+
+/** 相关条目推荐，对齐 PHP block_rec */
+function RecsSection({ recs }: { recs: SubjectRec[] }) {
+  if (recs.length === 0) {
+    return null;
+  }
+  return (
+    <SubjectSection title='喜欢这部作品的会员大概会喜欢'>
+      <ul className={styles.coverGrid}>
+        {recs.map(({ subject }) => (
+          <li key={subject.id} className={styles.coverItem}>
+            <Link
+              to={`https://bgm.tv/subject/${subject.id}`}
+              target='_blank'
+              rel='noopener noreferrer'
+              className={styles.coverLink}
+              title={subject.nameCN || subject.name}
+            >
+              <img src={subject.images?.grid} className={styles.cover} loading='lazy' alt='' />
+            </Link>
+            <p className={styles.coverTitle}>
+              <Link
+                to={`https://bgm.tv/subject/${subject.id}`}
+                target='_blank'
+                rel='noopener noreferrer'
+              >
+                {subject.name}
+              </Link>
+            </p>
+          </li>
+        ))}
+      </ul>
+    </SubjectSection>
+  );
+}
+
+/** 评论（日志），对齐 PHP subject_box_blog */
+function ReviewsSection({ subjectId, reviews }: { subjectId: number; reviews: SubjectReview[] }) {
+  if (reviews.length === 0) {
+    return null;
+  }
+  return (
+    <SubjectSection
+      title='评论'
+      extra={
+        <Link
+          to={`https://bgm.tv/subject/${subjectId}/reviews`}
+          target='_blank'
+          rel='noopener noreferrer'
+        >
+          更多评论 »
+        </Link>
+      }
+    >
+      <ul className={styles.textList}>
+        {reviews.map((review) => (
+          <li key={review.id}>
+            <Link
+              to={`https://bgm.tv/blog/${review.entry.id}`}
+              target='_blank'
+              rel='noopener noreferrer'
+              className={styles.textTitle}
+              title={review.entry.title}
+            >
+              {review.entry.title}
+            </Link>
+            <p className={styles.textInfo}>
+              <Link
+                to={`https://bgm.tv/user/${review.user.username}`}
+                target='_blank'
+                rel='noopener noreferrer'
+              >
+                {review.user.nickname}
+              </Link>
+              <span>{dayjs.unix(review.entry.updatedAt).format('YYYY-M-D')}</span>
+            </p>
+          </li>
+        ))}
+      </ul>
+    </SubjectSection>
+  );
+}
+
+/** 讨论版，对齐 PHP subject_box_board */
+function TopicsSection({ subjectId, topics }: { subjectId: number; topics: Topic[] }) {
+  if (topics.length === 0) {
+    return null;
+  }
+  return (
+    <SubjectSection title='讨论版'>
+      <table className={styles.topicTable}>
+        <tbody>
+          {topics.map((topic) => (
+            <tr key={topic.id}>
+              <td className={styles.topicSubject}>
+                <Link
+                  to={`https://bgm.tv/subject/topic/${topic.id}`}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  title={topic.title}
+                >
+                  {topic.title}
+                </Link>
+              </td>
+              <td className={styles.topicInfo}>
+                <Link
+                  to={`https://bgm.tv/user/${topic.creator?.username ?? ''}`}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                >
+                  {topic.creator?.nickname ?? ''}
+                </Link>
+              </td>
+              <td className={styles.topicInfo}>{topic.replyCount} replies</td>
+              <td className={styles.topicInfo}>{dayjs.unix(topic.updatedAt).format('YYYY-M-D')}</td>
+            </tr>
+          ))}
+          <tr>
+            <td colSpan={4} className={styles.topicMore}>
+              <Link
+                to={`https://bgm.tv/subject/${subjectId}/board`}
+                target='_blank'
+                rel='noopener noreferrer'
+              >
+                更多讨论 »
+              </Link>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </SubjectSection>
+  );
+}
+
+/** 吐槽箱，对齐 PHP subject_box_comment */
+function CommentsSection({
+  subjectId,
+  comments,
+}: {
+  subjectId: number;
+  comments: SubjectInterestComment[];
+}) {
+  if (comments.length === 0) {
+    return null;
+  }
+  return (
+    <SubjectSection
+      title='吐槽箱'
+      extra={
+        <Link
+          to={`https://bgm.tv/subject/${subjectId}/comments`}
+          target='_blank'
+          rel='noopener noreferrer'
+        >
+          更多吐槽 »
+        </Link>
+      }
+    >
+      <ul className={styles.commentList}>
+        {comments.map((comment) => (
+          <li key={comment.id}>
+            <Link to={getUserProfileLink(comment.user.username)} isExternal>
+              <Avatar src={comment.user.avatar.medium} size='small' alt='' />
+            </Link>
+            <div className={styles.commentInfo}>
+              <div className={styles.commentHeader}>
+                <Link to={getUserProfileLink(comment.user.username)} isExternal fontWeight='bold'>
+                  {comment.user.nickname}
+                </Link>
+                {comment.rate > 0 && <Rate value={comment.rate} />}
+                <span className={styles.commentMeta}>{COLLECT_DESC[comment.type]}</span>
+                <span className={styles.commentMeta}>
+                  {dayjs.unix(comment.updatedAt).format('YYYY-M-D HH:mm')}
+                </span>
+              </div>
+              {comment.comment != null && comment.comment !== '' && (
+                <p className={styles.commentText}>{comment.comment}</p>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </SubjectSection>
+  );
+}
+
+/** 右栏所有区块的组合，按 PHP 布局顺序渲染 */
+export const SubjectBlocks: React.FC<{ data: SubjectHomeResponse }> = ({ data }) => {
+  const { subject } = data;
+  return (
+    <>
+      <EpListSection subject={subject} episodes={data.episodes} />
+      {subject.summary != null && subject.summary !== '' && (
+        <SummarySection summary={subject.summary} />
+      )}
+      <TagsSection tags={subject.tags} />
+      <CollectionPanel subject={subject} />
+      <CharactersSection subjectId={subject.id} characters={data.characters} />
+      <RelationsSection subjectId={subject.id} relations={data.relations} />
+      <RecsSection recs={data.recs} />
+      <ReviewsSection subjectId={subject.id} reviews={data.reviews} />
+      <TopicsSection subjectId={subject.id} topics={data.topics} />
+      <CommentsSection subjectId={subject.id} comments={data.comments} />
+    </>
+  );
+};

--- a/packages/website/src/pages/index/subject/[id]/components/SubjectSection.module.less
+++ b/packages/website/src/pages/index/subject/[id]/components/SubjectSection.module.less
@@ -1,0 +1,29 @@
+@import '@bangumi/design/theme/base';
+
+.section {
+  background: #fff;
+  border: 1px solid @gray-10;
+  border-radius: 3px;
+  margin: 0 0 20px;
+  padding: 12px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin: 0 0 10px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid @gray-10;
+}
+
+.title {
+  font-size: 15px;
+  font-weight: normal;
+  margin: 0;
+}
+
+.extra {
+  flex: none;
+}

--- a/packages/website/src/pages/index/subject/[id]/components/SubjectSection.tsx
+++ b/packages/website/src/pages/index/subject/[id]/components/SubjectSection.tsx
@@ -1,0 +1,25 @@
+import type { PropsWithChildren } from 'react';
+import React from 'react';
+
+import styles from './SubjectSection.module.less';
+
+/**
+ * 详情页右栏区块容器，对齐 PHP subject_section
+ */
+const SubjectSection: React.FC<
+  PropsWithChildren<{ title?: React.ReactNode; extra?: React.ReactNode }>
+> = ({ title, extra, children }) => {
+  return (
+    <section className={styles.section}>
+      {title != null && (
+        <div className={styles.header}>
+          <h2 className={styles.title}>{title}</h2>
+          {extra != null && <div className={styles.extra}>{extra}</div>}
+        </div>
+      )}
+      {children}
+    </section>
+  );
+};
+
+export default SubjectSection;

--- a/packages/website/src/pages/index/subject/[id]/components/subject-common.ts
+++ b/packages/website/src/pages/index/subject/[id]/components/subject-common.ts
@@ -1,0 +1,33 @@
+import { CharacterCastType, CollectionType } from '@bangumi/client/client';
+
+export const COLLECT_DESC: Record<CollectionType, string> = {
+  [CollectionType.Wish]: '想看',
+  [CollectionType.Collect]: '看过',
+  [CollectionType.Doing]: '在看',
+  [CollectionType.OnHold]: '搁置',
+  [CollectionType.Dropped]: '抛弃',
+};
+
+export const CAST_TYPE_DESC: Partial<Record<CharacterCastType, string>> = {
+  [CharacterCastType.Cv]: 'CV',
+  [CharacterCastType.Dub]: '配音',
+  [CharacterCastType.Actor]: '演员',
+  [CharacterCastType.ChineseDub]: '中文配音',
+  [CharacterCastType.JapaneseDub]: '日语配音',
+  [CharacterCastType.EnglishDub]: '英语配音',
+  [CharacterCastType.KoreanDub]: '韩语配音',
+};
+
+/** 收藏动词：看/读/听/玩 */
+export function collectVerb(subjectType: number): string {
+  switch (subjectType) {
+    case 1:
+      return '读';
+    case 3:
+      return '听';
+    case 4:
+      return '玩';
+    default:
+      return '看';
+  }
+}

--- a/packages/website/src/pages/index/subject/[id]/index.tsx
+++ b/packages/website/src/pages/index/subject/[id]/index.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+import { withErrorBoundary } from '@bangumi/website/components/ErrorBoundary';
+import { useSubjectHome } from '@bangumi/website/hooks/use-subject-home';
+
+import SubjectDetail from './components/SubjectDetail';
+
+function SubjectPage() {
+  const { id } = useParams();
+  const subjectID = Number(id);
+  const { data } = useSubjectHome(subjectID);
+
+  if (!data) {
+    return null;
+  }
+
+  return <SubjectDetail data={data} />;
+}
+
+export default withErrorBoundary(SubjectPage, {
+  404: () => <div>没有找到条目</div>,
+});


### PR DESCRIPTION
## Summary

Implements the subject detail page (`/subject/:id`) on the new frontend, backed by the aggregated `GET /p1/subjects/:subjectID/home` API (bangumi/server-private#1771). Layout follows the PHP subject page (`Bangumi/public/templates/subject/subject.htm`): a header with nav tabs, a left column (infobox / indexes / collect stats) and a right column (episode list, summary, tags, collection panel, characters, relations, recs, reviews, board and comments).

## Changes

### Client

- Regenerated `client.ts` / `types/index.ts` from the `feat/subject-home-api` branch `openapi.json`, adding `getSubjectHome()` and types (`SubjectHomeResponse`, `SubjectCharacter`, `SubjectStaff`, `SubjectRelation`, `SubjectRec`, `SubjectInterestComment`, `SubjectReview`, ...).

### Subject detail page (`/subject/:id`)

- `pages/index/subject/[id]/index.tsx`: SWR (suspense) fetch + 404 error boundary.
- `hooks/use-subject-home.ts`: SWR wrapper around `getSubjectHome()`.
- `SubjectDetail.tsx` — layout, header (title + nav tabs; unimplemented sub-pages link to bgm.tv, Wiki tab uses the in-site route), left column (infobox, indexes, collect stats).
- `SubjectDetailBlocks.tsx` — right column blocks: episode list (grid for anime/real, track list for music), summary, tags, characters, relations, recs, reviews, board, comments.
- `CollectionPanel.tsx` — collection box: collect buttons when not collected, status/rate/comment display plus an edit form (type/rate/comment) when collected, saved via `PUT /p1/collections/subjects/:id` with SWR mutate; global rating score/rank/votes and distribution chart.
- Shared `SubjectSection` container and `subject-common.ts` constants.

### Notes

- `staff` block from the API is intentionally not rendered on the detail page (kept for the future `/persons` sub-page).
- Delete-collection is not implemented (no backend endpoint yet).
- Sub-pages such as `/subject/:id/board`, `/comments`, `/reviews`, `/characters` etc. are not implemented yet and link to bgm.tv.

### Testing

- `SubjectDetail.spec.tsx`: 2 cases (block rendering, collect action via PUT) with msw fixture.
- type-check, eslint, stylelint and prettier all pass locally.