### PR TITLE
refactor: migrate from vite-plugin-pages to explicit router registration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,82 @@
+# AGENTS.md
+
+## 项目概览
+
+这是 Bangumi 新前端项目，使用 React、TypeScript、Vite 和 pnpm workspace。
+项目要求 Node.js `>=22`，包管理器固定为 pnpm `10.34.1`。
+
+主要 workspace：
+
+- `packages/website`：主网站应用，页面、hooks、路由、样式和端到端测试。
+- `packages/design`：共享设计组件和 Storybook 文档。
+- `packages/icons`：共享 React 图标组件及 SVG 资源。
+- `packages/utils`：wiki、BBCode 等共享工具和解析逻辑。
+- `packages/client`：由 OpenAPI 生成的 API client 及其生成脚本。
+- `packages/server`：服务端 workspace。
+- `tests`：Vitest 全局 setup、网站测试配置和测试 mock。
+- `docs`：路由、CSS 命名和代码风格等项目文档。
+
+## 开发命令
+
+在仓库根目录执行命令。首次开发先运行 `pnpm install`。
+
+```bash
+pnpm dev                 # 启动 website 开发服务器，使用测试后端
+pnpm dev --mode production # 使用生产后端，除非必要不要使用
+pnpm build               # 构建 website
+pnpm test                # 运行 Vitest
+pnpm test:e2e            # 运行 website Playwright 测试
+pnpm lint                # ESLint
+pnpm lint:style          # CSS/Less Stylelint
+pnpm type-check          # TypeScript 类型检查
+pnpm prettier:check      # 检查 Prettier 格式
+```
+
+可使用 workspace 脚本定向执行任务，例如 `pnpm website build`、`pnpm utils test`、
+`pnpm design dev`。修改共享组件时，必要时运行 `pnpm design:doc` 查看 Storybook。
+
+## 代码约定
+
+- 使用 TypeScript；React 组件使用函数组件和项目现有 hooks/组件模式。
+- 遵循根目录 Prettier 配置：单引号、JSX 单引号、分号、尾随逗号、行宽 100。
+- ESLint 会检查未使用导入、导入顺序、Node 内置模块的 `node:` 协议、TypeScript 类型导入等。
+  保持导入分组和 `simple-import-sort` 可通过，不要用禁用规则掩盖问题。
+- 页面及页面级组件使用 CSS Modules；共享组件样式遵循 BEM 派生命名：
+  `.bgm-组件名`、`.bgm-组件名__元素`、`.bgm-组件名--修饰符`。
+- 注释只写必要的设计或行为说明。函数、变量、类的文档使用 TSDoc `/** ... */`，不要用
+  `//` 代替可被 TypeScript 工具识别的文档注释，也不要在 TSDoc 中重复 TypeScript 类型。
+- 优先复用 `@bangumi/design`、`@bangumi/icons`、`@bangumi/utils` 和现有 hooks；新增跨页面
+  能力前先确认是否应放入对应 shared workspace。
+- 保持改动范围聚焦，不提交构建产物、依赖目录或无关格式化变更。
+
+## Website 约定
+
+- 在 `packages/website/src/routes.tsx` 显式注册路由。页面组件位于
+  `packages/website/src/pages`；使用 `[param]` 命名的页面目录时，路由表中对应为 `:param`。
+  嵌套路由需要与页面中的 `Outlet` 保持一致。
+- 单元测试不得请求真实 API。使用 MSW，并在 `packages/website/src/mocks/handlers.ts` 注册
+  handler；`mockAPI` 对应的响应 fixture 放在 `packages/website/src/mocks/fixtures`，文件名遵循
+  `<path>-<METHOD>.json`。
+- 修改新特性或缺陷修复时同时补充测试；涉及用户流程时优先补 Vitest/Testing Library，必要时
+  补 Playwright 端到端测试。
+
+## 生成文件和 API client
+
+`packages/client/client.ts`、`packages/client/types` 等 API 产物由 OpenAPI 脚本生成，不要手工
+编辑。需要更新 API 时使用 `pnpm client update-openapi && pnpm client build`，并检查生成差异。
+
+## 验证和提交
+
+提交前至少运行与改动相关的测试、`pnpm lint`、`pnpm type-check` 和格式检查；UI 或样式改动
+还应运行 `pnpm lint:style`，网站构建改动应运行 `pnpm build`。测试或检查因环境、后端或浏览器
+依赖无法运行时，在提交说明中明确记录原因。
+
+PR 标题遵循 Conventional Commits；新特性和缺陷修复必须包含测试。`packages/design` 新增
+组件必须包含 Storybook story。详细贡献流程见 `CONTRIBUTING.md`，具体风格见 `docs/` 下文档。
+
+## 文档查询
+
+当任务涉及库、框架、SDK、API、CLI 工具或云服务的用法、配置、迁移或调试时，先使用 Context7
+获取当前官方文档：先 `resolve-library-id`，再用选定的库 ID 调用 `query-docs`；若答案不足，
+对同一库使用 `researchMode: true` 重试。重构、业务逻辑调试、代码审查和一般编程概念不需要
+调用 Context7。

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -52,7 +52,6 @@
     "typescript": "^5.9.3",
     "typescript-plugin-css-modules": "^5.2.0",
     "vite": "^7.3.5",
-    "vite-plugin-pages": "^0.33.3",
     "vite-plugin-svgr": "^4.5.0"
   }
 }

--- a/packages/website/src/App.tsx
+++ b/packages/website/src/App.tsx
@@ -1,4 +1,3 @@
-import pageRoutes from '~react-pages';
 import React, { Suspense } from 'react';
 import { HelmetProvider } from 'react-helmet-async';
 import { useRoutes } from 'react-router-dom';
@@ -6,6 +5,7 @@ import { useRoutes } from 'react-router-dom';
 import { NoticeProvider } from '@bangumi/website/hooks/use-notify';
 
 import { UserProvider } from './hooks/use-user';
+import { pageRoutes } from './routes';
 
 const App = () => {
   return (

--- a/packages/website/src/routes.tsx
+++ b/packages/website/src/routes.tsx
@@ -1,0 +1,109 @@
+import React, { lazy } from 'react';
+import type { RouteObject } from 'react-router-dom';
+
+const RootIndex = lazy(async () => import('./pages/index'));
+const MatchAll = lazy(async () => import('./pages/index/[...slug]'));
+const HomeIndex = lazy(async () => import('./pages/index/index'));
+const Notifications = lazy(async () => import('./pages/index/notifications'));
+const Group = lazy(async () => import('./pages/index/group/[name]/index'));
+const GroupForum = lazy(async () => import('./pages/index/group/[name]/index/forum'));
+const GroupHome = lazy(async () => import('./pages/index/group/[name]/index/index'));
+const GroupMembers = lazy(async () => import('./pages/index/group/[name]/index/members'));
+const GroupNewTopic = lazy(async () => import('./pages/index/group/[name]/new_topic'));
+const GroupReply = lazy(async () => import('./pages/index/group/reply/[id]'));
+const GroupReplyEdit = lazy(async () => import('./pages/index/group/reply/[id]/edit'));
+const GroupTopic = lazy(async () => import('./pages/index/group/topic/[id]'));
+const GroupTopicEdit = lazy(async () => import('./pages/index/group/topic/[id]/edit'));
+const GroupTopicHome = lazy(async () => import('./pages/index/group/topic/[id]/index'));
+const Subject = lazy(async () => import('./pages/index/subject/[id]/index'));
+const Wiki = lazy(async () => import('./pages/index/subject/[id]/wiki'));
+const WikiEdit = lazy(async () => import('./pages/index/subject/[id]/wiki/edit'));
+const WikiEditDetail = lazy(async () => import('./pages/index/subject/[id]/wiki/edit_detail'));
+const WikiHistory = lazy(async () => import('./pages/index/subject/[id]/wiki/history'));
+const WikiHome = lazy(async () => import('./pages/index/subject/[id]/wiki/index'));
+const WikiUploadImg = lazy(async () => import('./pages/index/subject/[id]/wiki/upload_img'));
+const Login = lazy(async () => import('./pages/login'));
+
+export const pageRoutes: RouteObject[] = [
+  {
+    path: '/',
+    element: <RootIndex />,
+    children: [
+      { path: '*', element: <MatchAll /> },
+      { path: '', element: <HomeIndex /> },
+      { path: 'notifications', element: <Notifications /> },
+      {
+        path: 'group',
+        children: [
+          {
+            path: ':name',
+            children: [
+              {
+                path: '',
+                element: <Group />,
+                children: [
+                  { path: 'forum', element: <GroupForum /> },
+                  { path: '', element: <GroupHome /> },
+                  { path: 'members', element: <GroupMembers /> },
+                ],
+              },
+              {
+                path: 'new_topic',
+                children: [{ path: '', element: <GroupNewTopic /> }],
+              },
+            ],
+          },
+          {
+            path: 'reply',
+            children: [
+              {
+                path: ':id',
+                element: <GroupReply />,
+                children: [{ path: 'edit', element: <GroupReplyEdit /> }],
+              },
+            ],
+          },
+          {
+            path: 'topic',
+            children: [
+              {
+                path: ':id',
+                element: <GroupTopic />,
+                children: [
+                  { path: 'edit', element: <GroupTopicEdit /> },
+                  { path: '', element: <GroupTopicHome /> },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        path: 'subject',
+        children: [
+          {
+            path: ':id',
+            children: [
+              { path: '', element: <Subject /> },
+              {
+                path: 'wiki',
+                element: <Wiki />,
+                children: [
+                  { path: 'edit', element: <WikiEdit /> },
+                  { path: 'edit_detail', element: <WikiEditDetail /> },
+                  { path: 'history', element: <WikiHistory /> },
+                  { path: '', element: <WikiHome /> },
+                  { path: 'upload_img', element: <WikiUploadImg /> },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    path: 'login',
+    children: [{ path: '', element: <Login /> }],
+  },
+];

--- a/packages/website/src/vite-env.d.ts
+++ b/packages/website/src/vite-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="vite/client" />
-/// <reference types="vite-plugin-pages/client-react" />
 
 interface ImportMetaEnv {
   readonly VITE_TURNSTILE_SITE_KEY: string;

--- a/packages/website/vite.config.ts
+++ b/packages/website/vite.config.ts
@@ -6,7 +6,6 @@ import react from '@vitejs/plugin-react';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import { defineConfig } from 'vite';
-import pages from 'vite-plugin-pages';
 import svgr from 'vite-plugin-svgr';
 
 import { version } from '../../package.json';
@@ -110,17 +109,6 @@ export default defineConfig(({ mode }) => {
           namedExport: 'ReactComponent',
           titleProp: true,
         },
-      }),
-      pages({
-        extensions: ['tsx'],
-        importMode: 'async',
-        exclude: [
-          '**/components/**/*.tsx',
-          '**/*.spec.ts',
-          '**/*.spec.tsx',
-          '**/*.test.ts',
-          '**/*.test.tsx',
-        ],
       }),
     ],
     css: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -426,9 +426,6 @@ importers:
       vite:
         specifier: ^7.3.5
         version: 7.3.5(@types/node@22.20.0)(less@4.6.7)(sass@1.101.0)(stylus@0.62.0)(tsx@4.22.4)(yaml@2.9.0)
-      vite-plugin-pages:
-        specifier: ^0.33.3
-        version: 0.33.3(vite@7.3.5(@types/node@22.20.0)(less@4.6.7)(sass@1.101.0)(stylus@0.62.0)(tsx@4.22.4)(yaml@2.9.0))
       vite-plugin-svgr:
         specifier: ^4.5.0
         version: 4.5.0(rollup@4.62.2)(typescript@5.9.3)(vite@7.3.5(@types/node@22.20.0)(less@4.6.7)(sass@1.101.0)(stylus@0.62.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -1965,9 +1962,6 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
-  '@types/debug@4.1.13':
-    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
-
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -1994,9 +1988,6 @@ packages:
 
   '@types/lodash@4.17.24':
     resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
-
-  '@types/ms@2.1.0':
-    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@22.20.0':
     resolution: {integrity: sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==}
@@ -2552,12 +2543,6 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
-  confbox@0.1.8:
-    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
-
-  confbox@0.2.4:
-    resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
-
   content-type@2.0.0:
     resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
     engines: {node: '>=18'}
@@ -2954,10 +2939,6 @@ packages:
     resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  esprima-extract-comments@1.1.0:
-    resolution: {integrity: sha512-sBQUnvJwpeE9QnPrxh7dpI/dp67erYG4WXEAreAMoelPRpMR7NWb4YtwRPn9b+H1uLQKl/qS8WYmyaljTpjIsw==}
-    engines: {node: '>=4'}
-
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
@@ -2991,13 +2972,6 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
-
-  exsolve@1.1.0:
-    resolution: {integrity: sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==}
-
-  extract-comments@1.1.0:
-    resolution: {integrity: sha512-dzbZV2AdSSVW/4E7Ti5hZdHWbA+Z80RJsJhr5uiL10oyjl/gy7/o+HI1HwK4/WSZhlq4SNKU3oUzXlM13Qx02Q==}
-    engines: {node: '>=6'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -3615,10 +3589,6 @@ packages:
     resolution: {integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==}
     engines: {node: '>=20.0.0'}
 
-  local-pkg@1.2.1:
-    resolution: {integrity: sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==}
-    engines: {node: '>=14'}
-
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -3734,9 +3704,6 @@ packages:
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
-
-  mlly@1.8.2:
-    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
   monaco-editor@0.55.1:
     resolution: {integrity: sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==}
@@ -3904,10 +3871,6 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
-  parse-code-context@1.0.0:
-    resolution: {integrity: sha512-OZQaqKaQnR21iqhlnPfVisFjBWjhnMl5J9MgbP8xC+EwoVqbXrq78lp+9Zb3ahmLzrIX5Us/qbvBnaS3hkH6OA==}
-    engines: {node: '>=6'}
-
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
@@ -3969,12 +3932,6 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
-
-  pkg-types@1.3.1:
-    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
-
-  pkg-types@2.3.1:
-    resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
 
   playwright-core@1.61.1:
     resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
@@ -4079,9 +4036,6 @@ packages:
   qified@0.10.1:
     resolution: {integrity: sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==}
     engines: {node: '>=20'}
-
-  quansync@0.2.11:
-    resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -4687,9 +4641,6 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  ufo@1.6.4:
-    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
-
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
@@ -4745,24 +4696,6 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-
-  vite-plugin-pages@0.33.3:
-    resolution: {integrity: sha512-k97CAlVN7VUD5CIkRaose8Ty1xjtpuSeJQngFxsinPyM7PCtAIp23QdnkygNRdoo4gjX21TORYdEAAN/lGtCIA==}
-    peerDependencies:
-      '@solidjs/router': '*'
-      '@vue/compiler-sfc': ^2.7.0 || ^3.0.0
-      react-router: '*'
-      vite: ^2.0.0 || ^3.0.0-0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0-0 || ^7.0.0-0 || ^8.0.0-0
-      vue-router: '*'
-    peerDependenciesMeta:
-      '@solidjs/router':
-        optional: true
-      '@vue/compiler-sfc':
-        optional: true
-      react-router:
-        optional: true
-      vue-router:
-        optional: true
 
   vite-plugin-svgr@4.5.0:
     resolution: {integrity: sha512-W+uoSpmVkSmNOGPSsDCWVW/DDAyv+9fap9AZXBvWiQqrboJ08j2vh0tFxTD/LjwqwAd3yYSVJgm54S/1GhbdnA==}
@@ -6256,10 +6189,6 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
-  '@types/debug@4.1.13':
-    dependencies:
-      '@types/ms': 2.1.0
-
   '@types/deep-eql@4.0.2': {}
 
   '@types/doctrine@0.0.9': {}
@@ -6279,8 +6208,6 @@ snapshots:
       '@types/lodash': 4.17.24
 
   '@types/lodash@4.17.24': {}
-
-  '@types/ms@2.1.0': {}
 
   '@types/node@22.20.0':
     dependencies:
@@ -6868,10 +6795,6 @@ snapshots:
 
   concat-map@0.0.1: {}
 
-  confbox@0.1.8: {}
-
-  confbox@0.2.4: {}
-
   content-type@2.0.0: {}
 
   convert-source-map@2.0.0: {}
@@ -7438,10 +7361,6 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.17.0)
       eslint-visitor-keys: 5.0.1
 
-  esprima-extract-comments@1.1.0:
-    dependencies:
-      esprima: 4.0.1
-
   esprima@4.0.1: {}
 
   esquery@1.7.0:
@@ -7465,13 +7384,6 @@ snapshots:
   eventemitter3@5.0.4: {}
 
   expect-type@1.3.0: {}
-
-  exsolve@1.1.0: {}
-
-  extract-comments@1.1.0:
-    dependencies:
-      esprima-extract-comments: 1.1.0
-      parse-code-context: 1.0.0
 
   fast-deep-equal@3.1.3: {}
 
@@ -8100,12 +8012,6 @@ snapshots:
       rfdc: 1.4.1
       wrap-ansi: 9.0.2
 
-  local-pkg@1.2.1:
-    dependencies:
-      mlly: 1.8.2
-      pkg-types: 2.3.1
-      quansync: 0.2.11
-
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -8202,13 +8108,6 @@ snapshots:
   minimist@1.2.8: {}
 
   minipass@7.1.3: {}
-
-  mlly@1.8.2:
-    dependencies:
-      acorn: 8.17.0
-      pathe: 2.0.3
-      pkg-types: 1.3.1
-      ufo: 1.6.4
 
   monaco-editor@0.55.1:
     dependencies:
@@ -8447,8 +8346,6 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
-  parse-code-context@1.0.0: {}
-
   parse-json@5.2.0:
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -8497,18 +8394,6 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
-
-  pkg-types@1.3.1:
-    dependencies:
-      confbox: 0.1.8
-      mlly: 1.8.2
-      pathe: 2.0.3
-
-  pkg-types@2.3.1:
-    dependencies:
-      confbox: 0.2.4
-      exsolve: 1.1.0
-      pathe: 2.0.3
 
   playwright-core@1.61.1: {}
 
@@ -8594,8 +8479,6 @@ snapshots:
   qified@0.10.1:
     dependencies:
       hookified: 2.2.0
-
-  quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
 
@@ -9358,8 +9241,6 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  ufo@1.6.4: {}
-
   unbox-primitive@1.1.0:
     dependencies:
       call-bound: 1.0.4
@@ -9434,22 +9315,6 @@ snapshots:
       react: 19.2.7
 
   util-deprecate@1.0.2: {}
-
-  vite-plugin-pages@0.33.3(vite@7.3.5(@types/node@22.20.0)(less@4.6.7)(sass@1.101.0)(stylus@0.62.0)(tsx@4.22.4)(yaml@2.9.0)):
-    dependencies:
-      '@types/debug': 4.1.13
-      debug: 4.4.3(supports-color@10.2.2)
-      dequal: 2.0.3
-      extract-comments: 1.1.0
-      json5: 2.2.3
-      local-pkg: 1.2.1
-      micromatch: 4.0.8
-      picocolors: 1.1.1
-      tinyglobby: 0.2.17
-      vite: 7.3.5(@types/node@22.20.0)(less@4.6.7)(sass@1.101.0)(stylus@0.62.0)(tsx@4.22.4)(yaml@2.9.0)
-      yaml: 2.9.0
-    transitivePeerDependencies:
-      - supports-color
 
   vite-plugin-svgr@4.5.0(rollup@4.62.2)(typescript@5.9.3)(vite@7.3.5(@types/node@22.20.0)(less@4.6.7)(sass@1.101.0)(stylus@0.62.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:


### PR DESCRIPTION
## Summary

Replace the `vite-plugin-pages` file-system routing with explicit router registration.

- Add `packages/website/src/routes.tsx` declaring the full route tree as `RouteObject[]`, with every page still wrapped in `React.lazy` to keep the existing per-route code splitting.
- The route tree is identical to the one previously generated by `vite-plugin-pages` (verified against the plugin's generated module), including the `/login` route living outside the root layout.
- Remove the `pages` plugin from `vite.config.ts`, its type reference from `vite-env.d.ts`, and the `vite-plugin-pages` dependency (with its transitive deps) from `package.json` / `pnpm-lock.yaml`.
- Add `AGENTS.md` documenting project conventions, including the new explicit route registration workflow.

## Verification

- `pnpm type-check` passes.
- `pnpm website build` passes; output chunks are still split per page (e.g. `edit`, `forum`, `wiki`, `edit_detail`), confirming lazy loading is preserved.
- `pnpm test -- --run`: 1 failed / 228 passed — the same result as on `master` before this change (the failure is a pre-existing jsdom `localStorage` issue in the group page snapshot test, unrelated to routing).
- ESLint passes on the touched files (`routes.tsx`, `App.tsx`, `vite.config.ts`).