### PR TITLE
refactor: use internal links for subjects on home page

### DIFF
--- a/packages/utils/pages.spec.ts
+++ b/packages/utils/pages.spec.ts
@@ -1,0 +1,7 @@
+import { getSubjectLink } from './pages';
+
+describe('page links', () => {
+  test('generates an internal subject link', () => {
+    expect(getSubjectLink(12)).toBe('/subject/12');
+  });
+});

--- a/packages/utils/pages.ts
+++ b/packages/utils/pages.ts
@@ -1,4 +1,8 @@
 // 一些页面在新站未 Ready， 为了以后切换方便，最好使用函数生成页面 URL
+export function getSubjectLink(subjectId: number): string {
+  return `/subject/${subjectId}`;
+}
+
 export function getUserProfileLink(username: string): string {
   return 'https://bgm.tv/user/' + username;
 }

--- a/packages/website/src/pages/index/index/HomePage.spec.tsx
+++ b/packages/website/src/pages/index/index/HomePage.spec.tsx
@@ -44,6 +44,18 @@ describe('HomePage', () => {
     expect(await screen.findByText('公告')).toBeInTheDocument();
   });
 
+  it('should use internal links for subjects', async () => {
+    setupHome();
+    await renderHome();
+
+    const subjectLinks = document.querySelectorAll<HTMLAnchorElement>('a[href="/subject/12"]');
+    expect(subjectLinks.length).toBeGreaterThan(0);
+    for (const link of subjectLinks) {
+      expect(link).not.toHaveAttribute('target');
+    }
+    expect(document.querySelector('a[href="https://bgm.tv/subject/12"]')).not.toBeInTheDocument();
+  });
+
   it('should mark the last unwatched episode as watched', async () => {
     setupHome();
     let patchedBody: unknown = null;

--- a/packages/website/src/pages/index/index/components/CalendarBlock.tsx
+++ b/packages/website/src/pages/index/index/components/CalendarBlock.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import type { Calendar } from '@bangumi/client/client';
 import { Typography } from '@bangumi/design';
+import { getSubjectLink } from '@bangumi/utils/pages';
 
 import styles from './CalendarBlock.module.less';
 import HomeSidePanel from './HomeSidePanel';
@@ -74,9 +75,7 @@ const CalendarBlock: React.FC<{ calendar: Calendar }> = ({ calendar }) => {
                 {items.map((item) => (
                   <Link
                     key={item.subject.id}
-                    to={`https://bgm.tv/subject/${item.subject.id}`}
-                    target='_blank'
-                    rel='noopener noreferrer'
+                    to={getSubjectLink(item.subject.id)}
                     title={`${item.subject.name}\n${item.subject.nameCN}`}
                   >
                     <img src={item.subject.images?.grid} width={48} loading='lazy' alt='' />

--- a/packages/website/src/pages/index/index/components/HotSubjectTopicsBlock.tsx
+++ b/packages/website/src/pages/index/index/components/HotSubjectTopicsBlock.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import type { SubjectTopic } from '@bangumi/client/client';
 import { Typography } from '@bangumi/design';
+import { getSubjectLink } from '@bangumi/utils/pages';
 
 import HomeSidePanel from './HomeSidePanel';
 import SideTopicList from './SideTopicList';
@@ -26,11 +27,7 @@ const HotSubjectTopicsBlock: React.FC<{ topics: SubjectTopic[] }> = ({ topics })
           creatorUsername: topic.creator?.username ?? '',
           topicLink: `https://bgm.tv/subject/topic/${topic.id}`,
           extra: (
-            <Link
-              to={`https://bgm.tv/subject/${topic.subject.id}`}
-              target='_blank'
-              rel='noopener noreferrer'
-            >
+            <Link to={getSubjectLink(topic.subject.id)}>
               {topic.subject.nameCN || topic.subject.name}
             </Link>
           ),

--- a/packages/website/src/pages/index/index/components/PrgManager.tsx
+++ b/packages/website/src/pages/index/index/components/PrgManager.tsx
@@ -5,6 +5,7 @@ import { ozaClient } from '@bangumi/client';
 import type { ProgressItem, UpdateSubjectProgress } from '@bangumi/client/client';
 import { EpisodeCollectionStatus, SubjectType } from '@bangumi/client/client';
 import { toast, Typography } from '@bangumi/design';
+import { getSubjectLink } from '@bangumi/utils/pages';
 import { useHomePage } from '@bangumi/website/hooks/use-home-page';
 
 import styles from './PrgManager.module.less';
@@ -85,9 +86,7 @@ function PrgRow({ item }: { item: ProgressItem }) {
   return (
     <li className={styles.row}>
       <Link
-        to={`https://bgm.tv/subject/${subject.id}`}
-        target='_blank'
-        rel='noopener noreferrer'
+        to={getSubjectLink(subject.id)}
         className={styles.coverLink}
         title={subject.nameCN || subject.name}
       >
@@ -97,9 +96,7 @@ function PrgRow({ item }: { item: ProgressItem }) {
       <div className={styles.info}>
         <div className={styles.header}>
           <Link
-            to={`https://bgm.tv/subject/${subject.id}`}
-            target='_blank'
-            rel='noopener noreferrer'
+            to={getSubjectLink(subject.id)}
             className={styles.subjectName}
             title={subject.nameCN || subject.name}
           >

--- a/packages/website/src/pages/index/index/components/TimelineBlock.tsx
+++ b/packages/website/src/pages/index/index/components/TimelineBlock.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import type { SlimSubject, Timeline } from '@bangumi/client/client';
 import { TimelineCat } from '@bangumi/client/client';
 import { Avatar, Typography } from '@bangumi/design';
-import { getUserProfileLink } from '@bangumi/utils/pages';
+import { getSubjectLink, getUserProfileLink } from '@bangumi/utils/pages';
 
 import styles from './TimelineBlock.module.less';
 
@@ -32,11 +32,7 @@ function makeDescriptiveTime(timestamp: number): string {
 }
 
 function SubjectName({ subject }: { subject: SlimSubject }) {
-  return (
-    <Link to={`https://bgm.tv/subject/${subject.id}`} target='_blank' rel='noopener noreferrer'>
-      {subject.nameCN || subject.name}
-    </Link>
-  );
+  return <Link to={getSubjectLink(subject.id)}>{subject.nameCN || subject.name}</Link>;
 }
 
 function renderStatus(timeline: Timeline): React.ReactNode {


### PR DESCRIPTION
## What

将首页各板块（日历、热门话题、进度管理、时间线）中指向旧站 `https://bgm.tv/subject/:id` 的外链（`target="_blank"`）改为站内链接 `/subject/:id`。

## Changes

- `packages/utils/pages.ts`: 新增 `getSubjectLink(subjectId)` 工具函数，统一生成站内 subject 链接
- `packages/utils/pages.spec.ts`: 新增 `getSubjectLink` 单测
- 首页 `CalendarBlock` / `HotSubjectTopicsBlock` / `PrgManager` / `TimelineBlock`: 使用 `getSubjectLink` 替换外链
- `HomePage.spec.tsx`: 新增测试，验证首页 subject 链接为站内链接且无 `target` 属性

## Why

站内 subject 页面（`/subject/:id`）已就绪，站内跳转体验更好，也避免新开标签页。

## Validation

- `pnpm test` 通过（5 tests）
- `pnpm type-check` 通过
- `pnpm lint` 通过