### PR TITLE
feat: add user home page

### DIFF
--- a/packages/utils/pages.spec.ts
+++ b/packages/utils/pages.spec.ts
@@ -1,8 +1,17 @@
 import {
+  getBlogLink,
+  getGroupLink,
+  getIndexLink,
   getLegacyPageLink,
   getSubjectCollectionsLink,
   getSubjectLink,
   getSubjectTagLink,
+  getUserBlogsPageLink,
+  getUserCollectionsLink,
+  getUserFriendsPageLink,
+  getUserGroupsPageLink,
+  getUserIndexesPageLink,
+  getUserMonoPageLink,
   getUserProfileLink,
 } from './pages';
 
@@ -23,5 +32,23 @@ describe('page links', () => {
     expect(getLegacyPageLink('/subject/12/stats?foo=bar#chart')).toBe(
       'https://bgm.tv/subject/12/stats?foo=bar#chart',
     );
+  });
+
+  test('generates a user collections link', () => {
+    expect(getUserCollectionsLink('anime', 'sai')).toBe('/anime/list/sai');
+  });
+
+  test('generates user sub page links', () => {
+    expect(getUserFriendsPageLink('sai')).toBe('/user/sai/friends');
+    expect(getUserGroupsPageLink('sai')).toBe('/user/sai/groups');
+    expect(getUserBlogsPageLink('sai')).toBe('/user/sai/blog');
+    expect(getUserIndexesPageLink('sai')).toBe('/user/sai/index');
+    expect(getUserMonoPageLink('sai')).toBe('/user/sai/mono');
+  });
+
+  test('generates group/blog/index links', () => {
+    expect(getGroupLink('sandbox')).toBe('/group/sandbox');
+    expect(getBlogLink(200)).toBe('/blog/200');
+    expect(getIndexLink(100)).toBe('/index/100');
   });
 });

--- a/packages/utils/pages.ts
+++ b/packages/utils/pages.ts
@@ -79,6 +79,31 @@ export function getGroupLink(groupName: string): string {
   return `/group/${groupName}`;
 }
 
+/** 用户收藏列表页，subjectTypePath 为 anime/book/music/game/real */
+export function getUserCollectionsLink(subjectTypePath: string, username: string): string {
+  return `/${subjectTypePath}/list/${username}`;
+}
+
+export function getUserFriendsPageLink(username: string): string {
+  return `/user/${username}/friends`;
+}
+
+export function getUserGroupsPageLink(username: string): string {
+  return `/user/${username}/groups`;
+}
+
+export function getUserBlogsPageLink(username: string): string {
+  return `/user/${username}/blog`;
+}
+
+export function getUserIndexesPageLink(username: string): string {
+  return `/user/${username}/index`;
+}
+
+export function getUserMonoPageLink(username: string): string {
+  return `/user/${username}/mono`;
+}
+
 export function getGroupTopicLink(topicId: number): string {
   return `/group/topic/${topicId}`;
 }

--- a/packages/website/src/components/PageRoutes/LegacyRedirect.spec.tsx
+++ b/packages/website/src/components/PageRoutes/LegacyRedirect.spec.tsx
@@ -25,7 +25,7 @@ it('redirects a registered legacy path to the legacy site', async () => {
 
 it.each([
   '/calendar',
-  '/user/test',
+  '/blog/42',
   '/subject/12/collections',
   '/subject/12/stats',
   '/subject/topic/42',

--- a/packages/website/src/hooks/use-user-blogs.ts
+++ b/packages/website/src/hooks/use-user-blogs.ts
@@ -1,0 +1,19 @@
+import { ok } from '@oazapfts/runtime';
+import useSWR from 'swr';
+
+import { ozaClient } from '@bangumi/client';
+import type { SlimBlogEntry } from '@bangumi/client/client';
+
+/** 获取用户发表的日志 */
+export function useUserBlogs(
+  username: string,
+  limit: number,
+): { data: SlimBlogEntry[] | undefined; total: number | undefined } {
+  const { data } = useSWR(
+    `user-blogs ${username} ${limit}`,
+    async () => ok(ozaClient.getUserBlogs(username, { limit })),
+    { suspense: true },
+  );
+
+  return data ?? { data: undefined, total: undefined };
+}

--- a/packages/website/src/hooks/use-user-collections.ts
+++ b/packages/website/src/hooks/use-user-collections.ts
@@ -1,0 +1,20 @@
+import { ok } from '@oazapfts/runtime';
+import useSWR from 'swr';
+
+import { ozaClient } from '@bangumi/client';
+import type { SlimSubject, SubjectType } from '@bangumi/client/client';
+
+/** 获取用户某类型条目的收藏列表 */
+export function useUserSubjectCollections(
+  username: string,
+  subjectType: SubjectType,
+  limit: number,
+): { data: SlimSubject[] | undefined; total: number | undefined } {
+  const { data } = useSWR(
+    `user-subject-collections ${username} ${subjectType} ${limit}`,
+    async () => ok(ozaClient.getUserSubjectCollections(username, { subjectType, limit })),
+    { suspense: true },
+  );
+
+  return data ?? { data: undefined, total: undefined };
+}

--- a/packages/website/src/hooks/use-user-friends.ts
+++ b/packages/website/src/hooks/use-user-friends.ts
@@ -1,0 +1,19 @@
+import { ok } from '@oazapfts/runtime';
+import useSWR from 'swr';
+
+import { ozaClient } from '@bangumi/client';
+import type { SlimUser } from '@bangumi/client/client';
+
+/** 获取用户的好友列表 */
+export function useUserFriends(
+  username: string,
+  limit: number,
+): { data: SlimUser[] | undefined; total: number | undefined } {
+  const { data } = useSWR(
+    `user-friends ${username} ${limit}`,
+    async () => ok(ozaClient.getUserFriends(username, { limit })),
+    { suspense: true },
+  );
+
+  return data ?? { data: undefined, total: undefined };
+}

--- a/packages/website/src/hooks/use-user-groups.ts
+++ b/packages/website/src/hooks/use-user-groups.ts
@@ -1,0 +1,19 @@
+import { ok } from '@oazapfts/runtime';
+import useSWR from 'swr';
+
+import { ozaClient } from '@bangumi/client';
+import type { SlimGroup } from '@bangumi/client/client';
+
+/** 获取用户加入的小组 */
+export function useUserGroups(
+  username: string,
+  limit: number,
+): { data: SlimGroup[] | undefined; total: number | undefined } {
+  const { data } = useSWR(
+    `user-groups ${username} ${limit}`,
+    async () => ok(ozaClient.getUserGroups(username, { limit })),
+    { suspense: true },
+  );
+
+  return data ?? { data: undefined, total: undefined };
+}

--- a/packages/website/src/hooks/use-user-home.ts
+++ b/packages/website/src/hooks/use-user-home.ts
@@ -1,0 +1,18 @@
+import { ok } from '@oazapfts/runtime';
+import useSWR from 'swr';
+
+import { ozaClient } from '@bangumi/client';
+import type { User } from '@bangumi/client/client';
+
+export function useUserHome(username: string): {
+  data: User | undefined;
+  mutate: () => Promise<unknown>;
+} {
+  const { data, mutate } = useSWR(
+    `user-home ${username}`,
+    async () => ok(ozaClient.getUser(username)),
+    { suspense: true },
+  );
+
+  return { data, mutate };
+}

--- a/packages/website/src/hooks/use-user-indexes.ts
+++ b/packages/website/src/hooks/use-user-indexes.ts
@@ -1,0 +1,19 @@
+import { ok } from '@oazapfts/runtime';
+import useSWR from 'swr';
+
+import { ozaClient } from '@bangumi/client';
+import type { SlimIndex } from '@bangumi/client/client';
+
+/** 获取用户创建的目录 */
+export function useUserIndexes(
+  username: string,
+  limit: number,
+): { data: SlimIndex[] | undefined; total: number | undefined } {
+  const { data } = useSWR(
+    `user-indexes ${username} ${limit}`,
+    async () => ok(ozaClient.getUserIndexes(username, { limit })),
+    { suspense: true },
+  );
+
+  return data ?? { data: undefined, total: undefined };
+}

--- a/packages/website/src/mocks/fixtures/p1/users/sai-GET.json
+++ b/packages/website/src/mocks/fixtures/p1/users/sai-GET.json
@@ -1,0 +1,40 @@
+{
+  "id": 1,
+  "username": "sai",
+  "nickname": "Sai",
+  "avatar": {
+    "small": "https://lain.bgm.tv/pic/user/s/000/00/00/1.jpg",
+    "medium": "https://lain.bgm.tv/pic/user/m/000/00/00/1.jpg",
+    "large": "https://lain.bgm.tv/pic/user/l/000/00/00/1.jpg"
+  },
+  "group": 2,
+  "joinedAt": 1262304000,
+  "sign": "测试签名",
+  "site": "example.com",
+  "location": "上海",
+  "bio": "测试简介",
+  "networkServices": [
+    {
+      "name": "weibo",
+      "title": "微博",
+      "url": "https://weibo.com/sai",
+      "color": "#E6162D",
+      "account": "sai"
+    }
+  ],
+  "homepage": {
+    "left": ["anime", "book", "blog"],
+    "right": ["friend", "group", "index"]
+  },
+  "stats": {
+    "subject": {
+      "2": { "1": 5, "2": 10, "3": 3, "4": 1, "5": 1 },
+      "1": { "1": 2, "2": 4 }
+    },
+    "mono": { "character": 2, "person": 1 },
+    "blog": 0,
+    "friend": 1,
+    "group": 2,
+    "index": 1
+  }
+}

--- a/packages/website/src/mocks/fixtures/p1/users/sai/blogs-GET.json
+++ b/packages/website/src/mocks/fixtures/p1/users/sai/blogs-GET.json
@@ -1,0 +1,17 @@
+{
+  "data": [
+    {
+      "id": 200,
+      "type": 1,
+      "uid": 1,
+      "title": "测试日志",
+      "icon": "",
+      "summary": "日志摘要",
+      "replies": 0,
+      "public": true,
+      "createdAt": 1600000000,
+      "updatedAt": 1600000000
+    }
+  ],
+  "total": 1
+}

--- a/packages/website/src/mocks/fixtures/p1/users/sai/collections/subjects-GET.json
+++ b/packages/website/src/mocks/fixtures/p1/users/sai/collections/subjects-GET.json
@@ -1,0 +1,41 @@
+{
+  "data": [
+    {
+      "id": 12,
+      "name": "Test Anime",
+      "nameCN": "测试动画",
+      "type": 2,
+      "images": {
+        "large": "https://lain.bgm.tv/pic/cover/l/00/00/12.jpg",
+        "common": "https://lain.bgm.tv/pic/cover/c/00/00/12.jpg",
+        "medium": "https://lain.bgm.tv/pic/cover/m/00/00/12.jpg",
+        "small": "https://lain.bgm.tv/pic/cover/s/00/00/12.jpg",
+        "grid": "https://lain.bgm.tv/pic/cover/g/00/00/12.jpg"
+      },
+      "info": "",
+      "metaTags": [],
+      "rating": { "rank": 10, "count": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], "score": 8.5, "total": 100 },
+      "locked": false,
+      "nsfw": false
+    },
+    {
+      "id": 13,
+      "name": "Test Book",
+      "nameCN": "测试书籍",
+      "type": 1,
+      "images": {
+        "large": "https://lain.bgm.tv/pic/cover/l/00/00/13.jpg",
+        "common": "https://lain.bgm.tv/pic/cover/c/00/00/13.jpg",
+        "medium": "https://lain.bgm.tv/pic/cover/m/00/00/13.jpg",
+        "small": "https://lain.bgm.tv/pic/cover/s/00/00/13.jpg",
+        "grid": "https://lain.bgm.tv/pic/cover/g/00/00/13.jpg"
+      },
+      "info": "",
+      "metaTags": [],
+      "rating": { "rank": 20, "count": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], "score": 7.5, "total": 50 },
+      "locked": false,
+      "nsfw": false
+    }
+  ],
+  "total": 2
+}

--- a/packages/website/src/mocks/fixtures/p1/users/sai/friends-GET.json
+++ b/packages/website/src/mocks/fixtures/p1/users/sai/friends-GET.json
@@ -1,0 +1,18 @@
+{
+  "data": [
+    {
+      "id": 2,
+      "username": "sai-2",
+      "nickname": "好友甲",
+      "avatar": {
+        "small": "https://lain.bgm.tv/pic/user/s/000/00/00/2.jpg",
+        "medium": "https://lain.bgm.tv/pic/user/m/000/00/00/2.jpg",
+        "large": "https://lain.bgm.tv/pic/user/l/000/00/00/2.jpg"
+      },
+      "group": 10,
+      "sign": "",
+      "joinedAt": 1600000000
+    }
+  ],
+  "total": 1
+}

--- a/packages/website/src/mocks/fixtures/p1/users/sai/groups-GET.json
+++ b/packages/website/src/mocks/fixtures/p1/users/sai/groups-GET.json
@@ -1,0 +1,20 @@
+{
+  "data": [
+    {
+      "id": 1,
+      "name": "sandbox",
+      "nsfw": false,
+      "title": "沙盒",
+      "icon": {
+        "small": "https://lain.bgm.tv/pic/icon/s/00/00/1.jpg",
+        "medium": "https://lain.bgm.tv/pic/icon/m/00/00/1.jpg",
+        "large": "https://lain.bgm.tv/pic/icon/l/00/00/1.jpg"
+      },
+      "creatorID": 1,
+      "members": 42,
+      "accessible": true,
+      "createdAt": 1500000000
+    }
+  ],
+  "total": 2
+}

--- a/packages/website/src/mocks/fixtures/p1/users/sai/indexes-GET.json
+++ b/packages/website/src/mocks/fixtures/p1/users/sai/indexes-GET.json
@@ -1,0 +1,18 @@
+{
+  "data": [
+    {
+      "id": 100,
+      "uid": 1,
+      "type": "normal",
+      "title": "我的测试目录",
+      "private": false,
+      "total": 3,
+      "stats": {
+        "subject": { "anime": 3 }
+      },
+      "createdAt": 1600000000,
+      "updatedAt": 1600000100
+    }
+  ],
+  "total": 1
+}

--- a/packages/website/src/mocks/handlers.ts
+++ b/packages/website/src/mocks/handlers.ts
@@ -1,3 +1,12 @@
 import { mockAPI } from './utils';
 
-export const handlers = [mockAPI('/p1/me', 'get'), mockAPI('/p1/home', 'get')];
+export const handlers = [
+  mockAPI('/p1/me', 'get'),
+  mockAPI('/p1/home', 'get'),
+  mockAPI('/p1/users/:username', 'get'),
+  mockAPI('/p1/users/:username/friends', 'get'),
+  mockAPI('/p1/users/:username/groups', 'get'),
+  mockAPI('/p1/users/:username/indexes', 'get'),
+  mockAPI('/p1/users/:username/blogs', 'get'),
+  mockAPI('/p1/users/:username/collections/subjects', 'get'),
+];

--- a/packages/website/src/pages/index/user/[username]/__tests__/UserHomePage.spec.tsx
+++ b/packages/website/src/pages/index/user/[username]/__tests__/UserHomePage.spec.tsx
@@ -1,0 +1,100 @@
+import type { RenderResult } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+import userFixture from '@bangumi/website/mocks/fixtures/p1/users/sai-GET.json';
+import { server as mockServer } from '@bangumi/website/mocks/server';
+import UserHomePage from '@bangumi/website/pages/index/user/[username]';
+import { renderPage } from '@bangumi/website/utils/test-utils';
+
+vi.mock('react-router-dom', async () => {
+  return {
+    __esModule: true,
+    ...(await vi.importActual<typeof import('react-router-dom')>('react-router-dom')),
+    useParams: vi.fn(),
+  } as unknown;
+});
+
+const mockedUseParams = vi.mocked(useParams);
+
+class UserHomeTest {
+  page!: RenderResult;
+
+  async setup(username: string, userData: object = userFixture): Promise<void> {
+    mockedUseParams.mockReturnValue({ username });
+
+    mockServer.use(
+      http.get(`http://localhost:3000/p1/users/${username}`, () => {
+        return HttpResponse.json(userData, { status: 200 });
+      }),
+    );
+
+    await act(async () => {
+      this.page = renderPage(<UserHomePage />);
+    });
+  }
+
+  static async create(username: string, userData?: object): Promise<UserHomeTest> {
+    const instance = new UserHomeTest();
+    await instance.setup(username, userData);
+    return instance;
+  }
+}
+
+describe('UserHomePage', () => {
+  it('should render user header and stats', async () => {
+    const test = await UserHomeTest.create('sai');
+
+    expect(await test.page.findByText('Sai')).toBeInTheDocument();
+    expect(screen.getByText('@sai')).toBeInTheDocument();
+    expect(screen.getByText('测试签名')).toBeInTheDocument();
+    // 网络服务与 bio
+    expect(screen.getByText('2010-01-01 加入')).toBeInTheDocument();
+    expect(screen.getByText('测试简介')).toBeInTheDocument();
+    // 收藏统计：动画类型 20 条收藏
+    expect(screen.getByText('20')).toBeInTheDocument();
+  });
+
+  it('should render subject collect blocks', async () => {
+    const test = await UserHomeTest.create('sai');
+
+    // 收藏统计块与收藏块标题中都会出现“动画”
+    expect((await test.page.findAllByText('动画')).length).toBeGreaterThan(0);
+    // 收藏块中的条目
+    await waitFor(() => {
+      expect(screen.getAllByText('测试动画').length).toBeGreaterThan(0);
+    });
+    expect(screen.getAllByText('测试书籍').length).toBeGreaterThan(0);
+  });
+
+  it('should render friend, group, index and blog blocks', async () => {
+    const test = await UserHomeTest.create('sai');
+
+    expect(await test.page.findByText('Sai的好友')).toBeInTheDocument();
+    expect(screen.getByText('好友甲')).toBeInTheDocument();
+    expect(screen.getByText('Sai参加的小组')).toBeInTheDocument();
+    expect(screen.getByText('沙盒')).toBeInTheDocument();
+    expect(screen.getByText('Sai的目录')).toBeInTheDocument();
+    expect(screen.getByText('我的测试目录')).toBeInTheDocument();
+    expect(screen.getByText('Sai的日志')).toBeInTheDocument();
+    expect(screen.getByText('测试日志')).toBeInTheDocument();
+  });
+
+  it('should show not found page when user does not exist', async () => {
+    mockedUseParams.mockReturnValue({ username: 'ghost' });
+
+    mockServer.use(
+      http.get('http://localhost:3000/p1/users/ghost', () => {
+        return HttpResponse.json({ message: 'user not found' }, { status: 404 });
+      }),
+    );
+
+    await act(async () => {
+      renderPage(<UserHomePage />);
+    });
+
+    expect(await screen.findByText('User Not found')).toBeInTheDocument();
+  });
+});

--- a/packages/website/src/pages/index/user/[username]/components/BlogBlock.tsx
+++ b/packages/website/src/pages/index/user/[username]/components/BlogBlock.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import type { User } from '@bangumi/client/client';
+import { Typography } from '@bangumi/design';
+import { getBlogLink, getUserBlogsPageLink } from '@bangumi/utils/pages';
+import { useUserBlogs } from '@bangumi/website/hooks/use-user-blogs';
+
+import styles from './SimpleListBlock.module.less';
+
+const { Link } = Typography;
+
+/** 用户主页的日志块 */
+const BlogBlock: React.FC<{ user: User }> = ({ user }) => {
+  const { data: blogs } = useUserBlogs(user.username, 5);
+
+  if (!blogs || blogs.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className={styles.block}>
+      <h2 className={styles.title}>
+        <Link to={getUserBlogsPageLink(user.username)}>{user.nickname}的日志</Link>
+      </h2>
+      <ul className={styles.list}>
+        {blogs.map((blog) => (
+          <li key={blog.id} className={styles.textItem}>
+            <Link to={getBlogLink(blog.id)}>{blog.title}</Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+};
+
+export default BlogBlock;

--- a/packages/website/src/pages/index/user/[username]/components/FriendBlock.module.less
+++ b/packages/website/src/pages/index/user/[username]/components/FriendBlock.module.less
@@ -1,0 +1,45 @@
+@import '@bangumi/design/theme/base';
+
+.block {
+  background: #fff;
+  border: 1px solid @gray-10;
+  border-radius: 3px;
+  padding: 12px;
+  margin-bottom: 16px;
+}
+
+.title {
+  margin: 0 0 8px;
+  font-size: 16px;
+  color: @gray-100;
+
+  a {
+    color: @blue-100;
+  }
+}
+
+.friendList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(60px, 1fr));
+  gap: 10px;
+
+  a {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    text-decoration: none;
+  }
+}
+
+.friendName {
+  max-width: 100%;
+  font-size: 12px;
+  color: @gray-80;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/packages/website/src/pages/index/user/[username]/components/FriendBlock.tsx
+++ b/packages/website/src/pages/index/user/[username]/components/FriendBlock.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import type { User } from '@bangumi/client/client';
+import { Avatar, Typography } from '@bangumi/design';
+import { getUserFriendsPageLink, getUserProfileLink } from '@bangumi/utils/pages';
+import { useUserFriends } from '@bangumi/website/hooks/use-user-friends';
+
+import styles from './FriendBlock.module.less';
+
+const { Link } = Typography;
+
+/** 用户主页的好友块 */
+const FriendBlock: React.FC<{ user: User }> = ({ user }) => {
+  const { data: friends } = useUserFriends(user.username, 15);
+
+  if (!friends || friends.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className={styles.block}>
+      <h2 className={styles.title}>
+        <Link to={getUserFriendsPageLink(user.username)}>{user.nickname}的好友</Link>
+      </h2>
+      <ul className={styles.friendList}>
+        {friends.map((friend) => (
+          <li key={friend.username}>
+            <Link to={getUserProfileLink(friend.username)} title={friend.nickname}>
+              <Avatar src={friend.avatar.medium} size='medium' alt={`${friend.nickname} 头像`} />
+              <span className={styles.friendName}>{friend.nickname}</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+};
+
+export default FriendBlock;

--- a/packages/website/src/pages/index/user/[username]/components/GroupBlock.tsx
+++ b/packages/website/src/pages/index/user/[username]/components/GroupBlock.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import type { User } from '@bangumi/client/client';
+import { Image, Typography } from '@bangumi/design';
+import { getGroupLink, getUserGroupsPageLink } from '@bangumi/utils/pages';
+import { useUserGroups } from '@bangumi/website/hooks/use-user-groups';
+
+import styles from './SimpleListBlock.module.less';
+
+const { Link } = Typography;
+
+/** 用户主页的小组块 */
+const GroupBlock: React.FC<{ user: User }> = ({ user }) => {
+  const { data: groups } = useUserGroups(user.username, 6);
+
+  if (!groups || groups.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className={styles.block}>
+      <h2 className={styles.title}>
+        <Link to={getUserGroupsPageLink(user.username)}>{user.nickname}参加的小组</Link>
+      </h2>
+      <ul className={styles.list}>
+        {groups.map((group) => (
+          <li key={group.name} className={styles.groupItem}>
+            <Image src={group.icon.medium} alt='' className={styles.groupIcon} />
+            <div className={styles.groupInfo}>
+              <Link to={getGroupLink(group.name)}>{group.title}</Link>
+              <span className={styles.meta}>{group.members} 位成员</span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+};
+
+export default GroupBlock;

--- a/packages/website/src/pages/index/user/[username]/components/HomeBlocks.tsx
+++ b/packages/website/src/pages/index/user/[username]/components/HomeBlocks.tsx
@@ -1,0 +1,41 @@
+import type { JSX } from 'react';
+import React from 'react';
+
+import type { User } from '@bangumi/client/client';
+
+import BlogBlock from './BlogBlock';
+import FriendBlock from './FriendBlock';
+import GroupBlock from './GroupBlock';
+import IndexBlock from './IndexBlock';
+import SubjectCollectBlock from './SubjectCollectBlock';
+
+const SUBJECT_COLLECT_BLOCKS = ['anime', 'game', 'book', 'music', 'real'];
+
+function renderBlock(user: User, block: string): JSX.Element | null {
+  if (SUBJECT_COLLECT_BLOCKS.includes(block)) {
+    return <SubjectCollectBlock key={block} user={user} block={block} />;
+  }
+  switch (block) {
+    case 'blog':
+      return <BlogBlock key={block} user={user} />;
+    case 'friend':
+      return <FriendBlock key={block} user={user} />;
+    case 'group':
+      return <GroupBlock key={block} user={user} />;
+    case 'index':
+      return <IndexBlock key={block} user={user} />;
+    default:
+      // mono 等模块暂未实现
+      return null;
+  }
+}
+
+/** 渲染用户主页左侧模块（收藏块/日志） */
+export const HomeLeftBlocks: React.FC<{ user: User }> = ({ user }) => (
+  <>{user.homepage.left.map((block) => renderBlock(user, block))}</>
+);
+
+/** 渲染用户主页右侧模块（好友/小组/目录） */
+export const HomeRightBlocks: React.FC<{ user: User }> = ({ user }) => (
+  <>{user.homepage.right.map((block) => renderBlock(user, block))}</>
+);

--- a/packages/website/src/pages/index/user/[username]/components/IndexBlock.tsx
+++ b/packages/website/src/pages/index/user/[username]/components/IndexBlock.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import type { User } from '@bangumi/client/client';
+import { Typography } from '@bangumi/design';
+import { getIndexLink, getUserIndexesPageLink } from '@bangumi/utils/pages';
+import { useUserIndexes } from '@bangumi/website/hooks/use-user-indexes';
+
+import styles from './SimpleListBlock.module.less';
+
+const { Link } = Typography;
+
+/** 用户主页的目录块 */
+const IndexBlock: React.FC<{ user: User }> = ({ user }) => {
+  const { data: indexes } = useUserIndexes(user.username, 5);
+
+  if (!indexes || indexes.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className={styles.block}>
+      <h2 className={styles.title}>
+        <Link to={getUserIndexesPageLink(user.username)}>{user.nickname}的目录</Link>
+      </h2>
+      <ul className={styles.list}>
+        {indexes.map((index) => (
+          <li key={index.id} className={styles.textItem}>
+            <Link to={getIndexLink(index.id)}>{index.title}</Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+};
+
+export default IndexBlock;

--- a/packages/website/src/pages/index/user/[username]/components/SimpleListBlock.module.less
+++ b/packages/website/src/pages/index/user/[username]/components/SimpleListBlock.module.less
@@ -1,0 +1,76 @@
+@import '@bangumi/design/theme/base';
+
+.block {
+  background: #fff;
+  border: 1px solid @gray-10;
+  border-radius: 3px;
+  padding: 12px;
+  margin-bottom: 16px;
+}
+
+.title {
+  margin: 0 0 8px;
+  font-size: 16px;
+  color: @gray-100;
+
+  a {
+    color: @blue-100;
+  }
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.textItem {
+  padding: 5px 0;
+  font-size: 13px;
+
+  a {
+    color: @gray-80;
+    text-decoration: none;
+
+    &:hover {
+      color: @blue-100;
+    }
+  }
+}
+
+.groupItem {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 0;
+}
+
+.groupIcon {
+  width: 32px;
+  height: 32px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.groupInfo {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+
+  a {
+    color: @gray-80;
+    text-decoration: none;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    &:hover {
+      color: @blue-100;
+    }
+  }
+}
+
+.meta {
+  font-size: 12px;
+  color: @gray-60;
+}

--- a/packages/website/src/pages/index/user/[username]/components/SubjectCollectBlock.module.less
+++ b/packages/website/src/pages/index/user/[username]/components/SubjectCollectBlock.module.less
@@ -1,0 +1,72 @@
+@import '@bangumi/design/theme/base';
+
+.block {
+  background: #fff;
+  border: 1px solid @gray-10;
+  border-radius: 3px;
+  padding: 12px;
+  margin-bottom: 16px;
+}
+
+.title {
+  margin: 0 0 8px;
+  font-size: 16px;
+  color: @gray-100;
+
+  a {
+    color: @blue-100;
+  }
+}
+
+.statList {
+  list-style: none;
+  margin: 0 0 10px;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 12px;
+
+  li {
+    display: flex;
+    gap: 4px;
+    font-size: 12px;
+    color: @gray-60;
+  }
+}
+
+.statCount {
+  color: @gray-100;
+}
+
+.coverList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+}
+
+.coverItem {
+  a {
+    display: block;
+    text-decoration: none;
+  }
+
+  img {
+    width: 100%;
+    aspect-ratio: 3 / 4;
+    object-fit: cover;
+    border-radius: 3px;
+  }
+}
+
+.coverName {
+  display: block;
+  margin-top: 4px;
+  font-size: 12px;
+  color: @gray-80;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/packages/website/src/pages/index/user/[username]/components/SubjectCollectBlock.tsx
+++ b/packages/website/src/pages/index/user/[username]/components/SubjectCollectBlock.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+import type { User } from '@bangumi/client/client';
+import { Image, Typography } from '@bangumi/design';
+import { getSubjectLink, getUserCollectionsLink } from '@bangumi/utils/pages';
+import { useUserSubjectCollections } from '@bangumi/website/hooks/use-user-collections';
+
+import { COLLECTION_LABELS, SUBJECT_BLOCKS } from './constants';
+import styles from './SubjectCollectBlock.module.less';
+
+const { Link } = Typography;
+
+/** 用户主页的条目收藏块（动画/书籍/音乐/游戏/三次元） */
+const SubjectCollectBlock: React.FC<{ user: User; block: string }> = ({ user, block }) => {
+  const meta = SUBJECT_BLOCKS[block];
+  if (!meta) {
+    return null;
+  }
+
+  const { data: collections } = useUserSubjectCollections(user.username, meta.subjectType, 8);
+
+  if (!collections || collections.length === 0) {
+    return null;
+  }
+
+  const stats = user.stats.subject[meta.subjectType];
+
+  return (
+    <section className={styles.block}>
+      <h2 className={styles.title}>
+        <Link to={getUserCollectionsLink(meta.path, user.username)}>{meta.label}</Link>
+      </h2>
+      {stats && (
+        <ul className={styles.statList}>
+          {Object.entries(COLLECTION_LABELS).map(([type, label]) => (
+            <li key={type}>
+              <span className={styles.statLabel}>{label}</span>
+              <span className={styles.statCount}>{stats[type] ?? 0}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+      <ul className={styles.coverList}>
+        {collections.map((subject) => (
+          <li key={subject.id} className={styles.coverItem}>
+            <Link to={getSubjectLink(subject.id)} title={subject.nameCN || subject.name}>
+              <Image src={subject.images?.medium ?? ''} alt={subject.nameCN || subject.name} />
+              <span className={styles.coverName}>{subject.nameCN || subject.name}</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+};
+
+export default SubjectCollectBlock;

--- a/packages/website/src/pages/index/user/[username]/components/UserHeader.module.less
+++ b/packages/website/src/pages/index/user/[username]/components/UserHeader.module.less
@@ -1,0 +1,34 @@
+@import '@bangumi/design/theme/base';
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  gap: 20px;
+  margin-bottom: 20px;
+}
+
+.info {
+  min-width: 0;
+}
+
+.nameRow {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+
+.nickname {
+  font-size: 24px;
+  font-weight: bold;
+  color: @gray-100;
+}
+
+.username {
+  color: @gray-60;
+}
+
+.sign {
+  margin-top: 6px;
+  color: @gray-60;
+  word-break: break-all;
+}

--- a/packages/website/src/pages/index/user/[username]/components/UserHeader.tsx
+++ b/packages/website/src/pages/index/user/[username]/components/UserHeader.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import type { User } from '@bangumi/client/client';
+import { Avatar } from '@bangumi/design';
+
+import styles from './UserHeader.module.less';
+
+const UserHeader: React.FC<{ user: User }> = ({ user }) => {
+  return (
+    <div className={styles.header}>
+      <Avatar src={user.avatar.large} size='large' alt={`${user.nickname} 头像`} />
+      <div className={styles.info}>
+        <div className={styles.nameRow}>
+          <span className={styles.nickname}>{user.nickname}</span>
+          <span className={styles.username}>@{user.username}</span>
+        </div>
+        {user.sign && <p className={styles.sign}>{user.sign}</p>}
+      </div>
+    </div>
+  );
+};
+
+export default UserHeader;

--- a/packages/website/src/pages/index/user/[username]/components/UserInfoCard.module.less
+++ b/packages/website/src/pages/index/user/[username]/components/UserInfoCard.module.less
@@ -1,0 +1,50 @@
+@import '@bangumi/design/theme/base';
+
+.card {
+  background: #fff;
+  border: 1px solid @gray-10;
+  border-radius: 3px;
+  padding: 12px;
+  margin-bottom: 16px;
+}
+
+.services {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+
+  li {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 0;
+    font-size: 12px;
+    color: @gray-80;
+    overflow: hidden;
+  }
+
+  a {
+    color: @blue-100;
+    text-decoration: none;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+.serviceName {
+  flex-shrink: 0;
+  padding: 1px 6px;
+  border-radius: 3px;
+  color: #fff;
+  font-size: 12px;
+}
+
+.bio {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid @gray-10;
+  font-size: 13px;
+  color: @gray-80;
+  word-break: normal;
+}

--- a/packages/website/src/pages/index/user/[username]/components/UserInfoCard.tsx
+++ b/packages/website/src/pages/index/user/[username]/components/UserInfoCard.tsx
@@ -1,0 +1,49 @@
+import dayjs from 'dayjs';
+import React from 'react';
+
+import type { User } from '@bangumi/client/client';
+import { render as renderBBCode } from '@bangumi/utils';
+
+import styles from './UserInfoCard.module.less';
+
+function withProtocol(url: string): string {
+  return /^https?:\/\//i.test(url) ? url : `https://${url}`;
+}
+
+const UserInfoCard: React.FC<{ user: User }> = ({ user }) => {
+  return (
+    <section className={styles.card}>
+      <ul className={styles.services}>
+        <li>
+          <span className={styles.serviceName}>Bangumi</span>
+          <span>{dayjs.unix(user.joinedAt).format('YYYY-MM-DD')} 加入</span>
+        </li>
+        {user.site && (
+          <li>
+            <span className={styles.serviceName}>Home</span>
+            <a href={withProtocol(user.site)} target='_blank' rel='nofollow me'>
+              {user.site}
+            </a>
+          </li>
+        )}
+        {user.networkServices.map((svc) => (
+          <li key={svc.name}>
+            <span className={styles.serviceName} style={{ backgroundColor: svc.color }}>
+              {svc.title}
+            </span>
+            {svc.url ? (
+              <a href={svc.url} target='_blank' rel='nofollow external noopener noreferrer'>
+                {svc.account}
+              </a>
+            ) : (
+              <span>{svc.account}</span>
+            )}
+          </li>
+        ))}
+      </ul>
+      {user.bio && <div className={styles.bio}>{renderBBCode(user.bio)}</div>}
+    </section>
+  );
+};
+
+export default UserInfoCard;

--- a/packages/website/src/pages/index/user/[username]/components/UserStatsBlock.module.less
+++ b/packages/website/src/pages/index/user/[username]/components/UserStatsBlock.module.less
@@ -1,0 +1,40 @@
+@import '@bangumi/design/theme/base';
+
+.block {
+  background: #fff;
+  border: 1px solid @gray-10;
+  border-radius: 3px;
+  padding: 12px;
+  margin-bottom: 16px;
+}
+
+.title {
+  margin: 0 0 10px;
+  font-size: 16px;
+  color: @gray-100;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+
+.num {
+  font-size: 20px;
+  font-weight: bold;
+  color: @gray-100;
+}
+
+.desc {
+  font-size: 12px;
+  color: @gray-60;
+}

--- a/packages/website/src/pages/index/user/[username]/components/UserStatsBlock.tsx
+++ b/packages/website/src/pages/index/user/[username]/components/UserStatsBlock.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+
+import type { CollectionType, User } from '@bangumi/client/client';
+import { Tab } from '@bangumi/design';
+
+import { COLLECTION_LABELS, SUBJECT_BLOCK_LIST } from './constants';
+import styles from './UserStatsBlock.module.less';
+
+type SubjectStats = Record<string, number>;
+
+/** 某类型条目的收藏统计，缺失的状态按 0 处理 */
+function renderStatItems(stats?: SubjectStats): { label: string; value: number }[] {
+  const types = [1, 2, 3, 4, 5] as CollectionType[];
+  const total = stats ? Object.values(stats).reduce((sum, count) => sum + count, 0) : 0;
+  return [
+    { label: '收藏', value: total },
+    ...types.map((type) => ({
+      label: COLLECTION_LABELS[type],
+      value: stats?.[type] ?? 0,
+    })),
+  ];
+}
+
+const UserStatsBlock: React.FC<{ user: User }> = ({ user }) => {
+  const { subject } = user.stats;
+  const available = SUBJECT_BLOCK_LIST.filter(({ subjectType }) => {
+    const stats = subject[subjectType];
+    return stats != null && Object.values(stats).some((count) => count > 0);
+  });
+
+  const [activeType, setActiveType] = useState(available[0]?.subjectType);
+
+  if (available.length === 0) {
+    return null;
+  }
+
+  const active = available.find((item) => item.subjectType === activeType) ?? available[0]!;
+  const activeStats = subject[active.subjectType];
+  const statItems = renderStatItems(activeStats);
+
+  return (
+    <section className={styles.block}>
+      <h2 className={styles.title}>收藏统计</h2>
+      {available.length > 1 && (
+        <Tab
+          items={available.map((item) => ({ key: item.subjectType, label: item.label }))}
+          activeKey={active.subjectType}
+          onChange={(key) => setActiveType(key as typeof active.subjectType)}
+        />
+      )}
+      <div className={styles.grid}>
+        {statItems.map(({ label, value }) => (
+          <div key={label} className={styles.item}>
+            <span className={styles.num}>{value}</span>
+            <span className={styles.desc}>{label}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default UserStatsBlock;

--- a/packages/website/src/pages/index/user/[username]/components/constants.ts
+++ b/packages/website/src/pages/index/user/[username]/components/constants.ts
@@ -1,0 +1,22 @@
+import { CollectionType, SubjectType } from '@bangumi/client/client';
+
+/** 用户主页可展示的条目收藏模块（homepage 配置中的 block 名） */
+export const SUBJECT_BLOCK_LIST = [
+  { block: 'anime', subjectType: SubjectType.Anime, label: '动画', path: 'anime' },
+  { block: 'book', subjectType: SubjectType.Book, label: '书籍', path: 'book' },
+  { block: 'music', subjectType: SubjectType.Music, label: '音乐', path: 'music' },
+  { block: 'game', subjectType: SubjectType.Game, label: '游戏', path: 'game' },
+  { block: 'real', subjectType: SubjectType.Real, label: '三次元', path: 'real' },
+] as const;
+
+export const SUBJECT_BLOCKS: Record<string, (typeof SUBJECT_BLOCK_LIST)[number]> =
+  Object.fromEntries(SUBJECT_BLOCK_LIST.map((item) => [item.block, item]));
+
+/** 收藏状态的中文名（对齐 CollectionPanel 的命名） */
+export const COLLECTION_LABELS: Record<CollectionType, string> = {
+  [CollectionType.Wish]: '想看',
+  [CollectionType.Collect]: '看过',
+  [CollectionType.Doing]: '在看',
+  [CollectionType.OnHold]: '搁置',
+  [CollectionType.Dropped]: '抛弃',
+};

--- a/packages/website/src/pages/index/user/[username]/index.module.less
+++ b/packages/website/src/pages/index/user/[username]/index.module.less
@@ -1,0 +1,33 @@
+@import '@bangumi/design/theme/base';
+
+.page {
+  padding: 23px 46px;
+}
+
+.columns {
+  display: flex;
+  align-items: flex-start;
+  gap: 20px;
+}
+
+.columnLeft {
+  flex: 0 0 220px;
+  width: 220px;
+  min-width: 0;
+}
+
+.columnRight {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+@media (max-width: @md) {
+  .columns {
+    flex-direction: column;
+  }
+
+  .columnLeft {
+    flex: none;
+    width: 100%;
+  }
+}

--- a/packages/website/src/pages/index/user/[username]/index.tsx
+++ b/packages/website/src/pages/index/user/[username]/index.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+import { UnreadableCodeError } from '@bangumi/utils';
+import { withErrorBoundary } from '@bangumi/website/components/ErrorBoundary';
+import Helmet from '@bangumi/website/components/Helmet';
+import { useUserHome } from '@bangumi/website/hooks/use-user-home';
+
+import { HomeLeftBlocks, HomeRightBlocks } from './components/HomeBlocks';
+import UserHeader from './components/UserHeader';
+import UserInfoCard from './components/UserInfoCard';
+import UserStatsBlock from './components/UserStatsBlock';
+import styles from './index.module.less';
+
+const UserHomePage: React.FC = () => {
+  const { username } = useParams();
+  if (!username) {
+    throw new UnreadableCodeError('BUG: username is undefined');
+  }
+
+  const { data: user } = useUserHome(username);
+
+  if (!user) {
+    return null;
+  }
+
+  return (
+    <>
+      <Helmet title={`${user.nickname}的主页`} />
+      <main className={styles.page}>
+        <UserHeader user={user} />
+        <div className={styles.columns}>
+          <div className={styles.columnLeft}>
+            <UserInfoCard user={user} />
+            <HomeLeftBlocks user={user} />
+          </div>
+          <div className={styles.columnRight}>
+            <UserStatsBlock user={user} />
+            <HomeRightBlocks user={user} />
+          </div>
+        </div>
+      </main>
+    </>
+  );
+};
+
+export default withErrorBoundary(UserHomePage, { 404: <>User Not found</> });

--- a/packages/website/src/routes.tsx
+++ b/packages/website/src/routes.tsx
@@ -25,6 +25,7 @@ const WikiHistory = lazy(async () => import('./pages/index/subject/[id]/wiki/his
 const WikiHome = lazy(async () => import('./pages/index/subject/[id]/wiki/index'));
 const WikiUploadImg = lazy(async () => import('./pages/index/subject/[id]/wiki/upload_img'));
 const Login = lazy(async () => import('./pages/login'));
+const UserHome = lazy(async () => import('./pages/index/user/[username]'));
 
 const legacyPagePaths = [
   'about',
@@ -65,7 +66,6 @@ const legacyPagePaths = [
   'subject/tag/:tag',
   'subject/topic/:id',
   'tokei',
-  'user/:username',
   'user/:username/timeline/status/:id',
   'wiki',
 ] as const;
@@ -146,6 +146,10 @@ export const pageRoutes: RouteObject[] = [
             ],
           },
         ],
+      },
+      {
+        path: 'user',
+        children: [{ path: ':username', element: <UserHome /> }],
       },
     ],
   },


### PR DESCRIPTION
## Summary

Implement the public user home page at `/user/:username`, following the layout of the legacy site (bgm.tv `/user/{username}`) using the new design system.

## What's included

- Route `/user/:username` registered in `routes.tsx`, public page with 404 fallback ("User Not found")
- `UserHeader`: avatar, nickname, `@username`, sign
- `UserInfoCard`: join date, site, network services, bio
- `UserStatsBlock`: collection stats with tabs (anime / book / music / game / real) showing counts per collection state
- Homepage blocks rendered according to `User.homepage` (left/right config):
  - Subject collection blocks (`anime`/`book`/`music`/`game`/`real`): state counts + recent covers
  - `friend` / `group` / `index` / `blog` blocks (each skipped when empty)
- New SWR hooks: `use-user-home`, `use-user-collections`, `use-user-friends`, `use-user-groups`, `use-user-indexes`, `use-user-blogs`
- `getUserProfileLink` now points to the internal route `/user/{username}`; added user page link helpers to `@bangumi/utils/pages`
- MSW handlers + fixtures, and component tests (render header/stats/blocks, 404 case)

## Notes

- Timeline (时间胶囊) and rating stats (avg score / deviation) are intentionally left out of this first version.
- Snapshot updates for `Comment.spec.tsx` are only the `getUserProfileLink` href change (`https://bgm.tv/user/...` → `/user/...`).

## Verification

- `pnpm type-check` ✅
- `pnpm lint`, `pnpm lint:style`, `pnpm prettier:check` ✅
- Full `pnpm test` — 238 passed; the 1 failing test (`group/[name]/index.spec.tsx` localStorage `setItem`) and `wiki.spec.ts` (missing git submodule) also fail on clean `master` (pre-existing).