### PR TITLE
fix: make header avatar link to user profile

### DIFF
--- a/packages/website/src/components/Header/index.spec.tsx
+++ b/packages/website/src/components/Header/index.spec.tsx
@@ -1,0 +1,27 @@
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { UserProvider } from '@bangumi/website/hooks/use-user';
+
+import Header from '.';
+
+const renderHeader = () =>
+  render(
+    <MemoryRouter>
+      <UserProvider>
+        <Header />
+      </UserProvider>
+    </MemoryRouter>,
+  );
+
+describe('Header', () => {
+  it('头像应链接到当前用户的个人主页', async () => {
+    const { container } = renderHeader();
+
+    // fixture: packages/website/src/mocks/fixtures/p1/me-GET.json，username 为 "382951"
+    await waitFor(() => {
+      expect(container.querySelector('a[href="/user/382951"]')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/website/src/components/Header/index.tsx
+++ b/packages/website/src/components/Header/index.tsx
@@ -6,6 +6,7 @@ import { Link, useLocation } from 'react-router-dom';
 import { Avatar, Button, Divider, Input, Menu } from '@bangumi/design';
 import { Notification, Search as SearchIcon } from '@bangumi/icons';
 import { UnreadableCodeError } from '@bangumi/utils';
+import { getUserProfileLink } from '@bangumi/utils/pages';
 import { useNotify } from '@bangumi/website/hooks/use-notify';
 
 import { ReactComponent as Logo } from '../../assets/logo.svg';
@@ -158,7 +159,9 @@ const Header: FC = () => {
               >
                 <Notification />
               </Link>
-              <Avatar src={user.avatar.large} wrapperClass={style.avatar} />
+              <Link to={getUserProfileLink(user.username)}>
+                <Avatar src={user.avatar.large} wrapperClass={style.avatar} />
+              </Link>
             </>
           ) : (
             <span className={style.userLogin}>


### PR DESCRIPTION
Clicking the avatar in the header did nothing because the `Avatar` component is purely presentational and had no link or click handler.

## Changes
- Wrap the header avatar in a `Link` to `/user/:username` using `getUserProfileLink`, matching the existing pattern in `SubjectDetailBlocks` and `FriendBlock`.
- Add a unit test asserting the avatar links to the current user's profile (fixture `me-GET.json`).

## Verification
- `pnpm vitest run packages/website/src/components/Header/index.spec.tsx` passed
- ESLint, `tsc --noEmit`, Prettier check passed