### PR TITLE
fix: wait for user info before rendering home page

### DIFF
--- a/packages/website/src/hooks/use-user.spec.tsx
+++ b/packages/website/src/hooks/use-user.spec.tsx
@@ -5,6 +5,7 @@ import { http, HttpResponse } from 'msw';
 import type { PropsWithChildren } from 'react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
+import { SWRConfig } from 'swr';
 
 import { server as mockServer } from '../mocks/server';
 import {
@@ -73,7 +74,9 @@ beforeEach(() => {
 
 const wrapper = ({ children }: PropsWithChildren) => (
   <MemoryRouter>
-    <UserProvider>{children}</UserProvider>
+    <SWRConfig value={{ provider: () => new Map() }}>
+      <UserProvider>{children}</UserProvider>
+    </SWRConfig>
   </MemoryRouter>
 );
 
@@ -119,6 +122,33 @@ it('should refresh me if login succeeded', async () => {
     await result.current.login('fakeuser', 'fakepassword', 'fake-token');
     expect(result.current.user).toMatchSnapshot();
   });
+});
+
+it('should stay loading until /me request resolves', async () => {
+  let resolveMe!: (value: unknown) => void;
+  mockServer.use(
+    http.get('http://localhost:3000/p1/me', async () => {
+      return new Promise((resolve) => {
+        resolveMe = resolve as (value: unknown) => void;
+      });
+    }),
+  );
+
+  const { result } = renderHook(() => useUser(), { wrapper });
+
+  // 等待请求发出，随后验证请求未完成时的状态
+  await waitFor(() => {
+    expect(typeof resolveMe).toBe('function');
+  });
+  expect(result.current.isLoading).toBe(true);
+  expect(result.current.user).toBeUndefined();
+
+  resolveMe(HttpResponse.json({ id: 1, username: 'fakeuser' }, { status: 200 }));
+
+  await waitFor(() => {
+    expect(result.current.isLoading).toBe(false);
+  });
+  expect(result.current.user).toEqual({ id: 1, username: 'fakeuser' });
 });
 
 it('should return true if passkey login succeeded', async () => {

--- a/packages/website/src/hooks/use-user.tsx
+++ b/packages/website/src/hooks/use-user.tsx
@@ -14,6 +14,8 @@ import type { Profile } from '@bangumi/client/user';
 
 interface UserContextType {
   user?: Profile;
+  /** 是否正在请求当前用户信息，加载完成前不应据此判断登录状态 */
+  isLoading: boolean;
   redirectToLogin: () => void;
   login: (username: string, password: string, captchaResp: string) => Promise<void>;
   /** 使用 Passkey 登录，成功返回 true，用户取消返回 false */
@@ -57,7 +59,11 @@ export class PasswordUnMatchError extends Error {
 }
 
 export const UserProvider: React.FC<PropsWithChildren> = ({ children }) => {
-  const { data: user, mutate } = useSWR('/me', async () => ok(ozaClient.getCurrentUser()));
+  const {
+    data: user,
+    mutate,
+    isLoading,
+  } = useSWR('/me', async () => ok(ozaClient.getCurrentUser()));
   const navigate = useNavigate();
 
   function redirectToLogin(): void {
@@ -78,6 +84,7 @@ export const UserProvider: React.FC<PropsWithChildren> = ({ children }) => {
       return ok;
     },
     user,
+    isLoading,
   };
 
   return <UserContext.Provider value={value}>{children}</UserContext.Provider>;

--- a/packages/website/src/pages/index/index.tsx
+++ b/packages/website/src/pages/index/index.tsx
@@ -8,7 +8,11 @@ import { useUser } from '@bangumi/website/hooks/use-user';
 import HomePage from './index/components/HomePage';
 
 function HomeIndex() {
-  const { user } = useUser();
+  const { user, isLoading } = useUser();
+  // 等待当前用户信息加载完成，避免首次渲染误判为未登录
+  if (isLoading) {
+    return null;
+  }
   // 未登录首页暂不实现，保持原 404 行为
   if (!user) {
     throw PageNeedLoginError;

--- a/packages/website/src/pages/index/notifications/index.tsx
+++ b/packages/website/src/pages/index/notifications/index.tsx
@@ -135,7 +135,11 @@ function Notifications() {
 }
 
 function NotificationPage() {
-  const { user } = useUser();
+  const { user, isLoading } = useUser();
+  // 等待当前用户信息加载完成，避免首次渲染误判为未登录
+  if (isLoading) {
+    return null;
+  }
   if (!user) {
     throw PageNeedLoginError;
   }


### PR DESCRIPTION
## Why

The home page occasionally failed to load with a "需要登录" error even when the user was logged in. Root cause was a race condition:

- `useUser()` is the only hook whose `useSWR('/me', ...)` call lacks `suspense: true`, so on the first render `user` is always `undefined`.
- `HomeIndex` / `NotificationPage` threw `PageNeedLoginError` immediately, and the `ErrorBoundary` permanently captured the error — it never recovers even after `/p1/me` resolves.
- Whether the page loads depends on a race between lazy chunk loading and the `/p1/me` request, hence the intermittent failure.

## What

- Expose `isLoading` from `UserContext` so consumers can distinguish "still loading" from "actually not logged in".
- `HomeIndex` and `NotificationPage` now wait for the user request to settle before deciding whether to show the login-required error.
- Add a regression test verifying `isLoading` stays `true` until `/p1/me` resolves, and isolate the test SWR cache per test.

## Verification

- `pnpm vitest run packages/website/src/hooks/use-user.spec.tsx packages/website/src/pages/index/index/HomePage.spec.tsx` passes.
- `pnpm type-check` passes.
- Verified against the dev server with Playwright: the home page now consistently renders the timeline instead of intermittently showing the login-required error page.