### PR TITLE
fix(website): align home timeline layout

### DIFF
--- a/packages/website/src/pages/index/index/HomePage.spec.tsx
+++ b/packages/website/src/pages/index/index/HomePage.spec.tsx
@@ -1,6 +1,7 @@
 import { act, fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import React from 'react';
+import { SWRConfig } from 'swr';
 
 import { server as mockServer } from '@bangumi/website/mocks/server';
 import { renderPage } from '@bangumi/website/utils/test-utils';
@@ -40,7 +41,11 @@ describe('HomePage', () => {
 
   const renderHome = async () => {
     await act(async () => {
-      renderPage(<HomePage />);
+      renderPage(
+        <SWRConfig value={{ provider: () => new Map() }}>
+          <HomePage />
+        </SWRConfig>,
+      );
     });
   };
 

--- a/packages/website/src/pages/index/index/HomePage.spec.tsx
+++ b/packages/website/src/pages/index/index/HomePage.spec.tsx
@@ -43,7 +43,9 @@ describe('HomePage', () => {
     await act(async () => {
       renderPage(
         <SWRConfig value={{ provider: () => new Map() }}>
-          <HomePage />
+          <React.Suspense fallback={null}>
+            <HomePage />
+          </React.Suspense>
         </SWRConfig>,
       );
     });

--- a/packages/website/src/pages/index/index/HomePage.spec.tsx
+++ b/packages/website/src/pages/index/index/HomePage.spec.tsx
@@ -77,6 +77,118 @@ describe('HomePage', () => {
     expect(document.querySelector('a[href="https://bgm.tv/subject/12"]')).not.toBeInTheDocument();
   });
 
+  it('should render timeline subject cards and action summaries', async () => {
+    const baseTimeline = homeFixture.timeline[0];
+    const anime = {
+      id: 268070,
+      name: '荒ぶる季節の乙女どもよ。',
+      nameCN: '骚动时节的少女们啊',
+      type: 2,
+      info: '12话 / 2019年7月5日 / 安藤真裕',
+      metaTags: [],
+      rating: { rank: 0, count: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], score: 0, total: 0 },
+      locked: false,
+      nsfw: false,
+      images: {
+        large: '/anime-large.jpg',
+        common: '/anime-common.jpg',
+        medium: '/anime-medium.jpg',
+        small: '/anime-small.jpg',
+        grid: '/anime-grid.jpg',
+      },
+    };
+    const book = {
+      ...anime,
+      id: 467390,
+      name: '冒険者になれなかった俺',
+      nameCN: '没能成为冒险者的我',
+      type: 1,
+      info: '2024-09-27 / ぺい / KADOKAWA',
+      images: {
+        large: '/book-large.jpg',
+        common: '/book-common.jpg',
+        medium: '/book-medium.jpg',
+        small: '/book-small.jpg',
+        grid: '/book-grid.jpg',
+      },
+    };
+
+    mockServer.use(
+      http.get('http://localhost:3000/p1/home', () =>
+        HttpResponse.json({
+          ...homeFixture,
+          timeline: [
+            {
+              ...baseTimeline,
+              id: 9002,
+              cat: 4,
+              type: 2,
+              source: { name: 'Chobits iOS', url: 'https://bgm.tv/group/topic/1' },
+              memo: {
+                progress: {
+                  single: {
+                    subject: anime,
+                    episode: {
+                      id: 893064,
+                      subjectID: anime.id,
+                      sort: 6,
+                      type: 0,
+                      disc: 0,
+                      name: '乙女は森のなか',
+                      nameCN: '少女隐于林',
+                      duration: '24m',
+                      airdate: '2019-08-09',
+                      comment: 0,
+                      desc: '',
+                    },
+                  },
+                },
+              },
+            },
+            {
+              ...baseTimeline,
+              id: 9003,
+              cat: 4,
+              type: 0,
+              memo: {
+                progress: {
+                  batch: {
+                    epsTotal: '??',
+                    epsUpdate: 26,
+                    volsTotal: '??',
+                    subject: book,
+                  },
+                },
+              },
+            },
+            {
+              ...baseTimeline,
+              id: 9004,
+              cat: 3,
+              type: 13,
+              memo: { subject: [{ subject: book, comment: '', rate: 0 }] },
+            },
+          ],
+        }),
+      ),
+    );
+    await renderHome();
+
+    const episodeLink = await screen.findByRole('link', { name: 'ep.6 乙女は森のなか' });
+    expect(episodeLink).toHaveAttribute('href', '/ep/893064');
+    expect(screen.getByRole('img', { name: '骚动时节的少女们啊' })).toHaveAttribute(
+      'src',
+      '/anime-grid.jpg',
+    );
+    expect(screen.getByText(/读过.*第26话/)).toBeInTheDocument();
+    expect(screen.getByText(/搁置了/)).toBeInTheDocument();
+    expect(screen.getByText('2024-09-27 / ぺい / KADOKAWA')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Chobits iOS' })).toHaveAttribute(
+      'href',
+      'https://bgm.tv/group/topic/1',
+    );
+  });
+
   it('should mark the last unwatched episode as watched', async () => {
     setupHome();
     let patchedBody: unknown = null;

--- a/packages/website/src/pages/index/index/components/HomePage.module.less
+++ b/packages/website/src/pages/index/index/components/HomePage.module.less
@@ -2,7 +2,13 @@
 
 .page {
   width: 100%;
+  max-width: 1180px;
   box-sizing: border-box;
+  margin: 0 auto;
+
+  :global(.bgm-link) {
+    color: #0084b4;
+  }
 }
 
 .greets {
@@ -17,17 +23,17 @@
 .columns {
   display: flex;
   align-items: flex-start;
-  gap: 16px;
+  gap: 10px;
 }
 
 .columnLeft {
-  flex: 1 1 auto;
+  flex: 7 1 0;
   min-width: 0;
 }
 
 .columnRight {
-  flex: 0 0 290px;
-  width: 290px;
+  flex: 3 1 0;
+  min-width: 0;
   box-sizing: border-box;
 }
 

--- a/packages/website/src/pages/index/index/components/TimelineBlock.module.less
+++ b/packages/website/src/pages/index/index/components/TimelineBlock.module.less
@@ -2,7 +2,7 @@
 
 .block {
   background: #fff;
-  border: 1px solid @gray-10;
+  border: 1px solid #eee;
   border-radius: 14px;
   margin: 0 0 20px;
   overflow: hidden;
@@ -108,11 +108,11 @@
 }
 
 .dayTitle {
-  margin: 0;
-  padding: 9px 10px 6px;
-  border-bottom: 1px solid @gray-10;
-  color: #149bc5;
-  font-size: 15px;
+  margin: 10px 0 5px;
+  padding: 0 0 5px 10px;
+  border-bottom: 1px solid #e8e8e8;
+  color: #1175a8;
+  font-size: 14px;
   font-weight: normal;
 }
 
@@ -124,13 +124,9 @@
 
 .item {
   display: flex;
-  gap: 8px;
-  padding: 10px;
-  border-bottom: 1px dotted @gray-10;
-
-  &:last-child {
-    border-bottom: none;
-  }
+  align-items: flex-start;
+  margin: 5px 0;
+  padding: 5px 0 0;
 }
 
 .empty {
@@ -160,17 +156,39 @@
 }
 
 .avatarLink {
-  flex: none;
+  flex: 0 0 50px;
+  width: 50px;
+  height: 50px;
+  margin: 0 5px;
+  overflow: hidden;
+}
+
+.avatar {
+  border: 0;
+  border-radius: 50%;
+
+  img {
+    border-radius: 50%;
+  }
 }
 
 .info {
+  flex: 1 1 auto;
   min-width: 0;
-  font-size: 13px;
-  line-height: 1.6;
+  min-height: 35px;
+  padding: 0 5px 5px 0;
+  border-bottom: 1px dotted #e8e8e8;
+  color: #666;
+  font-size: 14px;
+  line-height: 1.2;
+
+  :global(.bgm-link) {
+    color: #0084b4;
+  }
 }
 
 .desc {
-  color: @gray-100;
+  color: #555;
   overflow-wrap: anywhere;
 
   p {
@@ -179,14 +197,119 @@
 }
 
 .statusText {
-  color: @gray-80;
-  margin: 2px 0 0;
+  margin: 5px 10px 0 0;
+  color: #333;
+  font-size: 15px;
+  line-height: 1.5;
   overflow-wrap: anywhere;
   white-space: pre-wrap;
 }
 
+.subjectCards {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.subjectCard {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  width: min(600px, 100%);
+  min-height: 36px;
+  max-height: 36px;
+  box-sizing: border-box;
+  margin-top: 5px;
+  padding: 5px;
+  overflow: hidden;
+  border: 1px solid #eee;
+  border-radius: 10px;
+  background: #fff;
+}
+
+.subjectCardDetailed {
+  align-items: center;
+  min-height: 80px;
+  max-height: none;
+  padding: 5px;
+
+  .subjectCover {
+    width: 60px;
+    height: 70px;
+  }
+}
+
+.subjectCoverLink {
+  display: block;
+  flex: none;
+}
+
+.subjectCover {
+  display: block;
+  width: 25px;
+  height: 25px;
+  border-radius: 5px;
+  object-fit: cover;
+}
+
+.subjectInfo {
+  min-width: 0;
+}
+
+.subjectTitle {
+  display: block;
+  color: #454545;
+  font-size: 13px;
+  line-height: 1.2;
+  overflow-wrap: anywhere;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.subjectMeta {
+  height: 25px;
+  overflow: hidden;
+  color: #999;
+  font-size: 13px;
+  line-height: 25px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.subjectComment {
+  width: min(600px, 100%);
+  box-sizing: border-box;
+  margin: 5px 0;
+  padding: 5px 10px;
+  border: 1px solid #e8e8e8;
+  border-radius: 10px;
+  color: #555;
+  font-size: 15px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+}
+
 .time {
-  color: @gray-60;
-  font-size: 12px;
-  margin-top: 4px;
+  margin-top: 5px;
+  color: #999;
+  font-size: 10px;
+  line-height: 1.2;
+}
+
+.sourceLink {
+  font-weight: normal;
+}
+
+@media (max-width: @sm) {
+  .item {
+    margin: 0;
+    padding: 5px 10px 0;
+  }
+
+  .subjectCardDetailed .subjectCover {
+    width: 60px;
+    height: 70px;
+  }
 }

--- a/packages/website/src/pages/index/index/components/TimelineBlock.tsx
+++ b/packages/website/src/pages/index/index/components/TimelineBlock.tsx
@@ -4,10 +4,11 @@ import React, { useState } from 'react';
 
 import { ozaClient } from '@bangumi/client';
 import type { SlimSubject, Timeline } from '@bangumi/client/client';
-import { TimelineCat } from '@bangumi/client/client';
+import { SubjectType, TimelineCat } from '@bangumi/client/client';
 import { Avatar, toast, Typography } from '@bangumi/design';
 import {
   getBlogLink,
+  getEpisodeLink,
   getIndexLink,
   getSubjectLink,
   getUserProfileLink,
@@ -36,6 +37,28 @@ const PRIMARY_TIMELINE_CATEGORIES = new Set<TimelineCat>([
   TimelineCat.Blog,
 ]);
 
+const SUBJECT_ACTIONS: Record<number, string> = {
+  1: '想读',
+  2: '想看',
+  3: '想听',
+  4: '想玩',
+  5: '读过',
+  6: '看过',
+  7: '听过',
+  8: '玩过',
+  9: '在读',
+  10: '在看',
+  11: '在听',
+  12: '在玩',
+  13: '搁置了',
+  14: '抛弃了',
+};
+
+interface TimelineContent {
+  summary: React.ReactNode;
+  attachment?: React.ReactNode;
+}
+
 /** 相对时间，对齐 PHP GlobalCore::make_descriptive_time */
 function makeDescriptiveTime(timestamp: number): string {
   const now = DateTime.now();
@@ -57,109 +80,184 @@ function makeDescriptiveTime(timestamp: number): string {
   return time.toFormat('MM-dd');
 }
 
-function SubjectName({ subject }: { subject: SlimSubject }) {
-  return <Link to={getSubjectLink(subject.id)}>{subject.nameCN || subject.name}</Link>;
-}
-
-function renderStatus(timeline: Timeline): React.ReactNode {
-  const status = timeline.memo.status;
-  if (status?.nickname) {
-    return (
-      <>
-        将昵称修改为
-        <strong>{status.nickname.after}</strong>
-      </>
-    );
-  }
-  const text = status?.sign ?? status?.tsukkomi;
-  if (text) {
-    return <p className={styles.statusText}>{text}</p>;
-  }
-  return null;
-}
-
-function renderSubject(timeline: Timeline): React.ReactNode {
-  const list = timeline.memo.subject ?? [];
+function SubjectName({ subject, original = false }: { subject: SlimSubject; original?: boolean }) {
   return (
-    <>
-      {list.map((item, i) => (
-        <span key={i}>
-          {i > 0 && '、'}
-          <SubjectName subject={item.subject} />
-        </span>
-      ))}
-      已收藏
-      {list[0]?.comment && <p className={styles.statusText}>{list[0].comment}</p>}
-    </>
+    <Link to={getSubjectLink(subject.id)}>
+      {original ? subject.name : subject.nameCN || subject.name}
+    </Link>
   );
 }
 
-function renderProgress(timeline: Timeline): React.ReactNode {
-  const progress = timeline.memo.progress;
-  if (progress?.single) {
-    const { subject, episode } = progress.single;
-    return (
-      <>
-        看过
-        <SubjectName subject={subject} />第 {episode.sort} 话
-      </>
-    );
+function SubjectCard({ subject, detailed = false }: { subject: SlimSubject; detailed?: boolean }) {
+  const name = subject.nameCN || subject.name;
+  const image = detailed ? subject.images?.small : subject.images?.grid;
+
+  return (
+    <div className={`${styles.subjectCard} ${detailed ? styles.subjectCardDetailed : ''}`}>
+      {image && (
+        <Link to={getSubjectLink(subject.id)} noStyle className={styles.subjectCoverLink}>
+          <img className={styles.subjectCover} src={image} alt={name} loading='lazy' />
+        </Link>
+      )}
+      <div className={styles.subjectInfo}>
+        <Link to={getSubjectLink(subject.id)} noStyle className={styles.subjectTitle}>
+          {name}
+        </Link>
+        {detailed && subject.info && <div className={styles.subjectMeta}>{subject.info}</div>}
+      </div>
+    </div>
+  );
+}
+
+function renderStatus(timeline: Timeline): TimelineContent | null {
+  const status = timeline.memo.status;
+  if (status?.nickname) {
+    return {
+      summary: (
+        <>
+          将昵称修改为
+          <strong>{status.nickname.after}</strong>
+        </>
+      ),
+    };
   }
-  if (progress?.batch) {
-    const { subject, epsUpdate, epsTotal, volsUpdate, volsTotal } = progress.batch;
-    return (
-      <>
-        更新了
-        <SubjectName subject={subject} />
-        的进度到 {epsUpdate ?? '?'}/{epsTotal}
-        {volsTotal ? ` (${volsUpdate ?? '?'}/${volsTotal} 卷)` : ''}
-      </>
-    );
+  const text = status?.sign ?? status?.tsukkomi;
+  if (text) {
+    return { summary: <p className={styles.statusText}>{text}</p> };
   }
   return null;
 }
 
-function renderWiki(timeline: Timeline): React.ReactNode {
+function renderSubject(timeline: Timeline): TimelineContent | null {
+  const list = timeline.memo.subject ?? [];
+  if (list.length === 0) {
+    return null;
+  }
+
+  return {
+    summary: (
+      <>
+        {SUBJECT_ACTIONS[timeline.type] ?? '收藏了'}{' '}
+        {list.map((item, i) => (
+          <React.Fragment key={item.subject.id}>
+            {i > 0 && '、'}
+            <SubjectName subject={item.subject} original />
+          </React.Fragment>
+        ))}
+      </>
+    ),
+    attachment: (
+      <div className={styles.subjectCards}>
+        {list.map((item) => (
+          <div key={item.subject.id}>
+            {item.comment && <p className={styles.subjectComment}>{item.comment}</p>}
+            <SubjectCard subject={item.subject} detailed />
+          </div>
+        ))}
+      </div>
+    ),
+  };
+}
+
+function completedVerb(subjectType: SubjectType): string {
+  switch (subjectType) {
+    case SubjectType.Book:
+      return '读过';
+    case SubjectType.Music:
+      return '听过';
+    case SubjectType.Game:
+      return '玩过';
+    default:
+      return '看过';
+  }
+}
+
+function renderProgress(timeline: Timeline): TimelineContent | null {
+  const progress = timeline.memo.progress;
+  if (progress?.single) {
+    const { subject, episode } = progress.single;
+    return {
+      summary: (
+        <>
+          {timeline.type === 1 ? '想看' : timeline.type === 3 ? '抛弃' : '看过'}{' '}
+          <Link to={getEpisodeLink(episode.id)}>
+            ep.{episode.sort} {episode.name || episode.nameCN}
+          </Link>
+        </>
+      ),
+      attachment: <SubjectCard subject={subject} />,
+    };
+  }
+  if (progress?.batch) {
+    const { subject, epsUpdate, epsTotal, volsUpdate, volsTotal } = progress.batch;
+    return {
+      summary: (
+        <>
+          {subject.type === SubjectType.Book ? completedVerb(subject.type) : '完成了'}{' '}
+          <SubjectName subject={subject} original />{' '}
+          {subject.type === SubjectType.Book ? (
+            <>
+              {volsUpdate != null && volsUpdate > 0 && `第${volsUpdate}卷 `}
+              {epsUpdate != null && epsUpdate > 0 && `第${epsUpdate}话`}
+            </>
+          ) : (
+            `${epsUpdate ?? '?'} of ${epsTotal} 话`
+          )}
+        </>
+      ),
+      attachment: <SubjectCard subject={subject} />,
+    };
+  }
+  return null;
+}
+
+function renderWiki(timeline: Timeline): TimelineContent | null {
   const subject = timeline.memo.wiki?.subject;
   if (!subject) {
     return null;
   }
-  return (
-    <>
-      编辑了
-      <SubjectName subject={subject} />
-      的维基信息
-    </>
-  );
+  return {
+    summary: (
+      <>
+        编辑了
+        <SubjectName subject={subject} />
+        的维基信息
+      </>
+    ),
+  };
 }
 
-function renderBlog(timeline: Timeline): React.ReactNode {
+function renderBlog(timeline: Timeline): TimelineContent | null {
   const blog = timeline.memo.blog;
   if (!blog) {
     return null;
   }
-  return (
-    <>
-      发表了日志
-      <Link to={getBlogLink(blog.id)}>{blog.title}</Link>
-    </>
-  );
+  return {
+    summary: (
+      <>
+        发表了日志
+        <Link to={getBlogLink(blog.id)}>{blog.title}</Link>
+      </>
+    ),
+  };
 }
 
-function renderIndex(timeline: Timeline): React.ReactNode {
+function renderIndex(timeline: Timeline): TimelineContent | null {
   const index = timeline.memo.index;
   if (!index) {
     return null;
   }
-  return (
-    <>
-      更新了目录
-      <Link to={getIndexLink(index.id)}>{index.title}</Link>
-    </>
-  );
+  return {
+    summary: (
+      <>
+        更新了目录
+        <Link to={getIndexLink(index.id)}>{index.title}</Link>
+      </>
+    ),
+  };
 }
 
-function renderMono(timeline: Timeline): React.ReactNode {
+function renderMono(timeline: Timeline): TimelineContent | null {
   const mono = timeline.memo.mono;
   if (!mono) {
     return null;
@@ -167,10 +265,10 @@ function renderMono(timeline: Timeline): React.ReactNode {
   const names = [...mono.characters.map((c) => c.name), ...mono.persons.map((p) => p.name)].join(
     '、',
   );
-  return names ? <>更新了人物/角色：{names}</> : null;
+  return names ? { summary: <>更新了人物/角色：{names}</> } : null;
 }
 
-function renderDaily(timeline: Timeline): React.ReactNode {
+function renderDaily(timeline: Timeline): TimelineContent | null {
   const daily = timeline.memo.daily;
   if (!daily) {
     return null;
@@ -179,10 +277,10 @@ function renderDaily(timeline: Timeline): React.ReactNode {
     ...(daily.groups ?? []).map((g) => g.title),
     ...(daily.users ?? []).map((u) => u.nickname),
   ].join('、');
-  return names ? <>更新了每日推荐：{names}</> : null;
+  return names ? { summary: <>更新了每日推荐：{names}</> } : null;
 }
 
-function renderDesc(timeline: Timeline): React.ReactNode {
+function renderContent(timeline: Timeline): TimelineContent | null {
   switch (timeline.cat as TimelineCat) {
     case TimelineCat.Status:
       return renderStatus(timeline);
@@ -210,8 +308,8 @@ function TimelineItem({ timeline }: { timeline: Timeline }) {
   if (!user) {
     return null;
   }
-  const desc = renderDesc(timeline);
-  if (desc == null) {
+  const content = renderContent(timeline);
+  if (content == null) {
     return null;
   }
 
@@ -222,20 +320,30 @@ function TimelineItem({ timeline }: { timeline: Timeline }) {
         className={styles.avatarLink}
         title={user.nickname}
       >
-        <Avatar src={user.avatar.large} size='medium' />
+        <Avatar src={user.avatar.large} size='small' wrapperClass={styles.avatar} />
       </Link>
       <div className={styles.info}>
-        <div>
-          <Link to={getUserProfileLink(user.username)} fontWeight='bold'>
-            {user.nickname}
-          </Link>{' '}
-          <span className={styles.desc}>{desc}</span>
+        <div className={styles.summary}>
+          <Link to={getUserProfileLink(user.username)}>{user.nickname}</Link>{' '}
+          <span className={styles.desc}>{content.summary}</span>
         </div>
+        {content.attachment}
         <div className={styles.time}>
           <span title={DateTime.fromSeconds(timeline.createdAt).toFormat('yyyy-MM-dd HH:mm')}>
             {makeDescriptiveTime(timeline.createdAt)}
           </span>
-          {timeline.source.name != null && <span> · {timeline.source.name}</span>}
+          {timeline.source.name != null && (
+            <>
+              <span> · </span>
+              {timeline.source.url ? (
+                <Link isExternal to={timeline.source.url} className={styles.sourceLink}>
+                  {timeline.source.name}
+                </Link>
+              ) : (
+                <span>{timeline.source.name}</span>
+              )}
+            </>
+          )}
         </div>
       </div>
     </li>


### PR DESCRIPTION
## Summary

- align the home page with the legacy 1180px content width and 7:3 column proportions
- render compact subject cards for progress entries and detailed cards for collection entries
- restore the stronger legacy link, text, metadata, and separator contrast in the home timeline
- cover episode links, collection actions, card metadata, and timeline source links in the home page test

## Testing

- `pnpm test packages/website/src/pages/index/index/HomePage.spec.tsx --run --reporter=verbose`
- `pnpm type-check`
- targeted ESLint, Stylelint, and Prettier checks for the changed files

## Notes

The legacy implementation was used only to determine block geometry: 1180px usable home width, a 7:3 split with a 10px gap, a 60px avatar slot, and 600px timeline cards. Timeline content and card variants follow the provided visual reference; draggable block behavior is intentionally not included.
