### PR TITLE
fix: eliminate rollup build warnings

### DIFF
--- a/packages/design/.storybook/main.ts
+++ b/packages/design/.storybook/main.ts
@@ -2,11 +2,7 @@ import type { StorybookConfig } from '@storybook/react-vite';
 import svgr from 'vite-plugin-svgr';
 
 export default {
-  stories: [
-    '../components/**/*.stories.mdx',
-    '../components/**/*.stories.@(js|jsx|ts|tsx)',
-    '../../icons/index.stories.tsx',
-  ],
+  stories: ['../components/**/*.stories.@(js|jsx|ts|tsx)', '../../icons/index.stories.tsx'],
   addons: ['@storybook/addon-links', '@storybook/addon-themes'],
   framework: {
     name: '@storybook/react-vite',
@@ -25,6 +21,30 @@ export default {
     // ("[vite:css] [less] timed-out") on CPU-contended CI runners.
     viteConfig.css ??= {};
     viteConfig.css.preprocessorMaxWorkers = 0;
+
+    // react-router 7 ships only its development build, whose "use client"
+    // directives are ignored by Rollup and whose broken sourcemaps make
+    // warning locations unresolvable; silence that third-party noise.
+    viteConfig.build ??= {};
+    viteConfig.build.rollupOptions ??= {};
+    const originalOnwarn = viteConfig.build.rollupOptions.onwarn;
+    viteConfig.build.rollupOptions.onwarn = (warning, warn) => {
+      if (
+        warning.id?.includes('node_modules') &&
+        (warning.code === 'MODULE_LEVEL_DIRECTIVE' || warning.code === 'SOURCEMAP_ERROR')
+      ) {
+        return;
+      }
+      if (originalOnwarn) {
+        originalOnwarn(warning, warn);
+      } else {
+        warn(warning);
+      }
+    };
+
+    // The Storybook iframe bundle bundles all stories by design; raise the
+    // default 500 kB threshold so the build stops warning about it.
+    viteConfig.build.chunkSizeWarningLimit = 1200;
 
     /*
      * About auto-generated component docs:

--- a/packages/design/components/CollapsibleContent/CollapsibleContent.stories.tsx
+++ b/packages/design/components/CollapsibleContent/CollapsibleContent.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryFn } from '@storybook/react';
 import React, { useState } from 'react';
 
-import { render as renderBBCode } from '@bangumi/utils';
+import { render as renderBBCode } from '@bangumi/utils/bbcode/react';
 
 import type { CollapsibleContentProps } from '.';
 import CollapsibleContent from '.';

--- a/packages/design/components/RichContent/index.tsx
+++ b/packages/design/components/RichContent/index.tsx
@@ -3,7 +3,7 @@ import './style';
 import classNames from 'classnames';
 import React from 'react';
 
-import { render } from '@bangumi/utils';
+import { render } from '@bangumi/utils/bbcode/react';
 
 export interface RichContentProps {
   bbcode: string;

--- a/packages/website/src/pages/index/group/[name]/index/index.tsx
+++ b/packages/website/src/pages/index/group/[name]/index/index.tsx
@@ -3,7 +3,8 @@ import { useParams } from 'react-router-dom';
 
 import { Button, CollapsibleContent, Section } from '@bangumi/design';
 import { ArrowRightCircle } from '@bangumi/icons';
-import { render as renderBBCode, UnreadableCodeError } from '@bangumi/utils';
+import { UnreadableCodeError } from '@bangumi/utils';
+import { render as renderBBCode } from '@bangumi/utils/bbcode/react';
 import Helmet from '@bangumi/website/components/Helmet';
 import { useGroupTopics } from '@bangumi/website/hooks/use-group-topics';
 import { useUser } from '@bangumi/website/hooks/use-user';

--- a/packages/website/src/pages/index/group/components/GroupHeader.tsx
+++ b/packages/website/src/pages/index/group/components/GroupHeader.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 
 import type { Group } from '@bangumi/client/client';
 import { CollapsibleContent, Image, Typography } from '@bangumi/design';
-import { render as renderBBCode } from '@bangumi/utils';
+import { render as renderBBCode } from '@bangumi/utils/bbcode/react';
 
 import GroupActions from './GroupActions';
 import styles from './GroupHeader.module.less';

--- a/packages/website/src/pages/index/user/[username]/components/UserInfoCard.tsx
+++ b/packages/website/src/pages/index/user/[username]/components/UserInfoCard.tsx
@@ -2,7 +2,7 @@ import dayjs from 'dayjs';
 import React from 'react';
 
 import type { User } from '@bangumi/client/client';
-import { render as renderBBCode } from '@bangumi/utils';
+import { render as renderBBCode } from '@bangumi/utils/bbcode/react';
 
 import styles from './UserInfoCard.module.less';
 


### PR DESCRIPTION
## Summary

Cleans up the remaining Rollup/Vite build warnings that appear when building the Storybook docs and the website, after the less worker timeout fix.

## Changes

- **Fix potential chunk cycle (`CYCLIC_CROSS_CHUNK_REEXPORT`)**: import `render` directly from `@bangumi/utils/bbcode/react` instead of through the `@bangumi/utils` barrel re-export chain. Rollup warned that the re-exported module and its importer could land in different chunks, breaking execution order. Applies to `RichContent`, `CollapsibleContent.stories`, `GroupHeader`, group detail page, and `UserInfoCard`.
- **Drop unused glob**: removed `../components/**/*.stories.mdx` from the Storybook stories config (no MDX stories exist).
- **Silence react-router third-party noise**: react-router 7 only ships a development build whose `"use client"` directives and broken sourcemaps trigger `MODULE_LEVEL_DIRECTIVE` / `SOURCEMAP_ERROR` warnings. Filtered via `rollupOptions.onwarn` for `node_modules` sources only.
- **Raise `chunkSizeWarningLimit` to 1200 kB** for the Storybook build: the iframe bundle includes all stories by design.

## Verification

- `pnpm design:build-doc`: 0 warnings (previously 7)
- `pnpm build`: bbcode warnings gone; only the known `edit_detail` chunk-size warning remains (needs route-level code splitting, tracked separately)
- `pnpm type-check`, `pnpm lint`, Prettier: all pass
- Full test suite: 273 tests pass
