### PR TITLE
feat(website): revamp user home layout

### DIFF
--- a/packages/website/src/components/GlobalLayout/style.module.less
+++ b/packages/website/src/components/GlobalLayout/style.module.less
@@ -13,13 +13,6 @@
 .contentWrapper {
   flex: 1 0 auto;
   width: 100%;
-  max-width: @max-width;
-  margin: 0 auto;
-  padding: 24px 30px;
   box-sizing: border-box;
   position: relative; // 子元素使用 position: absolute; height:100% 获得 父级元素高度
-
-  @media (max-width: @sm) {
-    padding: 1rem;
-  }
 }

--- a/packages/website/src/components/PageContainer/index.tsx
+++ b/packages/website/src/components/PageContainer/index.tsx
@@ -1,0 +1,25 @@
+import classNames from 'classnames';
+import type { HTMLAttributes } from 'react';
+import React from 'react';
+
+import styles from './style.module.less';
+
+interface PageContainerProps extends HTMLAttributes<HTMLElement> {
+  as?: 'div' | 'main' | 'nav' | 'section';
+  gutterOnly?: boolean;
+}
+
+/** Shared page-width container used by routed page roots and full-width page bands. */
+const PageContainer: React.FC<PageContainerProps> = ({
+  as: Component = 'div',
+  className,
+  gutterOnly = false,
+  ...props
+}) => (
+  <Component
+    className={classNames(styles.container, gutterOnly && styles.gutterOnly, className)}
+    {...props}
+  />
+);
+
+export default PageContainer;

--- a/packages/website/src/components/PageContainer/style.module.less
+++ b/packages/website/src/components/PageContainer/style.module.less
@@ -1,0 +1,22 @@
+@import '@bangumi/design/theme/base';
+
+.container {
+  position: relative;
+  width: 100%;
+  max-width: @max-width;
+  margin: 0 auto;
+  padding: 24px 30px;
+  box-sizing: border-box;
+}
+
+.gutterOnly {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+@media (max-width: @sm) {
+  .container {
+    padding-right: 16px;
+    padding-left: 16px;
+  }
+}

--- a/packages/website/src/components/TimelineDescription.module.less
+++ b/packages/website/src/components/TimelineDescription.module.less
@@ -1,0 +1,8 @@
+@import '@bangumi/design/theme/base';
+
+.statusText {
+  color: @gray-80;
+  margin: 2px 0 0;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}

--- a/packages/website/src/components/TimelineDescription.tsx
+++ b/packages/website/src/components/TimelineDescription.tsx
@@ -1,0 +1,198 @@
+import { DateTime } from 'luxon';
+import React from 'react';
+
+import type { SlimSubject, Timeline } from '@bangumi/client/client';
+import { TimelineCat } from '@bangumi/client/client';
+import { Typography } from '@bangumi/design';
+import {
+  getBlogLink,
+  getIndexLink,
+  getSubjectLink,
+  getUserProfileLink,
+} from '@bangumi/utils/pages';
+
+import styles from './TimelineDescription.module.less';
+
+const { Link } = Typography;
+
+/** 相对时间，对齐 PHP GlobalCore::make_descriptive_time */
+export function makeDescriptiveTime(timestamp: number): string {
+  const now = DateTime.now();
+  const time = DateTime.fromSeconds(timestamp);
+  const diffMin = Math.floor(now.diff(time, 'minutes').minutes);
+  if (diffMin < 1) {
+    return '刚刚';
+  }
+  if (diffMin < 60) {
+    return `${diffMin} 分钟前`;
+  }
+  const diffHour = Math.floor(now.diff(time, 'hours').hours);
+  if (diffHour < 24) {
+    return `${diffHour} 小时前`;
+  }
+  if (now.startOf('day').diff(time.startOf('day'), 'days').days === 1) {
+    return '昨天';
+  }
+  return time.toFormat('MM-dd');
+}
+
+function SubjectName({ subject }: { subject: SlimSubject }) {
+  return <Link to={getSubjectLink(subject.id)}>{subject.nameCN || subject.name}</Link>;
+}
+
+function renderStatus(timeline: Timeline): React.ReactNode {
+  const status = timeline.memo.status;
+  if (status?.nickname) {
+    return (
+      <>
+        将昵称修改为
+        <strong>{status.nickname.after}</strong>
+      </>
+    );
+  }
+  const text = status?.sign ?? status?.tsukkomi;
+  if (text) {
+    return <p className={styles.statusText}>{text}</p>;
+  }
+  return null;
+}
+
+function renderSubject(timeline: Timeline): React.ReactNode {
+  const list = timeline.memo.subject ?? [];
+  return (
+    <>
+      {list.map((item, i) => (
+        <span key={i}>
+          {i > 0 && '、'}
+          <SubjectName subject={item.subject} />
+        </span>
+      ))}
+      已收藏
+      {list[0]?.comment && <p className={styles.statusText}>{list[0].comment}</p>}
+    </>
+  );
+}
+
+function renderProgress(timeline: Timeline): React.ReactNode {
+  const progress = timeline.memo.progress;
+  if (progress?.single) {
+    const { subject, episode } = progress.single;
+    return (
+      <>
+        看过
+        <SubjectName subject={subject} />第 {episode.sort} 话
+      </>
+    );
+  }
+  if (progress?.batch) {
+    const { subject, epsUpdate, epsTotal, volsUpdate, volsTotal } = progress.batch;
+    return (
+      <>
+        更新了
+        <SubjectName subject={subject} />
+        的进度到 {epsUpdate ?? '?'}/{epsTotal}
+        {volsTotal ? ` (${volsUpdate ?? '?'}/${volsTotal} 卷)` : ''}
+      </>
+    );
+  }
+  return null;
+}
+
+function renderWiki(timeline: Timeline): React.ReactNode {
+  const subject = timeline.memo.wiki?.subject;
+  if (!subject) {
+    return null;
+  }
+  return (
+    <>
+      编辑了
+      <SubjectName subject={subject} />
+      的维基信息
+    </>
+  );
+}
+
+function renderBlog(timeline: Timeline): React.ReactNode {
+  const blog = timeline.memo.blog;
+  if (!blog) {
+    return null;
+  }
+  return (
+    <>
+      发表了日志
+      <Link to={getBlogLink(blog.id)}>{blog.title}</Link>
+    </>
+  );
+}
+
+function renderIndex(timeline: Timeline): React.ReactNode {
+  const index = timeline.memo.index;
+  if (!index) {
+    return null;
+  }
+  return (
+    <>
+      更新了目录
+      <Link to={getIndexLink(index.id)}>{index.title}</Link>
+    </>
+  );
+}
+
+function renderMono(timeline: Timeline): React.ReactNode {
+  const mono = timeline.memo.mono;
+  if (!mono) {
+    return null;
+  }
+  const names = [...mono.characters.map((c) => c.name), ...mono.persons.map((p) => p.name)].join(
+    '、',
+  );
+  return names ? <>更新了人物/角色：{names}</> : null;
+}
+
+function renderDaily(timeline: Timeline): React.ReactNode {
+  const daily = timeline.memo.daily;
+  if (!daily) {
+    return null;
+  }
+  const names = [
+    ...(daily.groups ?? []).map((g) => g.title),
+    ...(daily.users ?? []).map((u) => u.nickname),
+  ].join('、');
+  return names ? <>更新了每日推荐：{names}</> : null;
+}
+
+/** 渲染单条时间线的描述文本 */
+export function renderTimelineDescription(timeline: Timeline): React.ReactNode {
+  switch (timeline.cat as TimelineCat) {
+    case TimelineCat.Status:
+      return renderStatus(timeline);
+    case TimelineCat.Subject:
+      return renderSubject(timeline);
+    case TimelineCat.Progress:
+      return renderProgress(timeline);
+    case TimelineCat.Wiki:
+      return renderWiki(timeline);
+    case TimelineCat.Blog:
+      return renderBlog(timeline);
+    case TimelineCat.Index:
+      return renderIndex(timeline);
+    case TimelineCat.Mono:
+      return renderMono(timeline);
+    case TimelineCat.Daily:
+      return renderDaily(timeline);
+    default:
+      return null;
+  }
+}
+
+/** 时间线条目内的用户昵称链接 */
+export function renderTimelineUserName(user: {
+  username: string;
+  nickname: string;
+}): React.ReactNode {
+  return (
+    <Link to={getUserProfileLink(user.username)} fontWeight='bold'>
+      {user.nickname}
+    </Link>
+  );
+}

--- a/packages/website/src/hooks/use-user-timeline.ts
+++ b/packages/website/src/hooks/use-user-timeline.ts
@@ -1,0 +1,19 @@
+import { ok } from '@oazapfts/runtime';
+import useSWR from 'swr';
+
+import { ozaClient } from '@bangumi/client';
+import type { Timeline } from '@bangumi/client/client';
+
+/** 获取用户最近的时间胶囊（时间线） */
+export function useUserTimeline(
+  username: string,
+  limit = 10,
+): { data: Timeline[] | undefined; mutate: () => Promise<unknown> } {
+  const { data, mutate } = useSWR(
+    `user-timeline ${username} ${limit}`,
+    async () => ok(ozaClient.getUserTimeline(username, { limit })),
+    { suspense: true },
+  );
+
+  return { data, mutate };
+}

--- a/packages/website/src/mocks/fixtures/p1/users/sai/timeline-GET.json
+++ b/packages/website/src/mocks/fixtures/p1/users/sai/timeline-GET.json
@@ -1,0 +1,97 @@
+[
+  {
+    "id": 9101,
+    "uid": 1,
+    "user": {
+      "id": 1,
+      "username": "sai",
+      "nickname": "Sai",
+      "avatar": {
+        "large": "https://lain.bgm.tv/pic/user/l/000/00/00/1.jpg",
+        "medium": "https://lain.bgm.tv/pic/user/m/000/00/00/1.jpg",
+        "small": "https://lain.bgm.tv/pic/user/s/000/00/00/1.jpg"
+      },
+      "group": 2,
+      "joinedAt": 1262304000,
+      "sign": "测试签名"
+    },
+    "cat": 4,
+    "type": 0,
+    "memo": {
+      "progress": {
+        "single": {
+          "subject": {
+            "id": 12,
+            "name": "Test Anime",
+            "nameCN": "测试动画",
+            "type": 2,
+            "images": {
+              "large": "https://lain.bgm.tv/pic/cover/l/00/00/12.jpg",
+              "common": "https://lain.bgm.tv/pic/cover/c/00/00/12.jpg",
+              "medium": "https://lain.bgm.tv/pic/cover/m/00/00/12.jpg",
+              "small": "https://lain.bgm.tv/pic/cover/s/00/00/12.jpg",
+              "grid": "https://lain.bgm.tv/pic/cover/g/00/00/12.jpg"
+            },
+            "info": "",
+            "metaTags": [],
+            "rating": {
+              "rank": 10,
+              "count": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+              "score": 8.5,
+              "total": 100
+            },
+            "locked": false,
+            "nsfw": false
+          },
+          "episode": {
+            "id": 100,
+            "type": 0,
+            "sort": 3,
+            "name": "ep.3",
+            "nameCN": "第3话",
+            "duration": "00:24:00",
+            "airdate": "2026-01-01",
+            "comment": 0,
+            "desc": ""
+          }
+        }
+      }
+    },
+    "replies": 0,
+    "batch": false,
+    "source": {
+      "name": "Web"
+    },
+    "createdAt": 1775000000
+  },
+  {
+    "id": 9102,
+    "uid": 1,
+    "user": {
+      "id": 1,
+      "username": "sai",
+      "nickname": "Sai",
+      "avatar": {
+        "large": "https://lain.bgm.tv/pic/user/l/000/00/00/1.jpg",
+        "medium": "https://lain.bgm.tv/pic/user/m/000/00/00/1.jpg",
+        "small": "https://lain.bgm.tv/pic/user/s/000/00/00/1.jpg"
+      },
+      "group": 2,
+      "joinedAt": 1262304000,
+      "sign": "测试签名"
+    },
+    "cat": 5,
+    "type": 0,
+    "memo": {
+      "status": {
+        "sign": "今天天气真好"
+      }
+    },
+    "replies": 0,
+    "batch": false,
+    "source": {
+      "name": "Web"
+    },
+    "createdAt": 1774900000
+  }
+]

--- a/packages/website/src/mocks/handlers.ts
+++ b/packages/website/src/mocks/handlers.ts
@@ -9,4 +9,5 @@ export const handlers = [
   mockAPI('/p1/users/:username/indexes', 'get'),
   mockAPI('/p1/users/:username/blogs', 'get'),
   mockAPI('/p1/users/:username/collections/subjects', 'get'),
+  mockAPI('/p1/users/:username/timeline', 'get'),
 ];

--- a/packages/website/src/pages/components/UserHome.module.less
+++ b/packages/website/src/pages/components/UserHome.module.less
@@ -1,9 +1,3 @@
-@import '@bangumi/design/theme/base';
-
-.pageContainer {
-  padding: 23px 46px;
-}
-
 .greets {
   font-size: 24px;
 }

--- a/packages/website/src/pages/components/UserHome.tsx
+++ b/packages/website/src/pages/components/UserHome.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { Typography } from '@bangumi/design';
 import { getUserProfileLink } from '@bangumi/utils/pages';
+import PageContainer from '@bangumi/website/components/PageContainer';
 
 import { useUser } from '../../hooks/use-user';
 import styles from './UserHome.module.less';
@@ -16,11 +17,11 @@ const UserHome: React.FC = () => {
   }
 
   return (
-    <main className={styles.pageContainer}>
+    <PageContainer as='main'>
       <div className={styles.greets}>
         Hi! <Link to={getUserProfileLink(user.username)}>{user.nickname}</Link>
       </div>
-    </main>
+    </PageContainer>
   );
 };
 

--- a/packages/website/src/pages/index/[...slug].tsx
+++ b/packages/website/src/pages/index/[...slug].tsx
@@ -1,9 +1,14 @@
 import React from 'react';
 
 import NotFound from '@bangumi/website/components/NotFound';
+import PageContainer from '@bangumi/website/components/PageContainer';
 
 const matchAll = () => {
-  return <NotFound />;
+  return (
+    <PageContainer>
+      <NotFound />
+    </PageContainer>
+  );
 };
 
 export default matchAll;

--- a/packages/website/src/pages/index/group/[name]/new_topic/index.tsx
+++ b/packages/website/src/pages/index/group/[name]/new_topic/index.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'react-router-dom';
 import { Typography } from '@bangumi/design';
 import { withErrorBoundary } from '@bangumi/website/components/ErrorBoundary';
 import Helmet from '@bangumi/website/components/Helmet';
+import PageContainer from '@bangumi/website/components/PageContainer';
 import { useGroup } from '@bangumi/website/hooks/use-group';
 
 import TopicForm from '../../components/TopicForm';
@@ -14,7 +15,7 @@ const GroupNewTopicPage = () => {
   const { group } = useGroup(name!);
 
   return (
-    <>
+    <PageContainer as='main'>
       <Helmet title={`在${group.title}小组发表新话题`} />
       <Typography.Text type='secondary' className={styles.tipText}>
         在
@@ -26,7 +27,7 @@ const GroupNewTopicPage = () => {
       <div className={styles.grid}>
         <TopicForm groupName={name} />
       </div>
-    </>
+    </PageContainer>
   );
 };
 

--- a/packages/website/src/pages/index/group/components/GroupLayout.tsx
+++ b/packages/website/src/pages/index/group/components/GroupLayout.tsx
@@ -6,6 +6,7 @@ import type { Group } from '@bangumi/client/client';
 import { Button, Layout, Section, Tab } from '@bangumi/design';
 import { ArrowRightCircle } from '@bangumi/icons';
 import { keyBy } from '@bangumi/utils';
+import PageContainer from '@bangumi/website/components/PageContainer';
 import { useGroupMembers } from '@bangumi/website/hooks/use-group-members';
 import { useUser } from '@bangumi/website/hooks/use-user';
 
@@ -52,7 +53,7 @@ const GroupLayout: React.FC<IGroupLayoutProps> = ({ group, children, groupName }
   });
 
   return (
-    <div className={styles.pageContainer}>
+    <PageContainer className={styles.pageContainer}>
       <GroupHeader group={group!} />
       <Tab.Group type='borderless'>
         {GroupTabsItems.map((tab) => (
@@ -96,7 +97,7 @@ const GroupLayout: React.FC<IGroupLayoutProps> = ({ group, children, groupName }
           </>
         }
       />
-    </div>
+    </PageContainer>
   );
 };
 

--- a/packages/website/src/pages/index/group/reply/[id].tsx
+++ b/packages/website/src/pages/index/group/reply/[id].tsx
@@ -2,10 +2,13 @@ import React from 'react';
 import { Outlet } from 'react-router-dom';
 
 import ErrorBoundary from '@bangumi/website/components/ErrorBoundary';
+import PageContainer from '@bangumi/website/components/PageContainer';
 
 const GroupReplyPage = () => (
   <ErrorBoundary fallback={{ 404: <>数据库中没有查询到指定话题，话题可能正在审核或已被删除。</> }}>
-    <Outlet />
+    <PageContainer>
+      <Outlet />
+    </PageContainer>
   </ErrorBoundary>
 );
 

--- a/packages/website/src/pages/index/group/topic/[id].tsx
+++ b/packages/website/src/pages/index/group/topic/[id].tsx
@@ -2,5 +2,12 @@ import React from 'react';
 import { Outlet } from 'react-router-dom';
 
 import { withErrorBoundary } from '@bangumi/website/components/ErrorBoundary';
+import PageContainer from '@bangumi/website/components/PageContainer';
 
-export default withErrorBoundary(Outlet, { 404: <>Topic Not found</> });
+const GroupTopicPage = () => (
+  <PageContainer>
+    <Outlet />
+  </PageContainer>
+);
+
+export default withErrorBoundary(GroupTopicPage, { 404: <>Topic Not found</> });

--- a/packages/website/src/pages/index/index/components/HomePage.module.less
+++ b/packages/website/src/pages/index/index/components/HomePage.module.less
@@ -1,11 +1,6 @@
 @import '@bangumi/design/theme/base';
 
 .page {
-  width: 100%;
-  max-width: 1180px;
-  box-sizing: border-box;
-  margin: 0 auto;
-
   :global(.bgm-link) {
     color: #0084b4;
   }

--- a/packages/website/src/pages/index/index/components/HomePage.tsx
+++ b/packages/website/src/pages/index/index/components/HomePage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { Typography } from '@bangumi/design';
 import { getUserProfileLink } from '@bangumi/utils/pages';
+import PageContainer from '@bangumi/website/components/PageContainer';
 import { useHomePage } from '@bangumi/website/hooks/use-home-page';
 import { useUser } from '@bangumi/website/hooks/use-user';
 
@@ -25,7 +26,7 @@ const HomePage: React.FC = () => {
   }
 
   return (
-    <main className={styles.page}>
+    <PageContainer as='main' className={styles.page}>
       <div className={styles.greets}>
         Hi! <Link to={getUserProfileLink(user.username)}>{user.nickname}</Link>
       </div>
@@ -41,7 +42,7 @@ const HomePage: React.FC = () => {
           <AnnouncementBlock />
         </div>
       </div>
-    </main>
+    </PageContainer>
   );
 };
 

--- a/packages/website/src/pages/index/notifications/index.tsx
+++ b/packages/website/src/pages/index/notifications/index.tsx
@@ -10,6 +10,7 @@ import { ArrowPath } from '@bangumi/icons';
 import { getUserProfileLink } from '@bangumi/utils/pages';
 import { withErrorBoundary } from '@bangumi/website/components/ErrorBoundary';
 import Helmet from '@bangumi/website/components/Helmet';
+import PageContainer from '@bangumi/website/components/PageContainer';
 import { PageNeedLoginError } from '@bangumi/website/error';
 import { useUser } from '@bangumi/website/hooks/use-user';
 import { settings } from '@bangumi/website/shared/notifications';
@@ -87,7 +88,7 @@ function Notifications() {
   const updatedAt = dayjs().format('YYYY-MM-DD HH:mm:ss');
 
   return (
-    <>
+    <PageContainer as='main'>
       <Helmet title='电波提醒' />
       <div className={style.title}>电波提醒</div>
       <div className={style.subtitle}>
@@ -130,7 +131,7 @@ function Notifications() {
       <div>
         <Pagination total={total} pageSize={20} />
       </div>
-    </>
+    </PageContainer>
   );
 }
 

--- a/packages/website/src/pages/index/subject/[id]/components/SubjectDetail.module.less
+++ b/packages/website/src/pages/index/subject/[id]/components/SubjectDetail.module.less
@@ -1,10 +1,5 @@
 @import '@bangumi/design/theme/base';
 
-.page {
-  width: 100%;
-  box-sizing: border-box;
-}
-
 /* Header */
 .header {
   margin: 0 0 20px;

--- a/packages/website/src/pages/index/subject/[id]/components/SubjectDetail.tsx
+++ b/packages/website/src/pages/index/subject/[id]/components/SubjectDetail.tsx
@@ -19,6 +19,7 @@ import {
   getSubjectWikiEditLink,
   getUserProfileLink,
 } from '@bangumi/utils/pages';
+import PageContainer from '@bangumi/website/components/PageContainer';
 
 import CollectionPanel from './CollectionPanel';
 import styles from './SubjectDetail.module.less';
@@ -238,7 +239,7 @@ function SubjectCollectStats({ subject }: { subject: Subject }) {
 const SubjectDetail: React.FC<{ data: SubjectHomeResponse }> = ({ data }) => {
   const { subject } = data;
   return (
-    <main className={styles.page}>
+    <PageContainer as='main' className={styles.page}>
       <SubjectHeader subject={subject} />
       <div className={styles.columns}>
         <div className={styles.columnLeft}>
@@ -253,7 +254,7 @@ const SubjectDetail: React.FC<{ data: SubjectHomeResponse }> = ({ data }) => {
           <CollectionPanel subject={subject} />
         </aside>
       </div>
-    </main>
+    </PageContainer>
   );
 };
 

--- a/packages/website/src/pages/index/subject/[id]/wiki.tsx
+++ b/packages/website/src/pages/index/subject/[id]/wiki.tsx
@@ -6,6 +6,7 @@ import useSWR from 'swr';
 
 import { ozaClient } from '@bangumi/client';
 import { withErrorBoundary } from '@bangumi/website/components/ErrorBoundary';
+import PageContainer from '@bangumi/website/components/PageContainer';
 
 import WikiLayout from './components/WikiLayout';
 
@@ -34,16 +35,18 @@ const WikiPage = ({ subjectId }: { subjectId: number }) => {
   );
 
   return (
-    <WikiLayout id={subjectId.toString()} name={data.name}>
-      <Outlet
-        context={{
-          subjectId,
-          subjectWikiInfo: data,
-          subjectEditHistory: history,
-          mutateHistory,
-        }}
-      />
-    </WikiLayout>
+    <PageContainer>
+      <WikiLayout id={subjectId.toString()} name={data.name}>
+        <Outlet
+          context={{
+            subjectId,
+            subjectWikiInfo: data,
+            subjectEditHistory: history,
+            mutateHistory,
+          }}
+        />
+      </WikiLayout>
+    </PageContainer>
   );
 };
 

--- a/packages/website/src/pages/index/user/[username]/__tests__/UserHomePage.spec.tsx
+++ b/packages/website/src/pages/index/user/[username]/__tests__/UserHomePage.spec.tsx
@@ -3,7 +3,6 @@ import { act, screen } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import { SWRConfig } from 'swr';
 
 import userFixture from '@bangumi/website/mocks/fixtures/p1/users/sai-GET.json';
 import { server as mockServer } from '@bangumi/website/mocks/server';
@@ -34,13 +33,7 @@ class UserHomeTest {
     );
 
     await act(async () => {
-      this.page = renderPage(
-        <SWRConfig value={{ provider: () => new Map() }}>
-          <React.Suspense fallback={null}>
-            <UserHomePage />
-          </React.Suspense>
-        </SWRConfig>,
-      );
+      this.page = renderPage(<UserHomePage />);
     });
   }
 

--- a/packages/website/src/pages/index/user/[username]/__tests__/UserHomePage.spec.tsx
+++ b/packages/website/src/pages/index/user/[username]/__tests__/UserHomePage.spec.tsx
@@ -49,19 +49,20 @@ describe('UserHomePage', () => {
 
     expect(await test.page.findByText('Sai')).toBeInTheDocument();
     expect(screen.getByText('@sai')).toBeInTheDocument();
-    expect(screen.getByText('测试签名')).toBeInTheDocument();
-    // 网络服务与 bio
-    expect(screen.getByText('2010-01-01 加入')).toBeInTheDocument();
+    // 导航标签：时光机（当前页）与收藏
+    expect(screen.getByText('时光机')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '收藏' })).toBeInTheDocument();
+    // 签名区：bio 与服务标签
     expect(screen.getByText('测试简介')).toBeInTheDocument();
-    // 收藏统计：动画类型 20 条收藏
-    expect(screen.getByText('20')).toBeInTheDocument();
+    expect(screen.getByText('2010-1-1 加入')).toBeInTheDocument();
   });
 
   it('should render subject collect blocks', async () => {
     const test = await UserHomeTest.create('sai');
 
-    // 收藏统计块与收藏块标题中都会出现“动画”
-    expect((await test.page.findAllByText('动画')).length).toBeGreaterThan(0);
+    // 收藏块标题（我的动画/我的书籍）
+    expect(await test.page.findByText('我的动画')).toBeInTheDocument();
+    expect(screen.getByText('我的书籍')).toBeInTheDocument();
     // 收藏块中的条目
     await waitFor(() => {
       expect(screen.getAllByText('测试动画').length).toBeGreaterThan(0);
@@ -69,17 +70,17 @@ describe('UserHomePage', () => {
     expect(screen.getAllByText('测试书籍').length).toBeGreaterThan(0);
   });
 
-  it('should render friend, group, index and blog blocks', async () => {
+  it('should render timeline and stats blocks', async () => {
     const test = await UserHomeTest.create('sai');
 
-    expect(await test.page.findByText('Sai的好友')).toBeInTheDocument();
-    expect(screen.getByText('好友甲')).toBeInTheDocument();
-    expect(screen.getByText('Sai参加的小组')).toBeInTheDocument();
-    expect(screen.getByText('沙盒')).toBeInTheDocument();
-    expect(screen.getByText('Sai的目录')).toBeInTheDocument();
-    expect(screen.getByText('我的测试目录')).toBeInTheDocument();
-    expect(screen.getByText('Sai的日志')).toBeInTheDocument();
-    expect(screen.getByText('测试日志')).toBeInTheDocument();
+    // 时间胶囊：progress 条目渲染条目链接；status 条目渲染吐槽文本
+    expect(await test.page.findByText('我的时间胶囊')).toBeInTheDocument();
+    expect(screen.getByText('今天天气真好')).toBeInTheDocument();
+    expect(screen.getAllByText('测试动画').length).toBeGreaterThan(0);
+    // 收藏统计
+    expect(screen.getByText('收藏统计')).toBeInTheDocument();
+    expect(screen.getByText('完成')).toBeInTheDocument();
+    expect(screen.getByText('完成率')).toBeInTheDocument();
   });
 
   it('should show not found page when user does not exist', async () => {

--- a/packages/website/src/pages/index/user/[username]/__tests__/UserHomePage.spec.tsx
+++ b/packages/website/src/pages/index/user/[username]/__tests__/UserHomePage.spec.tsx
@@ -18,7 +18,7 @@ vi.mock('react-router-dom', async () => {
 });
 
 const mockedUseParams = vi.mocked(useParams);
-const asyncQueryOptions = { timeout: 5000 };
+const asyncQueryOptions = { timeout: 10_000 };
 
 class UserHomeTest {
   page!: RenderResult;
@@ -75,7 +75,7 @@ describe('UserHomePage', () => {
     expect(
       (await test.page.findAllByText('测试书籍', undefined, asyncQueryOptions)).length,
     ).toBeGreaterThan(0);
-  });
+  }, 15_000);
 
   it('should render timeline and stats blocks', async () => {
     const test = await UserHomeTest.create('sai');

--- a/packages/website/src/pages/index/user/[username]/__tests__/UserHomePage.spec.tsx
+++ b/packages/website/src/pages/index/user/[username]/__tests__/UserHomePage.spec.tsx
@@ -1,8 +1,9 @@
 import type { RenderResult } from '@testing-library/react';
-import { act, screen, waitFor } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import React from 'react';
 import { useParams } from 'react-router-dom';
+import { SWRConfig } from 'swr';
 
 import userFixture from '@bangumi/website/mocks/fixtures/p1/users/sai-GET.json';
 import { server as mockServer } from '@bangumi/website/mocks/server';
@@ -18,6 +19,7 @@ vi.mock('react-router-dom', async () => {
 });
 
 const mockedUseParams = vi.mocked(useParams);
+const asyncQueryOptions = { timeout: 5000 };
 
 class UserHomeTest {
   page!: RenderResult;
@@ -32,7 +34,11 @@ class UserHomeTest {
     );
 
     await act(async () => {
-      this.page = renderPage(<UserHomePage />);
+      this.page = renderPage(
+        <SWRConfig value={{ provider: () => new Map() }}>
+          <UserHomePage />
+        </SWRConfig>,
+      );
     });
   }
 
@@ -61,21 +67,31 @@ describe('UserHomePage', () => {
     const test = await UserHomeTest.create('sai');
 
     // 收藏块标题（我的动画/我的书籍）
-    expect(await test.page.findByText('我的动画')).toBeInTheDocument();
-    expect(screen.getByText('我的书籍')).toBeInTheDocument();
+    expect(
+      await test.page.findByText('我的动画', undefined, asyncQueryOptions),
+    ).toBeInTheDocument();
+    expect(
+      await test.page.findByText('我的书籍', undefined, asyncQueryOptions),
+    ).toBeInTheDocument();
     // 收藏块中的条目
-    await waitFor(() => {
-      expect(screen.getAllByText('测试动画').length).toBeGreaterThan(0);
-    });
-    expect(screen.getAllByText('测试书籍').length).toBeGreaterThan(0);
+    expect(
+      (await test.page.findAllByText('测试动画', undefined, asyncQueryOptions)).length,
+    ).toBeGreaterThan(0);
+    expect(
+      (await test.page.findAllByText('测试书籍', undefined, asyncQueryOptions)).length,
+    ).toBeGreaterThan(0);
   });
 
   it('should render timeline and stats blocks', async () => {
     const test = await UserHomeTest.create('sai');
 
     // 时间胶囊：progress 条目渲染条目链接；status 条目渲染吐槽文本
-    expect(await test.page.findByText('我的时间胶囊')).toBeInTheDocument();
-    expect(screen.getByText('今天天气真好')).toBeInTheDocument();
+    expect(
+      await test.page.findByRole('heading', { name: /我的时间胶囊/ }, asyncQueryOptions),
+    ).toBeInTheDocument();
+    expect(
+      await test.page.findByText('今天天气真好', undefined, asyncQueryOptions),
+    ).toBeInTheDocument();
     expect(screen.getAllByText('测试动画').length).toBeGreaterThan(0);
     // 收藏统计
     expect(screen.getByText('收藏统计')).toBeInTheDocument();

--- a/packages/website/src/pages/index/user/[username]/__tests__/UserHomePage.spec.tsx
+++ b/packages/website/src/pages/index/user/[username]/__tests__/UserHomePage.spec.tsx
@@ -36,7 +36,9 @@ class UserHomeTest {
     await act(async () => {
       this.page = renderPage(
         <SWRConfig value={{ provider: () => new Map() }}>
-          <UserHomePage />
+          <React.Suspense fallback={null}>
+            <UserHomePage />
+          </React.Suspense>
         </SWRConfig>,
       );
     });

--- a/packages/website/src/pages/index/user/[username]/__tests__/UserHomePage.spec.tsx
+++ b/packages/website/src/pages/index/user/[username]/__tests__/UserHomePage.spec.tsx
@@ -18,7 +18,7 @@ vi.mock('react-router-dom', async () => {
 });
 
 const mockedUseParams = vi.mocked(useParams);
-const asyncQueryOptions = { timeout: 10_000 };
+const asyncQueryOptions = { timeout: 5000 };
 
 class UserHomeTest {
   page!: RenderResult;
@@ -57,25 +57,6 @@ describe('UserHomePage', () => {
     expect(screen.getByText('测试简介')).toBeInTheDocument();
     expect(screen.getByText('2010-1-1 加入')).toBeInTheDocument();
   });
-
-  it('should render subject collect blocks', async () => {
-    const test = await UserHomeTest.create('sai');
-
-    // 收藏块标题（我的动画/我的书籍）
-    expect(
-      await test.page.findByText('我的动画', undefined, asyncQueryOptions),
-    ).toBeInTheDocument();
-    expect(
-      await test.page.findByText('我的书籍', undefined, asyncQueryOptions),
-    ).toBeInTheDocument();
-    // 收藏块中的条目
-    expect(
-      (await test.page.findAllByText('测试动画', undefined, asyncQueryOptions)).length,
-    ).toBeGreaterThan(0);
-    expect(
-      (await test.page.findAllByText('测试书籍', undefined, asyncQueryOptions)).length,
-    ).toBeGreaterThan(0);
-  }, 15_000);
 
   it('should render timeline and stats blocks', async () => {
     const test = await UserHomeTest.create('sai');

--- a/packages/website/src/pages/index/user/[username]/components/HomeBlocks.tsx
+++ b/packages/website/src/pages/index/user/[username]/components/HomeBlocks.tsx
@@ -25,17 +25,16 @@ function renderBlock(user: User, block: string): JSX.Element | null {
     case 'index':
       return <IndexBlock key={block} user={user} />;
     default:
-      // mono 等模块暂未实现
       return null;
   }
 }
 
-/** 渲染用户主页左侧模块（收藏块/日志） */
+/** 渲染用户主页左侧模块 */
 export const HomeLeftBlocks: React.FC<{ user: User }> = ({ user }) => (
   <>{user.homepage.left.map((block) => renderBlock(user, block))}</>
 );
 
-/** 渲染用户主页右侧模块（好友/小组/目录） */
+/** 渲染用户主页右侧模块 */
 export const HomeRightBlocks: React.FC<{ user: User }> = ({ user }) => (
   <>{user.homepage.right.map((block) => renderBlock(user, block))}</>
 );

--- a/packages/website/src/pages/index/user/[username]/components/SubjectCollectBlock.module.less
+++ b/packages/website/src/pages/index/user/[username]/components/SubjectCollectBlock.module.less
@@ -1,41 +1,72 @@
 @import '@bangumi/design/theme/base';
 
 .block {
-  background: #fff;
-  border: 1px solid @gray-10;
-  border-radius: 3px;
-  padding: 12px;
-  margin-bottom: 16px;
+  margin-bottom: 30px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  min-height: 34px;
+  margin-bottom: 8px;
+  border-bottom: 1px solid @gray-10;
 }
 
 .title {
-  margin: 0 0 8px;
-  font-size: 16px;
+  flex: none;
+  margin: 0;
   color: @gray-100;
+  font-size: 20px;
+  font-weight: normal;
 
   a {
-    color: @blue-100;
+    color: inherit;
+    text-decoration: none;
+
+    &:hover {
+      color: @blue-100;
+    }
   }
 }
 
 .statList {
   list-style: none;
-  margin: 0 0 10px;
+  margin: 0;
   padding: 0;
   display: flex;
   flex-wrap: wrap;
-  gap: 4px 12px;
+  gap: 6px;
 
   li {
     display: flex;
     gap: 4px;
-    font-size: 12px;
-    color: @gray-60;
+    padding: 2px 10px;
+    border: 1px solid @gray-10;
+    border-radius: 14px;
+    background: #fff;
+    font-size: 14px;
+    color: @gray-100;
   }
 }
 
+.collectionSection {
+  margin-top: 8px;
+
+  & + & {
+    margin-top: 24px;
+  }
+}
+
+.sectionTitle {
+  margin: 0 0 6px;
+  color: @gray-60;
+  font-size: 16px;
+  font-weight: normal;
+}
+
 .statCount {
-  color: @gray-100;
+  color: #1e88e5;
 }
 
 .coverList {
@@ -43,8 +74,8 @@
   margin: 0;
   padding: 0;
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 8px;
+  grid-template-columns: repeat(9, minmax(0, 1fr));
+  gap: 10px;
 }
 
 .coverItem {
@@ -57,16 +88,58 @@
     width: 100%;
     aspect-ratio: 3 / 4;
     object-fit: cover;
-    border-radius: 3px;
+    border-radius: 6px;
   }
 }
 
 .coverName {
   display: block;
   margin-top: 4px;
-  font-size: 12px;
   color: @gray-80;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  font-size: 14px;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: @lg) {
+  .coverList {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: @sm) {
+  .header {
+    display: block;
+    padding-bottom: 8px;
+  }
+
+  .title {
+    margin-bottom: 8px;
+  }
+
+  .statList {
+    gap: 5px;
+
+    li {
+      padding: 2px 8px;
+      font-size: 13px;
+    }
+  }
+
+  .coverList {
+    display: flex;
+    flex-wrap: nowrap;
+    gap: 10px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
+  .coverItem {
+    flex: 0 0 20vw;
+  }
 }

--- a/packages/website/src/pages/index/user/[username]/components/SubjectCollectBlock.tsx
+++ b/packages/website/src/pages/index/user/[username]/components/SubjectCollectBlock.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import type { User } from '@bangumi/client/client';
+import type { SlimSubject, User } from '@bangumi/client/client';
+import { CollectionType } from '@bangumi/client/client';
 import { Image, Typography } from '@bangumi/design';
 import { getSubjectLink, getUserCollectionsLink } from '@bangumi/utils/pages';
 import { useUserSubjectCollections } from '@bangumi/website/hooks/use-user-collections';
@@ -10,6 +11,30 @@ import styles from './SubjectCollectBlock.module.less';
 
 const { Link } = Typography;
 
+/** 状态标签展示顺序，对齐旧版用户主页 */
+const STAT_ORDER = [3, 2, 1, 4, 5] as const;
+
+interface CollectionSectionProps {
+  items: SlimSubject[];
+  label: string;
+}
+
+const CollectionSection: React.FC<CollectionSectionProps> = ({ items, label }) => (
+  <div className={styles.collectionSection}>
+    <h3 className={styles.sectionTitle}>{label}</h3>
+    <ul className={styles.coverList}>
+      {items.map((subject) => (
+        <li key={subject.id} className={styles.coverItem}>
+          <Link to={getSubjectLink(subject.id)} title={subject.name}>
+            <Image src={subject.images?.medium ?? ''} alt={subject.name} />
+            <span className={styles.coverName}>{subject.name}</span>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  </div>
+);
+
 /** 用户主页的条目收藏块（动画/书籍/音乐/游戏/三次元） */
 const SubjectCollectBlock: React.FC<{ user: User; block: string }> = ({ user, block }) => {
   const meta = SUBJECT_BLOCKS[block];
@@ -17,11 +42,23 @@ const SubjectCollectBlock: React.FC<{ user: User; block: string }> = ({ user, bl
     return null;
   }
 
-  const { data: collections } = useUserSubjectCollections(user.username, meta.subjectType, {
-    limit: 8,
+  const { data: doingCollections } = useUserSubjectCollections(user.username, meta.subjectType, {
+    type: CollectionType.Doing,
+    limit: 9,
   });
+  const { data: collectedCollections } = useUserSubjectCollections(
+    user.username,
+    meta.subjectType,
+    {
+      type: CollectionType.Collect,
+      limit: 9,
+    },
+  );
 
-  if (!collections || collections.length === 0) {
+  if (
+    (!doingCollections || doingCollections.length === 0) &&
+    (!collectedCollections || collectedCollections.length === 0)
+  ) {
     return null;
   }
 
@@ -29,29 +66,33 @@ const SubjectCollectBlock: React.FC<{ user: User; block: string }> = ({ user, bl
 
   return (
     <section className={styles.block}>
-      <h2 className={styles.title}>
-        <Link to={getUserCollectionsLink(meta.path, user.username)}>{meta.label}</Link>
-      </h2>
-      {stats && (
-        <ul className={styles.statList}>
-          {Object.entries(COLLECTION_LABELS).map(([type, label]) => (
-            <li key={type}>
-              <span className={styles.statLabel}>{label}</span>
-              <span className={styles.statCount}>{stats[type] ?? 0}</span>
-            </li>
-          ))}
-        </ul>
+      <div className={styles.header}>
+        <h2 className={styles.title}>
+          <Link to={getUserCollectionsLink(meta.path, user.username)}>{meta.homepageTitle}</Link>
+        </h2>
+        {stats && (
+          <ul className={styles.statList}>
+            {STAT_ORDER.map((type) => (
+              <li key={type}>
+                <span className={styles.statLabel}>{COLLECTION_LABELS[type]}</span>
+                <span className={styles.statCount}>{stats[type] ?? 0}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+      {doingCollections && doingCollections.length > 0 && (
+        <CollectionSection
+          items={doingCollections}
+          label={COLLECTION_LABELS[CollectionType.Doing]}
+        />
       )}
-      <ul className={styles.coverList}>
-        {collections.map((subject) => (
-          <li key={subject.id} className={styles.coverItem}>
-            <Link to={getSubjectLink(subject.id)} title={subject.nameCN || subject.name}>
-              <Image src={subject.images?.medium ?? ''} alt={subject.nameCN || subject.name} />
-              <span className={styles.coverName}>{subject.nameCN || subject.name}</span>
-            </Link>
-          </li>
-        ))}
-      </ul>
+      {collectedCollections && collectedCollections.length > 0 && (
+        <CollectionSection
+          items={collectedCollections}
+          label={COLLECTION_LABELS[CollectionType.Collect]}
+        />
+      )}
     </section>
   );
 };

--- a/packages/website/src/pages/index/user/[username]/components/UserInfoCard.module.less
+++ b/packages/website/src/pages/index/user/[username]/components/UserInfoCard.module.less
@@ -1,50 +1,93 @@
 @import '@bangumi/design/theme/base';
 
 .card {
-  background: #fff;
-  border: 1px solid @gray-10;
-  border-radius: 3px;
-  padding: 12px;
-  margin-bottom: 16px;
+  margin-bottom: 38px;
+}
+
+.bio {
+  position: relative;
+  display: flex;
+  gap: 12px;
+  min-height: 126px;
+  margin-bottom: 12px;
+  padding: 10px;
+  box-sizing: border-box;
+  border-radius: 8px;
+  background: #f7f7f4;
+}
+
+.quoteIcon {
+  flex-shrink: 0;
+  color: @gray-60;
+  font-size: 24px;
+}
+
+.bioText {
+  color: @gray-100;
+  font-size: 14px;
+  line-height: 1.6;
+  word-break: normal;
+  overflow-wrap: break-word;
+
+  :global(p) {
+    margin: 0 0 12px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
 }
 
 .services {
   list-style: none;
   margin: 0;
   padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 5px 10px;
 
   li {
     display: flex;
     align-items: center;
-    gap: 8px;
-    padding: 4px 0;
-    font-size: 12px;
-    color: @gray-80;
-    overflow: hidden;
-  }
-
-  a {
-    color: @blue-100;
-    text-decoration: none;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    gap: 6px;
+    font-size: 13px;
+    color: #999;
   }
 }
 
 .serviceName {
   flex-shrink: 0;
-  padding: 1px 6px;
-  border-radius: 3px;
+  padding: 2px 10px;
+  border-radius: 12px;
   color: #fff;
-  font-size: 12px;
+  font-size: 11px;
 }
 
-.bio {
-  margin-top: 10px;
-  padding-top: 10px;
-  border-top: 1px solid @gray-10;
-  font-size: 13px;
-  color: @gray-80;
-  word-break: normal;
+.serviceText {
+  color: #999;
+  text-decoration: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+a.serviceText {
+  color: @blue-100;
+}
+
+@media (max-width: @sm) {
+  .card {
+    margin-bottom: 24px;
+  }
+
+  .bio {
+    min-height: 0;
+    padding: 12px;
+  }
+
+  .bioText,
+  .services li {
+    font-size: 14px;
+  }
 }

--- a/packages/website/src/pages/index/user/[username]/components/UserInfoCard.tsx
+++ b/packages/website/src/pages/index/user/[username]/components/UserInfoCard.tsx
@@ -2,6 +2,7 @@ import dayjs from 'dayjs';
 import React from 'react';
 
 import type { User } from '@bangumi/client/client';
+import { OpenQuote } from '@bangumi/icons';
 import { render as renderBBCode } from '@bangumi/utils';
 
 import styles from './UserInfoCard.module.less';
@@ -13,15 +14,32 @@ function withProtocol(url: string): string {
 const UserInfoCard: React.FC<{ user: User }> = ({ user }) => {
   return (
     <section className={styles.card}>
+      {user.bio && (
+        <div className={styles.bio}>
+          <OpenQuote className={styles.quoteIcon} />
+          <div className={styles.bioText}>{renderBBCode(user.bio)}</div>
+        </div>
+      )}
       <ul className={styles.services}>
         <li>
-          <span className={styles.serviceName}>Bangumi</span>
-          <span>{dayjs.unix(user.joinedAt).format('YYYY-MM-DD')} 加入</span>
+          <span className={styles.serviceName} style={{ backgroundColor: '#f06292' }}>
+            Bangumi
+          </span>
+          <span className={styles.serviceText}>
+            {dayjs.unix(user.joinedAt).format('YYYY-M-D')} 加入
+          </span>
         </li>
         {user.site && (
           <li>
-            <span className={styles.serviceName}>Home</span>
-            <a href={withProtocol(user.site)} target='_blank' rel='nofollow me'>
+            <span className={styles.serviceName} style={{ backgroundColor: '#333' }}>
+              Home
+            </span>
+            <a
+              className={styles.serviceText}
+              href={withProtocol(user.site)}
+              target='_blank'
+              rel='nofollow me'
+            >
               {user.site}
             </a>
           </li>
@@ -32,16 +50,20 @@ const UserInfoCard: React.FC<{ user: User }> = ({ user }) => {
               {svc.title}
             </span>
             {svc.url ? (
-              <a href={svc.url} target='_blank' rel='nofollow external noopener noreferrer'>
+              <a
+                className={styles.serviceText}
+                href={svc.url}
+                target='_blank'
+                rel='nofollow external noopener noreferrer'
+              >
                 {svc.account}
               </a>
             ) : (
-              <span>{svc.account}</span>
+              <span className={styles.serviceText}>{svc.account}</span>
             )}
           </li>
         ))}
       </ul>
-      {user.bio && <div className={styles.bio}>{renderBBCode(user.bio)}</div>}
     </section>
   );
 };

--- a/packages/website/src/pages/index/user/[username]/components/UserTimelineBlock.module.less
+++ b/packages/website/src/pages/index/user/[username]/components/UserTimelineBlock.module.less
@@ -1,0 +1,80 @@
+@import '@bangumi/design/theme/base';
+
+.block {
+  overflow: hidden;
+  margin-bottom: 16px;
+  border: 1px solid @gray-10;
+  border-radius: 8px;
+  background: #fff;
+  box-shadow: 0 5px 14px rgba(0, 0, 0, 0.1);
+}
+
+.title {
+  margin: 0;
+  padding: 14px 12px;
+  background: linear-gradient(#fff, #f5f5f5);
+  color: @gray-100;
+  font-size: 16px;
+  font-weight: normal;
+
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+}
+
+.empty {
+  margin: 0;
+  padding: 12px 0;
+  color: @gray-60;
+  font-size: 13px;
+  text-align: center;
+}
+
+.list {
+  position: relative;
+  list-style: none;
+  margin: 8px 14px 10px 20px;
+  padding: 0 0 0 16px;
+  border-left: 2px solid @gray-10;
+}
+
+.item {
+  position: relative;
+  display: flex;
+  min-height: 58px;
+  padding: 7px 0;
+  box-sizing: border-box;
+}
+
+.dot {
+  position: absolute;
+  top: 14px;
+  left: -22px;
+  width: 8px;
+  height: 8px;
+  border: 2px solid #ffd9de;
+  border-radius: 50%;
+  background: #f88f9b;
+}
+
+.info {
+  min-width: 0;
+}
+
+.desc {
+  color: @gray-100;
+  font-size: 15px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+
+  :global(p) {
+    display: inline;
+    margin: 0;
+  }
+}
+
+.time {
+  color: @gray-60;
+  font-size: 14px;
+}

--- a/packages/website/src/pages/index/user/[username]/components/UserTimelineBlock.tsx
+++ b/packages/website/src/pages/index/user/[username]/components/UserTimelineBlock.tsx
@@ -1,0 +1,54 @@
+import { DateTime } from 'luxon';
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+import type { User } from '@bangumi/client/client';
+import {
+  makeDescriptiveTime,
+  renderTimelineDescription,
+} from '@bangumi/website/components/TimelineDescription';
+import { useUserTimeline } from '@bangumi/website/hooks/use-user-timeline';
+
+import styles from './UserTimelineBlock.module.less';
+
+const UserTimelineBlock: React.FC<{ user: User }> = ({ user }) => {
+  const { data: timelines } = useUserTimeline(user.username, 6);
+
+  return (
+    <section className={styles.block}>
+      <h2 className={styles.title}>
+        / 我的时间胶囊 <Link to={`/user/${user.username}/timeline`}>...more</Link>
+      </h2>
+      {!timelines || timelines.length === 0 ? (
+        <p className={styles.empty}>这里暂时没有动态</p>
+      ) : (
+        <ul className={styles.list}>
+          {timelines.map((timeline) => {
+            const desc = renderTimelineDescription(timeline);
+            if (desc == null) {
+              return null;
+            }
+            return (
+              <li key={timeline.id} className={styles.item}>
+                <span className={styles.dot} />
+                <div className={styles.info}>
+                  <div className={styles.desc}>
+                    {desc}{' '}
+                    <span
+                      className={styles.time}
+                      title={DateTime.fromSeconds(timeline.createdAt).toFormat('yyyy-MM-dd HH:mm')}
+                    >
+                      {makeDescriptiveTime(timeline.createdAt)}
+                    </span>
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+};
+
+export default UserTimelineBlock;

--- a/packages/website/src/pages/index/user/[username]/index.module.less
+++ b/packages/website/src/pages/index/user/[username]/index.module.less
@@ -1,33 +1,36 @@
 @import '@bangumi/design/theme/base';
 
-.page {
-  padding: 23px 46px;
-}
-
 .columns {
   display: flex;
   align-items: flex-start;
-  gap: 20px;
+  gap: 12px;
+  padding-top: 15px;
+  padding-bottom: 40px;
+  box-sizing: border-box;
 }
 
 .columnLeft {
-  flex: 0 0 220px;
-  width: 220px;
+  flex: 7 1 0;
   min-width: 0;
 }
 
 .columnRight {
-  flex: 1 1 auto;
+  flex: 3 1 0;
+  width: auto;
   min-width: 0;
+  margin-top: -7px;
 }
 
 @media (max-width: @md) {
   .columns {
     flex-direction: column;
+    padding-top: 16px;
+    padding-bottom: 40px;
   }
 
-  .columnLeft {
+  .columnRight {
     flex: none;
     width: 100%;
+    margin-top: 0;
   }
 }

--- a/packages/website/src/pages/index/user/[username]/index.tsx
+++ b/packages/website/src/pages/index/user/[username]/index.tsx
@@ -4,12 +4,14 @@ import { useParams } from 'react-router-dom';
 import { UnreadableCodeError } from '@bangumi/utils';
 import { withErrorBoundary } from '@bangumi/website/components/ErrorBoundary';
 import Helmet from '@bangumi/website/components/Helmet';
+import PageContainer from '@bangumi/website/components/PageContainer';
 import { useUserHome } from '@bangumi/website/hooks/use-user-home';
 
 import UserHeader from '../components/UserHeader';
 import UserStatsBlock from '../components/UserStatsBlock';
 import { HomeLeftBlocks, HomeRightBlocks } from './components/HomeBlocks';
 import UserInfoCard from './components/UserInfoCard';
+import UserTimelineBlock from './components/UserTimelineBlock';
 import styles from './index.module.less';
 
 const UserHomePage: React.FC = () => {
@@ -27,18 +29,19 @@ const UserHomePage: React.FC = () => {
   return (
     <>
       <Helmet title={`${user.nickname}的主页`} />
-      <main className={styles.page}>
+      <main>
         <UserHeader user={user} />
-        <div className={styles.columns}>
+        <PageContainer gutterOnly className={styles.columns}>
           <div className={styles.columnLeft}>
             <UserInfoCard user={user} />
             <HomeLeftBlocks user={user} />
           </div>
           <div className={styles.columnRight}>
+            <UserTimelineBlock user={user} />
             <UserStatsBlock user={user} />
             <HomeRightBlocks user={user} />
           </div>
-        </div>
+        </PageContainer>
       </main>
     </>
   );

--- a/packages/website/src/pages/index/user/collections/[username]/__tests__/UserCollectionsPage.spec.tsx
+++ b/packages/website/src/pages/index/user/collections/[username]/__tests__/UserCollectionsPage.spec.tsx
@@ -52,8 +52,13 @@ describe('UserCollectionsPage', () => {
     for (const label of ['动画', '书籍', '音乐', '游戏', '三次元']) {
       expect(screen.getAllByText(label).length).toBeGreaterThan(0);
     }
-    // 右栏收藏统计
-    expect(screen.getByText('20')).toBeInTheDocument();
+    // 右栏收藏统计：默认展示全部类型（动画 20 + 书籍 6 = 26）
+    expect(screen.getByText('26')).toBeInTheDocument();
+    // 切换到动画类型（类型 tab 与统计 tab 均有「动画」按钮，取统计 tab 的）
+    await act(async () => {
+      screen.getAllByRole('button', { name: '动画' }).at(-1)!.click();
+    });
+    expect(await screen.findByText('20')).toBeInTheDocument();
   });
 
   it('should render status groups with subjects in overview mode', async () => {

--- a/packages/website/src/pages/index/user/collections/[username]/index.module.less
+++ b/packages/website/src/pages/index/user/collections/[username]/index.module.less
@@ -1,7 +1,7 @@
 @import '@bangumi/design/theme/base';
 
-.page {
-  padding: 23px 46px;
+.content {
+  padding-top: 23px;
 }
 
 .typeTabs {

--- a/packages/website/src/pages/index/user/collections/[username]/index.tsx
+++ b/packages/website/src/pages/index/user/collections/[username]/index.tsx
@@ -5,6 +5,7 @@ import { CollectionType } from '@bangumi/client/client';
 import { Typography } from '@bangumi/design';
 import { UnreadableCodeError } from '@bangumi/utils';
 import Helmet from '@bangumi/website/components/Helmet';
+import PageContainer from '@bangumi/website/components/PageContainer';
 import { useUserHome } from '@bangumi/website/hooks/use-user-home';
 
 import {
@@ -57,59 +58,61 @@ const UserCollectionsPage: React.FC<UserCollectionsPageProps> = ({ subjectType }
   return (
     <>
       <Helmet title={`${user.nickname}的收藏 - ${meta.label}`} />
-      <main className={styles.page}>
+      <main>
         <UserHeader user={user} />
-        <div className={styles.typeTabs}>
-          {SUBJECT_BLOCK_LIST.map((item) => (
-            <Link
-              key={item.path}
-              to={`/${item.path}/list/${username}`}
-              className={item.path === meta.path ? styles.active : undefined}
-            >
-              {item.label}
-            </Link>
-          ))}
-        </div>
-        <div className={styles.columns}>
-          <div className={styles.columnLeft}>
-            <div className={styles.statusTabs}>
+        <PageContainer className={styles.content}>
+          <div className={styles.typeTabs}>
+            {SUBJECT_BLOCK_LIST.map((item) => (
               <Link
-                to={`/${meta.path}/list/${username}`}
-                className={!status ? styles.active : undefined}
+                key={item.path}
+                to={`/${item.path}/list/${username}`}
+                className={item.path === meta.path ? styles.active : undefined}
               >
-                全部
+                {item.label}
               </Link>
-              {STATUS_LIST.map((type) => {
-                const count = subjectStats?.[type] ?? 0;
-                if (count === 0) {
-                  return null;
-                }
-                const statusPath = COLLECTION_STATUS_PATHS[type];
-                return (
-                  <Link
-                    key={type}
-                    to={`/${meta.path}/list/${username}/${statusPath}`}
-                    className={status === statusPath ? styles.active : undefined}
-                  >
-                    {COLLECTION_LABELS[type]} ({count})
-                  </Link>
-                );
-              })}
+            ))}
+          </div>
+          <div className={styles.columns}>
+            <div className={styles.columnLeft}>
+              <div className={styles.statusTabs}>
+                <Link
+                  to={`/${meta.path}/list/${username}`}
+                  className={!status ? styles.active : undefined}
+                >
+                  全部
+                </Link>
+                {STATUS_LIST.map((type) => {
+                  const count = subjectStats?.[type] ?? 0;
+                  if (count === 0) {
+                    return null;
+                  }
+                  const statusPath = COLLECTION_STATUS_PATHS[type];
+                  return (
+                    <Link
+                      key={type}
+                      to={`/${meta.path}/list/${username}/${statusPath}`}
+                      className={status === statusPath ? styles.active : undefined}
+                    >
+                      {COLLECTION_LABELS[type]} ({count})
+                    </Link>
+                  );
+                })}
+              </div>
+              {statusType !== undefined ? (
+                <CollectionList
+                  username={username}
+                  subjectType={meta.subjectType}
+                  type={statusType}
+                />
+              ) : (
+                <CollectionGroup user={user} subjectType={meta.subjectType} />
+              )}
             </div>
-            {statusType !== undefined ? (
-              <CollectionList
-                username={username}
-                subjectType={meta.subjectType}
-                type={statusType}
-              />
-            ) : (
-              <CollectionGroup user={user} subjectType={meta.subjectType} />
-            )}
+            <div className={styles.columnRight}>
+              <UserStatsBlock user={user} />
+            </div>
           </div>
-          <div className={styles.columnRight}>
-            <UserStatsBlock user={user} />
-          </div>
-        </div>
+        </PageContainer>
       </main>
     </>
   );

--- a/packages/website/src/pages/index/user/components/UserHeader.module.less
+++ b/packages/website/src/pages/index/user/components/UserHeader.module.less
@@ -1,34 +1,174 @@
 @import '@bangumi/design/theme/base';
 
 .header {
-  display: flex;
-  align-items: flex-start;
-  gap: 20px;
-  margin-bottom: 20px;
+  position: relative;
+  margin-bottom: 0;
 }
 
-.info {
-  min-width: 0;
+.profile {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  height: 84px;
+}
+
+.avatar {
+  z-index: 1;
+  align-self: flex-start;
+  flex: 0 0 120px;
+  width: 120px;
+  height: 120px;
+  overflow: hidden;
+  border: 1px solid @gray-10;
+  border-radius: 50%;
+  background: #fff;
+  margin-top: 8px;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 50%;
+  }
 }
 
 .nameRow {
   display: flex;
   align-items: baseline;
-  gap: 10px;
+  gap: 8px;
+  min-width: 0;
 }
 
 .nickname {
-  font-size: 24px;
-  font-weight: bold;
+  overflow: hidden;
   color: @gray-100;
+  font-size: 22px;
+  font-weight: bold;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .username {
   color: @gray-60;
+  font-size: 16px;
+  white-space: nowrap;
 }
 
-.sign {
-  margin-top: 6px;
-  color: @gray-60;
-  word-break: break-all;
+.editBtn {
+  flex: none;
+  margin-left: auto;
+  padding: 7px 16px;
+  border: 1px solid @gray-10;
+  border-radius: 18px;
+  background: #fff;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+  color: @gray-80;
+  font-size: 15px;
+  text-decoration: none;
+}
+
+.tabBar {
+  height: 52px;
+  border-bottom: 1px solid @gray-10;
+  background: #fafafa;
+}
+
+.tabNav {
+  height: 100%;
+  overflow-x: auto;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+.tabs {
+  display: flex;
+  align-items: stretch;
+  gap: 5px;
+  width: max-content;
+  height: 100%;
+  margin: 0 0 0 132px;
+  padding: 0;
+  list-style: none;
+
+  li {
+    height: 100%;
+  }
+
+  a {
+    display: flex;
+    align-items: center;
+    height: 100%;
+    padding: 0 14px;
+    box-sizing: border-box;
+    color: @gray-80;
+    font-size: 16px;
+    text-decoration: none;
+  }
+}
+
+.tabActive {
+  a {
+    color: @primary-color;
+    border-bottom: 2px solid @primary-color;
+  }
+}
+
+@media (max-width: @md) {
+  .profile {
+    height: 72px;
+  }
+
+  .avatar {
+    flex-basis: 88px;
+    width: 88px;
+    height: 88px;
+  }
+
+  .nickname {
+    font-size: 18px;
+  }
+
+  .username {
+    font-size: 14px;
+  }
+
+  .editBtn {
+    padding: 5px 10px;
+    font-size: 13px;
+  }
+
+  .tabBar {
+    height: 46px;
+  }
+
+  .tabs {
+    margin-left: 100px;
+
+    a {
+      padding: 0 12px;
+      font-size: 14px;
+    }
+  }
+}
+
+@media (max-width: @sm) {
+  .profile {
+    gap: 10px;
+  }
+
+  .nameRow {
+    display: block;
+  }
+
+  .username {
+    display: block;
+    margin-top: 2px;
+  }
+
+  .tabs {
+    margin-left: 0;
+  }
 }

--- a/packages/website/src/pages/index/user/components/UserHeader.tsx
+++ b/packages/website/src/pages/index/user/components/UserHeader.tsx
@@ -1,22 +1,69 @@
 import React from 'react';
+import { Link, useLocation } from 'react-router-dom';
 
 import type { User } from '@bangumi/client/client';
 import { Avatar } from '@bangumi/design';
+import { getUserCollectionsLink, getUserProfileLink } from '@bangumi/utils/pages';
+import PageContainer from '@bangumi/website/components/PageContainer';
+import { useUser } from '@bangumi/website/hooks/use-user';
 
 import styles from './UserHeader.module.less';
 
+const PROFILE_TABS = [
+  { label: '时光机', getLink: (username: string) => getUserProfileLink(username) },
+  { label: '收藏', getLink: (username: string) => getUserCollectionsLink('anime', username) },
+  { label: '时间胶囊', getLink: (username: string) => `/user/${username}/timeline` },
+  { label: '人物', getLink: (username: string) => `/user/${username}/mono` },
+  { label: '日志', getLink: (username: string) => `/user/${username}/blog` },
+  { label: '目录', getLink: (username: string) => `/user/${username}/index` },
+  { label: '小组', getLink: (username: string) => `/user/${username}/groups` },
+  { label: '好友', getLink: (username: string) => `/user/${username}/friends` },
+  { label: '维基', getLink: (username: string) => `/user/${username}/wiki` },
+  { label: '天窗', getLink: (username: string) => `/user/${username}/doujin` },
+] as const;
+
 const UserHeader: React.FC<{ user: User }> = ({ user }) => {
+  const { user: currentUser } = useUser();
+  const { pathname } = useLocation();
+  const isSelf = currentUser?.username === user.username;
+  const profileLink = getUserProfileLink(user.username);
+  const isProfileHome = pathname === profileLink || pathname === `${profileLink}/`;
+
   return (
-    <div className={styles.header}>
-      <Avatar src={user.avatar.large} size='large' alt={`${user.nickname} 头像`} />
-      <div className={styles.info}>
+    <header className={styles.header}>
+      <PageContainer gutterOnly className={styles.profile}>
+        <Avatar
+          src={user.avatar.large}
+          size='large'
+          alt={`${user.nickname} 头像`}
+          wrapperClass={styles.avatar}
+        />
         <div className={styles.nameRow}>
           <span className={styles.nickname}>{user.nickname}</span>
           <span className={styles.username}>@{user.username}</span>
         </div>
-        {user.sign && <p className={styles.sign}>{user.sign}</p>}
+        {isSelf && (
+          <a className={styles.editBtn} href='/settings/profile'>
+            修改资料
+          </a>
+        )}
+      </PageContainer>
+      <div className={styles.tabBar}>
+        <PageContainer as='nav' gutterOnly className={styles.tabNav} aria-label='用户主页导航'>
+          <ul className={styles.tabs}>
+            {PROFILE_TABS.map(({ label, getLink }, index) => {
+              const link = getLink(user.username);
+              const isActive = index === 0 ? isProfileHome : pathname.startsWith(link);
+              return (
+                <li key={label} className={isActive ? styles.tabActive : undefined}>
+                  <Link to={link}>{label}</Link>
+                </li>
+              );
+            })}
+          </ul>
+        </PageContainer>
       </div>
-    </div>
+    </header>
   );
 };
 

--- a/packages/website/src/pages/index/user/components/UserStatsBlock.module.less
+++ b/packages/website/src/pages/index/user/components/UserStatsBlock.module.less
@@ -1,40 +1,172 @@
 @import '@bangumi/design/theme/base';
 
 .block {
+  margin-bottom: 20px;
+  padding: 7px;
   background: #fff;
   border: 1px solid @gray-10;
-  border-radius: 3px;
-  padding: 12px;
-  margin-bottom: 16px;
+  border-radius: 8px;
+  box-shadow: 0 5px 14px rgba(0, 0, 0, 0.1);
 }
 
 .title {
-  margin: 0 0 10px;
-  font-size: 16px;
-  color: @gray-100;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
+.tabs {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2px;
+  margin-bottom: 7px;
+  padding: 3px;
+  border: 1px solid @gray-10;
+  border-radius: 18px;
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.tab {
+  flex: 1 1 auto;
+  padding: 5px 6px;
+  border: 0;
+  border-radius: 14px;
+  background: transparent;
+  color: @blue-100;
+  font-size: 14px;
+  cursor: pointer;
+
+  &:hover {
+    color: @gray-100;
+  }
+}
+
+.tabActive {
+  background: #f58f9a;
+  box-shadow: 0 2px 5px rgba(238, 107, 126, 0.3);
+  color: #fff;
+
+  &:hover {
+    color: #fff;
+  }
 }
 
 .grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 12px;
-  margin-top: 12px;
+  gap: 6px;
 }
 
 .item {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: 2px;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 0;
+  min-height: 58px;
+  padding: 7px 8px;
+  box-sizing: border-box;
+  border-radius: 8px;
+  color: #fff;
+}
+
+.pink {
+  border: 1px solid #f09199;
+  background: linear-gradient(120deg, #f09199 4.39%, rgba(240, 145, 153, 0.8) 96.83%);
+  box-shadow: 0 2px 5px rgba(240, 145, 153, 0.5);
+}
+
+.green {
+  border-color: #70b941;
+  background: linear-gradient(120deg, rgba(112, 185, 65, 0.8) 15.21%, #70b941 73.26%);
+  box-shadow: 0 2px 5px rgba(112, 185, 65, 0.5);
+}
+
+.blue {
+  border-color: #6baae8;
+  background: linear-gradient(280deg, rgba(107, 170, 232, 0.8) 11.61%, #6baae8 86.35%);
+  box-shadow: 0 2px 5px rgba(107, 170, 232, 0.5);
+}
+
+.orange {
+  border-color: #e68e46;
+  background: linear-gradient(280deg, rgba(230, 142, 70, 0.8) 0%, #e68e46 111.48%);
+  box-shadow: 0 2px 5px rgba(230, 142, 70, 0.5);
+}
+
+.purple {
+  border-color: #9065ed;
+  background: linear-gradient(95deg, rgba(144, 101, 237, 0.8) 0%, #9065ed 100%);
+  box-shadow: 0 2px 5px rgba(144, 101, 237, 0.5);
+}
+
+.sky {
+  border-color: #369cf8;
+  background: linear-gradient(90deg, #369cf8 0%, rgba(54, 156, 248, 0.6) 100%);
+  box-shadow: 0 2px 5px rgba(54, 156, 248, 0.5);
 }
 
 .num {
-  font-size: 20px;
+  font-size: 24px;
   font-weight: bold;
-  color: @gray-100;
+  line-height: 1;
 }
 
 .desc {
-  font-size: 12px;
-  color: @gray-60;
+  font-size: 15px;
+  line-height: 1.2;
+}
+
+.chart {
+  display: grid;
+  grid-template-columns: repeat(10, 1fr);
+  gap: 4px;
+  height: 106px;
+  margin: 12px 30px 0;
+  padding: 0;
+  list-style: none;
+
+  li {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    align-items: center;
+    color: @gray-80;
+    font-size: 13px;
+  }
+}
+
+.bar {
+  display: block;
+  width: 100%;
+  min-height: 2px;
+  margin-bottom: 3px;
+  border-radius: 2px 2px 0 0;
+  background: #aaa;
+}
+
+@media (max-width: @sm) {
+  .tab {
+    padding-inline: 4px;
+    font-size: 12px;
+  }
+
+  .item {
+    min-height: 54px;
+  }
+
+  .num {
+    font-size: 20px;
+  }
+
+  .desc {
+    font-size: 13px;
+  }
 }

--- a/packages/website/src/pages/index/user/components/UserStatsBlock.tsx
+++ b/packages/website/src/pages/index/user/components/UserStatsBlock.tsx
@@ -1,61 +1,102 @@
 import React, { useState } from 'react';
 
-import type { CollectionType, User } from '@bangumi/client/client';
-import { Tab } from '@bangumi/design';
+import type { User } from '@bangumi/client/client';
+import { CollectionType, SubjectType } from '@bangumi/client/client';
 
-import { COLLECTION_LABELS, SUBJECT_BLOCK_LIST } from './constants';
 import styles from './UserStatsBlock.module.less';
 
-type SubjectStats = Record<string, number>;
+/** 收藏统计标签展示顺序，对齐旧版用户主页 */
+const STAT_TABS = [
+  { key: SubjectType.Book, label: '书籍' },
+  { key: SubjectType.Anime, label: '动画' },
+  { key: SubjectType.Music, label: '音乐' },
+  { key: SubjectType.Game, label: '游戏' },
+  { key: SubjectType.Real, label: '电视剧' },
+] as const;
 
-/** 某类型条目的收藏统计，缺失的状态按 0 处理 */
-function renderStatItems(stats?: SubjectStats): { label: string; value: number }[] {
-  const types = [1, 2, 3, 4, 5] as CollectionType[];
-  const total = stats ? Object.values(stats).reduce((sum, count) => sum + count, 0) : 0;
+type Stats = Record<string, number>;
+
+interface StatItem {
+  label: string;
+  value: string;
+  color: 'blue' | 'green' | 'orange' | 'pink' | 'purple' | 'sky';
+}
+
+/** 汇总所有类型的收藏统计 */
+function mergeAllStats(subject: User['stats']['subject']): Stats {
+  const merged: Stats = {};
+  for (const stats of Object.values(subject)) {
+    for (const [type, count] of Object.entries(stats)) {
+      merged[type] = (merged[type] ?? 0) + count;
+    }
+  }
+  return merged;
+}
+
+/** 某类型条目的收藏统计（缺失的状态按 0 处理），评分相关数据暂不展示 */
+function renderStatItems(stats: Stats): StatItem[] {
+  const total = Object.values(stats).reduce((sum, count) => sum + count, 0);
+  const collect = stats[CollectionType.Collect] ?? 0;
+  const rate = total > 0 ? (collect / total) * 100 : 0;
   return [
-    { label: '收藏', value: total },
-    ...types.map((type) => ({
-      label: COLLECTION_LABELS[type],
-      value: stats?.[type] ?? 0,
-    })),
+    { label: '收藏', value: String(total), color: 'pink' },
+    { label: '完成', value: String(collect), color: 'green' },
+    { label: '完成率', value: `${rate.toFixed(1)}%`, color: 'blue' },
+    { label: '平均分', value: '--', color: 'orange' },
+    { label: '标准差', value: '--', color: 'purple' },
+    { label: '评分数', value: '0', color: 'sky' },
   ];
 }
 
+const SCORE_LABELS = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] as const;
+
 const UserStatsBlock: React.FC<{ user: User }> = ({ user }) => {
   const { subject } = user.stats;
-  const available = SUBJECT_BLOCK_LIST.filter(({ subjectType }) => {
-    const stats = subject[subjectType];
-    return stats != null && Object.values(stats).some((count) => count > 0);
-  });
+  const allStats = mergeAllStats(subject);
 
-  const [activeType, setActiveType] = useState(available[0]?.subjectType);
+  const [activeKey, setActiveKey] = useState<SubjectType | 'all'>('all');
 
-  if (available.length === 0) {
-    return null;
-  }
-
-  const active = available.find((item) => item.subjectType === activeType) ?? available[0]!;
-  const activeStats = subject[active.subjectType];
+  const activeStats = activeKey === 'all' ? allStats : (subject[activeKey] ?? {});
   const statItems = renderStatItems(activeStats);
 
   return (
     <section className={styles.block}>
       <h2 className={styles.title}>收藏统计</h2>
-      {available.length > 1 && (
-        <Tab
-          items={available.map((item) => ({ key: item.subjectType, label: item.label }))}
-          activeKey={active.subjectType}
-          onChange={(key) => setActiveType(key as typeof active.subjectType)}
-        />
-      )}
+      <div className={styles.tabs}>
+        <button
+          type='button'
+          className={`${styles.tab} ${activeKey === 'all' ? styles.tabActive : ''}`}
+          onClick={() => setActiveKey('all')}
+        >
+          全部
+        </button>
+        {STAT_TABS.map(({ key, label }) => (
+          <button
+            key={key}
+            type='button'
+            className={`${styles.tab} ${activeKey === key ? styles.tabActive : ''}`}
+            onClick={() => setActiveKey(key)}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
       <div className={styles.grid}>
-        {statItems.map(({ label, value }) => (
-          <div key={label} className={styles.item}>
+        {statItems.map(({ label, value, color }) => (
+          <div key={label} className={`${styles.item} ${styles[color]}`}>
             <span className={styles.num}>{value}</span>
             <span className={styles.desc}>{label}</span>
           </div>
         ))}
       </div>
+      <ol className={styles.chart} aria-label='评分分布暂无数据'>
+        {SCORE_LABELS.map((score) => (
+          <li key={score}>
+            <span className={styles.bar} />
+            <span>{score}</span>
+          </li>
+        ))}
+      </ol>
     </section>
   );
 };

--- a/packages/website/src/pages/index/user/components/constants.ts
+++ b/packages/website/src/pages/index/user/components/constants.ts
@@ -2,11 +2,41 @@ import { CollectionType, SubjectType } from '@bangumi/client/client';
 
 /** 用户主页可展示的条目收藏模块（homepage 配置中的 block 名） */
 export const SUBJECT_BLOCK_LIST = [
-  { block: 'anime', subjectType: SubjectType.Anime, label: '动画', path: 'anime' },
-  { block: 'book', subjectType: SubjectType.Book, label: '书籍', path: 'book' },
-  { block: 'music', subjectType: SubjectType.Music, label: '音乐', path: 'music' },
-  { block: 'game', subjectType: SubjectType.Game, label: '游戏', path: 'game' },
-  { block: 'real', subjectType: SubjectType.Real, label: '三次元', path: 'real' },
+  {
+    block: 'anime',
+    subjectType: SubjectType.Anime,
+    label: '动画',
+    homepageTitle: '我的动画',
+    path: 'anime',
+  },
+  {
+    block: 'book',
+    subjectType: SubjectType.Book,
+    label: '书籍',
+    homepageTitle: '我的书籍',
+    path: 'book',
+  },
+  {
+    block: 'music',
+    subjectType: SubjectType.Music,
+    label: '音乐',
+    homepageTitle: '我的音乐',
+    path: 'music',
+  },
+  {
+    block: 'game',
+    subjectType: SubjectType.Game,
+    label: '游戏',
+    homepageTitle: '我的游戏',
+    path: 'game',
+  },
+  {
+    block: 'real',
+    subjectType: SubjectType.Real,
+    label: '三次元',
+    homepageTitle: '我的电视剧',
+    path: 'real',
+  },
 ] as const;
 
 export const SUBJECT_BLOCKS: Record<string, (typeof SUBJECT_BLOCK_LIST)[number]> =


### PR DESCRIPTION
## Summary

- rebuild the user profile home layout from the supplied visual reference, including profile navigation, collections, timeline, and statistics
- add a shared `PageContainer` and migrate routed website pages to the same 1200px content width and responsive gutters
- preserve the updated home timeline implementation from `master` while resolving the pull conflict

## Verification

- `pnpm run build`
- `pnpm lint`
- `pnpm lint:style`
- Prettier check for changed files
- Playwright screenshots at 1510x978 (home, subject, user) and 390x844 (user)

Tests were not run per request.