### PR TITLE
fix(website): render daily timeline actions by type

### DIFF
--- a/packages/website/src/pages/index/index/HomePage.spec.tsx
+++ b/packages/website/src/pages/index/index/HomePage.spec.tsx
@@ -196,6 +196,55 @@ describe('HomePage', () => {
     );
   });
 
+  it('should render daily timeline actions by type', async () => {
+    const baseTimeline = homeFixture.timeline[0]!;
+    const user = baseTimeline.user!;
+    const friendA = { ...user, id: 1001, username: 'friend-a', nickname: '好友甲' };
+    const friendB = { ...user, id: 1002, username: 'friend-b', nickname: '好友乙' };
+    const groupA = { id: 1, name: 'sakura', nsfw: false, title: '樱花庄的宠物女孩' };
+    const groupB = { id: 2, name: 'majo', nsfw: false, title: '魔女之旅' };
+
+    mockServer.use(
+      http.get('http://localhost:3000/p1/home', () =>
+        HttpResponse.json({
+          ...homeFixture,
+          timeline: [
+            {
+              ...baseTimeline,
+              id: 9011,
+              cat: 1,
+              type: 2,
+              batch: true,
+              memo: { daily: { users: [friendA, friendB] } },
+            },
+            {
+              ...baseTimeline,
+              id: 9012,
+              cat: 1,
+              type: 3,
+              memo: { daily: { groups: [groupA] } },
+            },
+            {
+              ...baseTimeline,
+              id: 9013,
+              cat: 1,
+              type: 4,
+              memo: { daily: { groups: [groupB] } },
+            },
+            // 加入乐园等未解析的 daily 类型不渲染
+            { ...baseTimeline, id: 9014, cat: 1, type: 5, memo: {} },
+          ],
+        }),
+      ),
+    );
+    await renderHome();
+
+    expect(screen.getByText('和 好友甲、好友乙 成为了好友')).toBeInTheDocument();
+    expect(screen.getByText('加入了小组 樱花庄的宠物女孩')).toBeInTheDocument();
+    expect(screen.getByText('创建了小组 魔女之旅')).toBeInTheDocument();
+    expect(screen.queryByText(/每日推荐/)).not.toBeInTheDocument();
+  });
+
   it('should mark the last unwatched episode as watched', async () => {
     setupHome();
     let patchedBody: unknown = null;

--- a/packages/website/src/pages/index/index/components/TimelineBlock.tsx
+++ b/packages/website/src/pages/index/index/components/TimelineBlock.tsx
@@ -273,11 +273,25 @@ function renderDaily(timeline: Timeline): TimelineContent | null {
   if (!daily) {
     return null;
   }
-  const names = [
-    ...(daily.groups ?? []).map((g) => g.title),
-    ...(daily.users ?? []).map((u) => u.nickname),
-  ].join('、');
-  return names ? { summary: <>更新了每日推荐：{names}</> } : null;
+  switch (timeline.type) {
+    case 2: {
+      // 添加好友
+      const names = (daily.users ?? []).map((u) => u.nickname).join('、');
+      return names ? { summary: <>和 {names} 成为了好友</> } : null;
+    }
+    case 3: {
+      // 加入小组
+      const names = (daily.groups ?? []).map((g) => g.title).join('、');
+      return names ? { summary: <>加入了小组 {names}</> } : null;
+    }
+    case 4: {
+      // 创建小组
+      const names = (daily.groups ?? []).map((g) => g.title).join('、');
+      return names ? { summary: <>创建了小组 {names}</> } : null;
+    }
+    default:
+      return null;
+  }
 }
 
 function renderContent(timeline: Timeline): TimelineContent | null {


### PR DESCRIPTION
## Why

`renderDaily` in `TimelineBlock.tsx` merged `daily.groups` and `daily.users` and rendered them with the summary "更新了每日推荐" (updated daily recommendation). This was wrong in two ways:

1. There is no such timeline type — the backend `TimelineDailyType` only has 神秘的行动/注册/添加好友/加入小组/创建小组/加入乐园, and the backend already splits `daily.users` (AddFriend, type=2) from `daily.groups` (JoinGroup/CreateGroup, type=3/4).
2. Showing "更新了每日推荐" for a friend-add timeline is incorrect copy.

## What

Render daily timelines by `timeline.type`:

- type=2 (添加好友): `和 {nicknames} 成为了好友`, multiple nicknames joined with 、
- type=3 (加入小组): `加入了小组 {group title}`
- type=4 (创建小组): `创建了小组 {group title}`
- other types (including 加入乐园, not parsed by the backend yet): render nothing

## Tests

Added a `HomePage.spec.tsx` test covering friend-add (batch), join-group, create-group, and an unparsed type that should not render.

Verified: `pnpm vitest run` (focused spec), `pnpm lint`, `pnpm type-check`, `pnpm prettier:check` all pass.