### PR TITLE
feat(website): add subject episodes page

### DIFF
--- a/packages/website/src/hooks/use-subject-episodes.ts
+++ b/packages/website/src/hooks/use-subject-episodes.ts
@@ -1,0 +1,41 @@
+import { ok } from '@oazapfts/runtime';
+import useSWR from 'swr';
+
+import { ozaClient } from '@bangumi/client';
+import type { Episode } from '@bangumi/client/client';
+
+const PAGE_SIZE = 100;
+
+async function fetchSubjectEpisodes(subjectID: number): Promise<Episode[]> {
+  const firstPage = await ok(
+    ozaClient.getSubjectEpisodes(subjectID, { limit: PAGE_SIZE, offset: 0 }),
+  );
+  const remainingPageCount = Math.ceil((firstPage.total - firstPage.data.length) / PAGE_SIZE);
+
+  if (remainingPageCount <= 0) {
+    return firstPage.data;
+  }
+
+  const remainingPages = await Promise.all(
+    Array.from({ length: remainingPageCount }, async (_, index) =>
+      ok(
+        ozaClient.getSubjectEpisodes(subjectID, {
+          limit: PAGE_SIZE,
+          offset: firstPage.data.length + index * PAGE_SIZE,
+        }),
+      ),
+    ),
+  );
+
+  return [firstPage, ...remainingPages].flatMap((page) => page.data);
+}
+
+export function useSubjectEpisodes(subjectID: number): Episode[] | undefined {
+  const { data } = useSWR(
+    `subject-episodes ${subjectID}`,
+    async () => fetchSubjectEpisodes(subjectID),
+    { suspense: true },
+  );
+
+  return data;
+}

--- a/packages/website/src/pages/index/subject/[id]/SubjectEpisodes.spec.tsx
+++ b/packages/website/src/pages/index/subject/[id]/SubjectEpisodes.spec.tsx
@@ -1,0 +1,27 @@
+import { screen } from '@testing-library/react';
+import React from 'react';
+
+import type { SubjectHomeResponse } from '@bangumi/client/client';
+import { renderPage } from '@bangumi/website/utils/test-utils';
+
+import fixture from '../../../../mocks/fixtures/p1/subjects/12/home-GET.json';
+import SubjectEpisodes from './components/SubjectEpisodes';
+
+const homeData = fixture as unknown as SubjectHomeResponse;
+
+describe('SubjectEpisodes', () => {
+  it('renders episode groups, metadata, and the subject return card', () => {
+    renderPage(<SubjectEpisodes subject={homeData.subject} episodes={homeData.episodes} />);
+
+    expect(screen.getByRole('heading', { name: '本篇' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '1.第1话' })).toHaveAttribute('href', '/ep/100');
+    expect(screen.getByText('时长:24m / 首播:2026-04-01 / 讨论:+0')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '返回条目' })).toHaveAttribute('href', '/subject/12');
+  });
+
+  it('renders an empty state when the subject has no episodes', () => {
+    renderPage(<SubjectEpisodes subject={homeData.subject} episodes={[]} />);
+
+    expect(screen.getByText('暂无章节')).toBeInTheDocument();
+  });
+});

--- a/packages/website/src/pages/index/subject/[id]/components/SubjectDetail.tsx
+++ b/packages/website/src/pages/index/subject/[id]/components/SubjectDetail.tsx
@@ -50,7 +50,7 @@ function collectVerb(subjectType: number): string {
 }
 
 /** 条目标题与导航 tabs，对齐 PHP subject_header */
-function SubjectHeader({ subject }: { subject: Subject }) {
+export function SubjectHeader({ subject }: { subject: Subject }) {
   const showEpTab =
     subject.type === SubjectType.Anime ||
     subject.type === SubjectType.Music ||
@@ -59,7 +59,7 @@ function SubjectHeader({ subject }: { subject: Subject }) {
 
   const tabs: { key: string; label: string; to: string; implemented: boolean }[] = [
     { key: 'overview', label: '概览', to: getSubjectLink(subject.id), implemented: true },
-    { key: 'ep', label: epLabel, to: getSubjectEpisodesLink(subject.id), implemented: false },
+    { key: 'ep', label: epLabel, to: getSubjectEpisodesLink(subject.id), implemented: true },
     {
       key: 'characters',
       label: '角色',
@@ -134,7 +134,7 @@ function SubjectHeader({ subject }: { subject: Subject }) {
                   <Tab.Item isActive={false}>{tab.label}</Tab.Item>
                 </Link>
               ) : (
-                <NavLink to={tab.to} key={tab.key}>
+                <NavLink to={tab.to} key={tab.key} end={tab.key === 'overview'}>
                   {({ isActive }) => <Tab.Item isActive={isActive}>{tab.label}</Tab.Item>}
                 </NavLink>
               ),

--- a/packages/website/src/pages/index/subject/[id]/components/SubjectEpisodes.module.less
+++ b/packages/website/src/pages/index/subject/[id]/components/SubjectEpisodes.module.less
@@ -1,0 +1,131 @@
+@import '@bangumi/design/theme/base';
+
+.columns {
+  display: grid;
+  grid-template-columns: minmax(0, 7fr) minmax(260px, 3fr);
+  align-items: start;
+  gap: 20px;
+}
+
+.episodeGroups {
+  min-width: 0;
+}
+
+.groupTitle {
+  margin: 0;
+  padding: 5px 10px;
+  border-top: 1px solid @gray-10;
+  border-bottom: 1px solid @gray-10;
+  color: @gray-80;
+  font-size: 13px;
+  font-weight: normal;
+  line-height: 18px;
+}
+
+.episodeList {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.episodeRow {
+  padding: 6px 5px;
+  border-bottom: 1px dotted #e0e0e0;
+  font-size: 14px;
+  line-height: 1.6;
+
+  &:nth-child(even) {
+    background: #f9f9f9;
+  }
+}
+
+.episodeTitle {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.airedStatus,
+.futureStatus {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  margin: 0 5px 1px 1px;
+  border-radius: 50%;
+}
+
+.airedStatus {
+  background: @blue-collect;
+}
+
+.futureStatus {
+  background: #d9dfe1;
+}
+
+.episodeNameCN {
+  color: @gray-80;
+}
+
+.episodeMeta {
+  margin: 0;
+  color: @gray-60;
+  font-size: 12px;
+  line-height: 19px;
+}
+
+.subjectCard {
+  display: flex;
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid @gray-10;
+  border-radius: 6px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.04);
+  box-sizing: border-box;
+}
+
+.coverLink {
+  flex: 0 0 48px;
+  height: 48px;
+  margin-right: 10px;
+}
+
+.cover {
+  width: 48px;
+  height: 48px;
+  border-radius: 4px;
+  object-fit: cover;
+}
+
+.subjectCardContent {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.subjectName {
+  max-width: 100%;
+  overflow: hidden;
+  color: @gray-80;
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.returnLink {
+  font-size: 12px;
+}
+
+.empty {
+  margin: 0;
+  padding: 16px 10px;
+  border-top: 1px solid @gray-10;
+  border-bottom: 1px dotted @gray-10;
+  color: @gray-60;
+  font-size: 13px;
+}
+
+@media (max-width: @md) {
+  .columns {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/packages/website/src/pages/index/subject/[id]/components/SubjectEpisodes.tsx
+++ b/packages/website/src/pages/index/subject/[id]/components/SubjectEpisodes.tsx
@@ -1,0 +1,149 @@
+import { DateTime } from 'luxon';
+import React from 'react';
+
+import type { Episode, Subject } from '@bangumi/client/client';
+import { EpisodeType, SubjectType } from '@bangumi/client/client';
+import { Typography } from '@bangumi/design';
+import { getEpisodeLink, getSubjectLink } from '@bangumi/utils/pages';
+import PageContainer from '@bangumi/website/components/PageContainer';
+
+import { SubjectHeader } from './SubjectDetail';
+import styles from './SubjectEpisodes.module.less';
+
+const { Link } = Typography;
+
+const EPISODE_TYPE_LABELS: Record<EpisodeType, string> = {
+  [EpisodeType.Normal]: '本篇',
+  [EpisodeType.Special]: 'SP',
+  [EpisodeType.Op]: 'OP',
+  [EpisodeType.Ed]: 'ED',
+  [EpisodeType.Pre]: '剧场版',
+  [EpisodeType.Mad]: 'MAD',
+  [EpisodeType.Other]: '其他',
+};
+
+const EPISODE_TYPE_PREFIXES: Record<EpisodeType, string> = {
+  [EpisodeType.Normal]: '',
+  [EpisodeType.Special]: 'SP',
+  [EpisodeType.Op]: 'OP',
+  [EpisodeType.Ed]: 'ED',
+  [EpisodeType.Pre]: 'Movie',
+  [EpisodeType.Mad]: 'MAD',
+  [EpisodeType.Other]: 'Other',
+};
+
+type EpisodeGroup = {
+  key: string;
+  label: string;
+  episodes: Episode[];
+};
+
+function groupEpisodes(subject: Subject, episodes: Episode[]): EpisodeGroup[] {
+  const grouped = new Map<number, Episode[]>();
+  const isMusic = subject.type === SubjectType.Music;
+
+  for (const episode of episodes) {
+    const groupKey = isMusic ? episode.disc : episode.type;
+    const group = grouped.get(groupKey) ?? [];
+    group.push(episode);
+    grouped.set(groupKey, group);
+  }
+
+  return [...grouped.entries()]
+    .sort(([left], [right]) => left - right)
+    .map(([key, group]) => ({
+      key: `${isMusic ? 'disc' : 'type'}-${key}`,
+      label: isMusic ? `Disc ${key}` : EPISODE_TYPE_LABELS[key as EpisodeType],
+      episodes: [...group].sort((left, right) => left.sort - right.sort),
+    }));
+}
+
+function isFutureEpisode(airdate: string): boolean {
+  const date = DateTime.fromISO(airdate);
+  return date.isValid && date.startOf('day').toMillis() > DateTime.now().startOf('day').toMillis();
+}
+
+function episodeTitle(episode: Episode): string {
+  return `${EPISODE_TYPE_PREFIXES[episode.type]}${episode.sort}.${episode.name}`;
+}
+
+function EpisodeRow({ episode, showAirStatus }: { episode: Episode; showAirStatus: boolean }) {
+  const broadcastInfo = [
+    episode.duration ? `时长:${episode.duration}` : '',
+    episode.airdate ? `首播:${episode.airdate}` : '',
+  ].filter(Boolean);
+
+  return (
+    <li className={styles.episodeRow}>
+      <div className={styles.episodeTitle}>
+        {showAirStatus && (
+          <span
+            className={isFutureEpisode(episode.airdate) ? styles.futureStatus : styles.airedStatus}
+            title={isFutureEpisode(episode.airdate) ? '未播出' : '已播出'}
+          />
+        )}
+        <Link to={getEpisodeLink(episode.id)}>{episodeTitle(episode)}</Link>
+        {episode.nameCN && <span className={styles.episodeNameCN}> / {episode.nameCN}</span>}
+      </div>
+      <p className={styles.episodeMeta}>
+        {broadcastInfo.join(' / ')}
+        {broadcastInfo.length > 0 && ' '}/ 讨论:+{episode.comment}
+      </p>
+    </li>
+  );
+}
+
+function SubjectSummaryCard({ subject }: { subject: Subject }) {
+  return (
+    <aside className={styles.subjectCard}>
+      {subject.images?.small && (
+        <Link to={getSubjectLink(subject.id)} noStyle className={styles.coverLink}>
+          <img src={subject.images.small} alt='' className={styles.cover} />
+        </Link>
+      )}
+      <div className={styles.subjectCardContent}>
+        <Link to={getSubjectLink(subject.id)} className={styles.subjectName}>
+          {subject.name}
+        </Link>
+        <Link to={getSubjectLink(subject.id)} className={styles.returnLink}>
+          返回条目
+        </Link>
+      </div>
+    </aside>
+  );
+}
+
+export default function SubjectEpisodes({
+  subject,
+  episodes,
+}: {
+  subject: Subject;
+  episodes: Episode[];
+}) {
+  const groups = groupEpisodes(subject, episodes);
+  const showAirStatus = subject.type !== SubjectType.Music;
+
+  return (
+    <PageContainer as='main'>
+      <SubjectHeader subject={subject} />
+      <div className={styles.columns}>
+        <div className={styles.episodeGroups}>
+          {groups.length === 0 && <p className={styles.empty}>暂无章节</p>}
+          {groups.map((group) => (
+            <section key={group.key} aria-labelledby={`${group.key}-heading`}>
+              <h2 id={`${group.key}-heading`} className={styles.groupTitle}>
+                {group.label}
+              </h2>
+              <ol className={styles.episodeList}>
+                {group.episodes.map((episode) => (
+                  <EpisodeRow key={episode.id} episode={episode} showAirStatus={showAirStatus} />
+                ))}
+              </ol>
+            </section>
+          ))}
+        </div>
+        <SubjectSummaryCard subject={subject} />
+      </div>
+    </PageContainer>
+  );
+}

--- a/packages/website/src/pages/index/subject/[id]/ep.tsx
+++ b/packages/website/src/pages/index/subject/[id]/ep.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+import { withErrorBoundary } from '@bangumi/website/components/ErrorBoundary';
+import Helmet from '@bangumi/website/components/Helmet';
+import { useSubjectEpisodes } from '@bangumi/website/hooks/use-subject-episodes';
+import { useSubjectHome } from '@bangumi/website/hooks/use-subject-home';
+
+import SubjectEpisodes from './components/SubjectEpisodes';
+
+function SubjectEpisodesPage() {
+  const { id } = useParams();
+  const subjectID = Number(id);
+  const { data } = useSubjectHome(subjectID);
+  const episodes = useSubjectEpisodes(subjectID);
+
+  if (!data || !episodes) {
+    return null;
+  }
+
+  return (
+    <>
+      <Helmet title={`${data.subject.nameCN || data.subject.name} - 章节`} />
+      <SubjectEpisodes subject={data.subject} episodes={episodes} />
+    </>
+  );
+}
+
+export default withErrorBoundary(SubjectEpisodesPage, {
+  404: () => <div>没有找到条目</div>,
+});

--- a/packages/website/src/routes.tsx
+++ b/packages/website/src/routes.tsx
@@ -18,6 +18,7 @@ const GroupTopic = lazy(async () => import('./pages/index/group/topic/[id]'));
 const GroupTopicEdit = lazy(async () => import('./pages/index/group/topic/[id]/edit'));
 const GroupTopicHome = lazy(async () => import('./pages/index/group/topic/[id]/index'));
 const Subject = lazy(async () => import('./pages/index/subject/[id]/index'));
+const SubjectEpisodes = lazy(async () => import('./pages/index/subject/[id]/ep'));
 const Wiki = lazy(async () => import('./pages/index/subject/[id]/wiki'));
 const WikiEdit = lazy(async () => import('./pages/index/subject/[id]/wiki/edit'));
 const WikiEditDetail = lazy(async () => import('./pages/index/subject/[id]/wiki/edit_detail'));
@@ -60,7 +61,6 @@ const legacyPagePaths = [
   'subject/:id/characters',
   'subject/:id/collections',
   'subject/:id/comments',
-  'subject/:id/ep',
   'subject/:id/persons',
   'subject/:id/relations',
   'subject/:id/reviews',
@@ -144,6 +144,7 @@ export const pageRoutes: RouteObject[] = [
             path: ':id',
             children: [
               { path: '', element: <Subject /> },
+              { path: 'ep', element: <SubjectEpisodes /> },
               {
                 path: 'wiki',
                 element: <Wiki />,


### PR DESCRIPTION
## What

Add the subject episodes page at `/subject/:id/ep`, implementing the previously disabled "章节" (episodes) tab in `SubjectHeader`.

## Changes

- `use-subject-episodes.ts`: hook that fetches all pages of episodes (100 per page) via SWR with suspense.
- `SubjectEpisodes.tsx`: lists episodes grouped by episode type (grouped by disc for music subjects), showing air status indicator, title (+CN title), duration, airdate, and comment counts. Includes a sidebar card linking back to the subject page.
- `ep.tsx`: page wrapper with 404 error boundary.
- `routes.tsx`: register `/subject/:id/ep` route and remove it from legacy redirect paths.
- `SubjectDetail.tsx`: mark the ep tab as implemented and make `SubjectHeader` exported/reused; use `end` on the overview tab link so the overview tab stays active for `/subject/:id`.
- `SubjectEpisodes.spec.tsx`: tests for grouping/metadata rendering and the empty state.

## Checks

- `pnpm vitest run packages/website/src/pages/index/subject`: 9 tests passed
- `pnpm type-check`: passed
- `pnpm lint`: passed
- `pnpm prettier:check`: passed