### PR TITLE
feat(website): revamp subject detail page

### DIFF
--- a/packages/website/src/pages/index/subject/[id]/SubjectDetail.spec.tsx
+++ b/packages/website/src/pages/index/subject/[id]/SubjectDetail.spec.tsx
@@ -38,7 +38,9 @@ describe('SubjectDetail', () => {
     expect(await screen.findByText(/人看过/)).toBeInTheDocument();
     // 主栏：ep / 标签
     expect(await screen.findByText('章节列表')).toBeInTheDocument();
-    expect(await screen.findByText('标签')).toBeInTheDocument();
+    expect(
+      await screen.findByRole('heading', { name: '大家将 Test Anime 标注为' }),
+    ).toBeInTheDocument();
     // 右栏：收藏盒
     expect(await screen.findByText('收藏盒')).toBeInTheDocument();
     expect(screen.getAllByRole('button', { pressed: false })).toHaveLength(5);
@@ -59,7 +61,9 @@ describe('SubjectDetail', () => {
     setup();
     await renderSubject();
 
-    const tagsSection = (await screen.findByRole('heading', { name: '标签' })).closest('section');
+    const tagsSection = (
+      await screen.findByRole('heading', { name: '大家将 Test Anime 标注为' })
+    ).closest('section');
     const collectionSection = screen.getByRole('heading', { name: '收藏盒' }).closest('section');
 
     expect(tagsSection?.parentElement).not.toBe(collectionSection?.parentElement);

--- a/packages/website/src/pages/index/subject/[id]/components/CollectionPanel.module.less
+++ b/packages/website/src/pages/index/subject/[id]/components/CollectionPanel.module.less
@@ -2,23 +2,30 @@
 
 .panel {
   overflow: hidden;
-  margin: 0 0 20px;
+  margin: 0 0 15px;
+  padding: 0;
   border: 1px solid @gray-10;
-  border-radius: 6px;
+  border-radius: 15px;
   background: #fff;
+  box-shadow: 0 5px 10px rgba(0, 0, 0, 0.09);
+  font-size: 12px;
+  overflow-wrap: break-word;
 }
 
 .panelTitle {
+  height: 40px;
   margin: 0;
-  padding: 11px 14px;
-  border-bottom: 1px solid @gray-10;
-  background: #fafafa;
-  font-size: 15px;
+  padding: 0 10px;
+  border: 0;
+  background: #f7f7f7;
+  color: @gray-80;
+  font-size: 13px;
   font-weight: normal;
+  line-height: 40px;
 }
 
 .panelBody {
-  padding: 10px 12px 12px;
+  padding: 10px;
 }
 
 .interestDetails {
@@ -71,7 +78,7 @@
 
 .collectBtn {
   min-width: 0;
-  height: 32px;
+  height: 28px;
   padding: 0 2px;
   border: 1px solid @blue-100;
   border-right-width: 0;
@@ -178,16 +185,40 @@
 }
 
 .rating {
-  margin-top: 12px;
+  margin-top: 10px;
   border-top: 1px solid @gray-10;
   padding-top: 10px;
+}
+
+.ratingAnonymous {
+  margin-top: 0;
+  padding-top: 0;
+  border-top: 0;
 }
 
 .ratingHeadline {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 10px;
+  justify-content: flex-start;
+  gap: 6px;
+}
+
+.ratingInfo {
+  min-width: 0;
+}
+
+.rateEmo {
+  display: flex;
+  width: 30px;
+  height: 30px;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid @primary-color;
+  color: @primary-color;
+  font-size: 9px;
+  font-weight: bold;
+  line-height: 1;
 }
 
 .scoreLink {
@@ -197,7 +228,7 @@
 }
 
 .score {
-  font-size: 26px;
+  font-size: 22px;
   font-weight: bold;
   color: @primary-color;
   line-height: 1;
@@ -210,8 +241,8 @@
 
 .rankDesc {
   display: block;
-  margin-top: 5px;
-  font-size: 12px;
+  margin-top: 2px;
+  font-size: 10px;
   color: @gray-80;
 
   strong {
@@ -221,6 +252,7 @@
 }
 
 .votes {
+  margin-left: auto;
   flex: none;
   padding: 2px 5px;
   background: #f3f1f1;
@@ -248,7 +280,7 @@
 .chartBarArea {
   display: flex;
   width: 100%;
-  height: 46px;
+  height: 62px;
   align-items: flex-end;
   justify-content: center;
 }

--- a/packages/website/src/pages/index/subject/[id]/components/CollectionPanel.tsx
+++ b/packages/website/src/pages/index/subject/[id]/components/CollectionPanel.tsx
@@ -7,6 +7,7 @@ import { CollectionType, SubjectType } from '@bangumi/client/client';
 import { Button, toast, Typography } from '@bangumi/design';
 import { getSubjectStatsLink } from '@bangumi/utils/pages';
 import { useSubjectHome } from '@bangumi/website/hooks/use-subject-home';
+import { useUser } from '@bangumi/website/hooks/use-user';
 
 import styles from './CollectionPanel.module.less';
 import { COLLECT_DESC } from './subject-common';
@@ -71,6 +72,7 @@ function ClickableRate({ value, onChange }: { value: number; onChange: (value: n
  * 收藏盒：我的收藏状态 + 收藏操作 + 全局评分，对齐 PHP panel_interest
  */
 const CollectionPanel: React.FC<{ subject: Subject }> = ({ subject }) => {
+  const { user } = useUser();
   const { mutate } = useSubjectHome(subject.id);
   const interest = subject.interest;
 
@@ -129,24 +131,26 @@ const CollectionPanel: React.FC<{ subject: Subject }> = ({ subject }) => {
     <section className={styles.panel}>
       <h2 className={styles.panelTitle}>收藏盒</h2>
       <div className={styles.panelBody}>
-        <div className={styles.collectButtons}>
-          {COLLECT_OPTIONS.map((option) => (
-            <button
-              key={option.type}
-              type='button'
-              className={`${styles.collectBtn} ${
-                interest?.type === option.type ? styles.collectBtnActive : ''
-              }`}
-              aria-pressed={interest?.type === option.type}
-              disabled={sending}
-              onClick={() => void updateType(option.type)}
-            >
-              {option.label}
-            </button>
-          ))}
-        </div>
+        {user && (
+          <div className={styles.collectButtons}>
+            {COLLECT_OPTIONS.map((option) => (
+              <button
+                key={option.type}
+                type='button'
+                className={`${styles.collectBtn} ${
+                  interest?.type === option.type ? styles.collectBtnActive : ''
+                }`}
+                aria-pressed={interest?.type === option.type}
+                disabled={sending}
+                onClick={() => void updateType(option.type)}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        )}
 
-        {interest != null ? (
+        {user && interest != null ? (
           <div className={styles.interestDetails}>
             <p className={styles.interestNow}>
               我{COLLECT_DESC[interest.type]}这部作品
@@ -171,7 +175,7 @@ const CollectionPanel: React.FC<{ subject: Subject }> = ({ subject }) => {
           </div>
         ) : null}
 
-        {editing && (
+        {user && editing && (
           <div className={styles.editForm}>
             <div className={styles.formRow}>
               <span className={styles.formLabel}>收藏状态</span>
@@ -212,18 +216,23 @@ const CollectionPanel: React.FC<{ subject: Subject }> = ({ subject }) => {
           </div>
         )}
 
-        <div className={styles.rating}>
+        <div className={user ? styles.rating : `${styles.rating} ${styles.ratingAnonymous}`}>
           <div className={styles.ratingHeadline}>
-            <Link to={getSubjectStatsLink(subject.id)} className={styles.scoreLink}>
-              <span className={styles.score}>{rating.score.toFixed(1)}</span>
-              <span className={styles.ratingLabel}>{getRatingLabel(rating.score)}</span>
-            </Link>
+            <span className={styles.rateEmo} aria-hidden='true'>
+              ≥▽≤
+            </span>
+            <div className={styles.ratingInfo}>
+              <Link to={getSubjectStatsLink(subject.id)} className={styles.scoreLink}>
+                <span className={styles.score}>{rating.score.toFixed(1)}</span>
+                <span className={styles.ratingLabel}>{getRatingLabel(rating.score)}</span>
+              </Link>
+              <Link to={getSubjectStatsLink(subject.id)} className={styles.rankDesc}>
+                Bangumi {RATING_CATEGORY[subject.type]} Ranked:{' '}
+                <strong>{rating.rank === 0 ? '--' : `#${rating.rank}`}</strong>
+              </Link>
+            </div>
             <div className={styles.votes}>{rating.total} votes</div>
           </div>
-          <Link to={getSubjectStatsLink(subject.id)} className={styles.rankDesc}>
-            Bangumi {RATING_CATEGORY[subject.type]} Ranked:{' '}
-            <strong>{rating.rank === 0 ? '--' : `#${rating.rank}`}</strong>
-          </Link>
           <ul className={styles.chart} aria-label='评分分布'>
             {ratingCounts.map(({ count, score }) => (
               <li key={score} className={styles.chartItem} title={`${score}分: ${count}人`}>

--- a/packages/website/src/pages/index/subject/[id]/components/SubjectDetail.module.less
+++ b/packages/website/src/pages/index/subject/[id]/components/SubjectDetail.module.less
@@ -1,124 +1,192 @@
 @import '@bangumi/design/theme/base';
 
-/* Header */
+.page {
+  padding: 10px 15px 24px;
+}
+
 .header {
-  margin: 0 0 20px;
+  margin: 0;
 }
 
 .name {
-  font-size: 22px;
+  margin: 15px 0;
+  font-size: 20px;
   font-weight: bold;
-  margin: 0 0 8px;
+  line-height: 1.3;
+
+  a {
+    color: @gray-100;
+    font-weight: bold;
+
+    &:hover {
+      color: @blue-100;
+    }
+  }
 }
 
-.nameCn {
-  font-size: 14px;
-  color: @gray-60;
-  margin-left: 8px;
+.headerInner,
+.tabsInner {
+  padding-right: 15px;
+  padding-left: 15px;
 }
 
 .platform {
-  font-size: 12px;
-  color: @gray-60;
   margin-left: 8px;
+  color: @gray-60;
+  font-size: 12px;
+  font-weight: normal;
 }
 
 .tabs {
+  border-top: 1px solid #fefefe;
   border-bottom: 1px solid @gray-10;
+  background: #fbfbfb;
 }
 
-/* 布局 */
+.tabsInner {
+  overflow-x: auto;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+.tabList {
+  display: flex;
+  width: max-content;
+  min-width: 100%;
+  margin: 0;
+  padding: 0;
+  gap: 5px;
+  list-style: none;
+}
+
+.tabLink {
+  display: block;
+  padding: 10px 10px 9px;
+  border-bottom: 2px solid transparent;
+  color: @gray-60;
+  font-size: 14px;
+  white-space: nowrap;
+
+  &:hover {
+    border-bottom-color: @blue-100;
+    color: @blue-100;
+    text-decoration: none;
+  }
+}
+
+.tabLinkActive {
+  border-bottom-color: @primary-color;
+  color: @primary-color;
+}
+
 .columns {
   display: grid;
-  grid-template-columns: 220px minmax(0, 1fr) 280px;
+  grid-template-columns: minmax(200px, 2.5fr) minmax(0, 7.5fr);
   align-items: flex-start;
-  gap: 20px;
+  gap: 10px;
 }
 
-.columnLeft {
-  min-width: 0;
-}
-
+.columnLeft,
+.columnContent,
 .columnMain,
 .columnRight {
   min-width: 0;
 }
 
-@media (max-width: @lg) {
+.primaryColumns {
+  display: grid;
+  grid-template-columns: minmax(0, 6.5fr) minmax(0, 3.5fr);
+  gap: 20px;
+  padding: 0 18px 0 10px;
+}
+
+@media (max-width: @sm) {
   .columns {
-    grid-template-columns: 220px minmax(0, 1fr);
+    display: block;
+  }
+
+  .columnLeft {
+    margin-bottom: 10px;
+  }
+
+  .primaryColumns {
+    display: block;
+    padding: 0;
   }
 
   .columnRight {
-    grid-column: 2;
+    margin-top: 10px;
   }
 }
 
-@media (max-width: @md) {
-  .columns {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .columnRight {
-    grid-column: auto;
-  }
-}
-
-/* 左栏：信息框 */
 .infobox {
-  background: #fff;
-  border: 1px solid @gray-10;
-  border-radius: 3px;
-  margin: 0 0 20px;
-  padding: 12px;
+  margin: 0 0 15px;
+  padding: 0 0 10px;
+  word-break: break-all;
 }
 
 .coverWrapper {
-  text-align: center;
   margin: 0 0 12px;
+  text-align: center;
 }
 
 .cover {
+  width: 255px;
   max-width: 100%;
-  border-radius: 3px;
+  height: auto;
+  aspect-ratio: 5 / 7;
+  box-sizing: border-box;
+  margin-bottom: 5px;
+  padding: 2px;
+  border: 1px solid #a9a9ab;
+  border-top-color: #c7c7c9;
+  border-bottom-color: #858486;
+  background: #fff;
+  box-shadow: 0 1px 5px #aaa;
+  object-fit: cover;
 }
 
 .infoList {
-  list-style: none;
   margin: 0;
   padding: 0;
-  font-size: 12px;
-  line-height: 1.8;
+  list-style: none;
+  font-size: 14px;
   word-break: break-all;
+
+  li {
+    padding: 5px;
+    border-bottom: 1px solid @gray-10;
+    line-height: 1.4;
+  }
 }
 
 .tip {
   color: @gray-60;
+  font-size: 14px;
 }
 
-/* 左栏：侧栏面板（目录/收藏统计） */
 .sidePanel {
-  background: #fff;
-  border: 1px solid @gray-10;
-  border-radius: 3px;
-  margin: 0 0 20px;
-  padding: 12px;
+  margin: 0 0 15px;
 }
 
 .sidePanelTitle {
-  font-size: 13px;
-  font-weight: normal;
-  margin: 0 0 8px;
-  padding-bottom: 6px;
+  margin: 0;
+  padding: 5px 0;
   border-bottom: 1px solid @gray-10;
+  color: @gray-80;
+  font-size: 15px;
+  font-weight: 300;
 }
 
 .indexList,
 .collectStats {
-  list-style: none;
   margin: 0;
   padding: 0;
-  font-size: 12px;
+  list-style: none;
+  font-size: 13px;
   line-height: 1.8;
 }
 
@@ -135,4 +203,60 @@
 
 .indexBy {
   color: @gray-60;
+}
+
+.shareTools {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 2px 3px;
+  color: @gray-60;
+  font-size: 12px;
+}
+
+.copyButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: @gray-60;
+  cursor: pointer;
+  font: inherit;
+
+  svg {
+    width: 15px;
+    height: 15px;
+  }
+}
+
+.shareIcon {
+  display: inline-flex;
+  width: 16px;
+  height: 16px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 2px;
+  color: #fff;
+  font-size: 10px;
+  font-weight: bold;
+  line-height: 16px;
+
+  &:hover {
+    color: #fff;
+    text-decoration: none;
+  }
+}
+
+.shareWeibo {
+  background: #e34b4b;
+}
+
+.shareDouban {
+  background: #3b8f55;
+}
+
+.shareTwitter {
+  background: #45bde0;
 }

--- a/packages/website/src/pages/index/subject/[id]/components/SubjectDetail.tsx
+++ b/packages/website/src/pages/index/subject/[id]/components/SubjectDetail.tsx
@@ -3,7 +3,8 @@ import { NavLink } from 'react-router-dom';
 
 import type { SlimIndex, Subject, SubjectHomeResponse } from '@bangumi/client/client';
 import { CollectionType, SubjectType } from '@bangumi/client/client';
-import { Tab, Typography } from '@bangumi/design';
+import { Typography } from '@bangumi/design';
+import { Link as LinkIcon } from '@bangumi/icons';
 import {
   getIndexLink,
   getSubjectBoardLink,
@@ -20,10 +21,11 @@ import {
   getUserProfileLink,
 } from '@bangumi/utils/pages';
 import PageContainer from '@bangumi/website/components/PageContainer';
+import { useUser } from '@bangumi/website/hooks/use-user';
 
 import CollectionPanel from './CollectionPanel';
 import styles from './SubjectDetail.module.less';
-import { SubjectBlocks } from './SubjectDetailBlocks';
+import { SubjectPrimaryBlocks, SubjectSecondaryBlocks } from './SubjectDetailBlocks';
 
 const { Link } = Typography;
 
@@ -51,97 +53,95 @@ function collectVerb(subjectType: number): string {
 
 /** 条目标题与导航 tabs，对齐 PHP subject_header */
 function SubjectHeader({ subject }: { subject: Subject }) {
+  const { user } = useUser();
   const showEpTab =
     subject.type === SubjectType.Anime ||
     subject.type === SubjectType.Music ||
     subject.type === SubjectType.Real;
   const epLabel = subject.type === SubjectType.Music ? '曲目' : '章节';
 
-  const tabs: { key: string; label: string; to: string; implemented: boolean }[] = [
-    { key: 'overview', label: '概览', to: getSubjectLink(subject.id), implemented: true },
-    { key: 'ep', label: epLabel, to: getSubjectEpisodesLink(subject.id), implemented: false },
+  const tabs: { key: string; label: string; to: string }[] = [
+    { key: 'overview', label: '概览', to: getSubjectLink(subject.id) },
+    { key: 'ep', label: epLabel, to: getSubjectEpisodesLink(subject.id) },
     {
       key: 'characters',
       label: '角色',
       to: getSubjectCharactersLink(subject.id),
-      implemented: false,
     },
     {
       key: 'persons',
       label: '制作人员',
       to: getSubjectPersonsLink(subject.id),
-      implemented: false,
     },
     {
       key: 'relations',
       label: '关联',
       to: getSubjectRelationsLink(subject.id),
-      implemented: false,
     },
     {
       key: 'comments',
       label: '吐槽',
       to: getSubjectCommentsLink(subject.id),
-      implemented: false,
     },
     {
       key: 'reviews',
       label: '评论',
       to: getSubjectReviewsLink(subject.id),
-      implemented: false,
     },
     {
       key: 'board',
       label: '讨论版',
       to: getSubjectBoardLink(subject.id),
-      implemented: false,
     },
     {
       key: 'stats',
       label: '透视',
       to: getSubjectStatsLink(subject.id),
-      implemented: false,
     },
     {
       key: 'wiki',
       label: 'Wiki',
       to: getSubjectWikiEditLink(subject.id),
-      implemented: true,
     },
   ];
 
   return (
-    <div className={styles.header}>
-      <h1 className={styles.name}>
-        <Link to={getSubjectLink(subject.id)} title={subject.nameCN}>
-          {subject.name}
-        </Link>
-        {subject.nameCN != null && subject.nameCN !== '' && (
-          <small className={styles.nameCn}>{subject.nameCN}</small>
-        )}
-        {subject.platform.typeCN != null && subject.platform.typeCN !== '' && (
-          <small className={styles.platform}>{subject.platform.typeCN}</small>
-        )}
-        {subject.series && <small className={styles.platform}>系列</small>}
-      </h1>
-      <div className={styles.tabs}>
-        <Tab.Group type='borderless'>
-          {tabs
-            .filter((tab) => tab.key !== 'ep' || showEpTab)
-            .map((tab) =>
-              !tab.implemented ? (
-                <Link key={tab.key} to={tab.to}>
-                  <Tab.Item isActive={false}>{tab.label}</Tab.Item>
-                </Link>
-              ) : (
-                <NavLink to={tab.to} key={tab.key}>
-                  {({ isActive }) => <Tab.Item isActive={isActive}>{tab.label}</Tab.Item>}
-                </NavLink>
-              ),
-            )}
-        </Tab.Group>
-      </div>
-    </div>
+    <header className={styles.header}>
+      <PageContainer gutterOnly className={styles.headerInner}>
+        <h1 className={styles.name}>
+          <Link to={getSubjectLink(subject.id)} title={subject.nameCN}>
+            {subject.name}
+          </Link>
+          {subject.platform.typeCN != null && subject.platform.typeCN !== '' && (
+            <small className={styles.platform}>{subject.platform.typeCN}</small>
+          )}
+          {subject.series && <small className={styles.platform}>系列</small>}
+        </h1>
+      </PageContainer>
+      <nav className={styles.tabs} aria-label='条目导航'>
+        <PageContainer gutterOnly className={styles.tabsInner}>
+          <ul className={styles.tabList}>
+            {tabs
+              .filter(
+                (tab) => (tab.key !== 'ep' || showEpTab) && (tab.key !== 'wiki' || user != null),
+              )
+              .map((tab) => (
+                <li key={tab.key}>
+                  <NavLink
+                    to={tab.to}
+                    end={tab.key === 'overview'}
+                    className={({ isActive }) =>
+                      isActive ? `${styles.tabLink} ${styles.tabLinkActive}` : styles.tabLink
+                    }
+                  >
+                    {tab.label}
+                  </NavLink>
+                </li>
+              ))}
+          </ul>
+        </PageContainer>
+      </nav>
+    </header>
   );
 }
 
@@ -236,25 +236,83 @@ function SubjectCollectStats({ subject }: { subject: Subject }) {
   );
 }
 
+function SubjectShare({ subject }: { subject: Subject }) {
+  const shareUrl = typeof window === 'undefined' ? '' : window.location.href;
+  const shareText = `「${subject.name}」`;
+
+  return (
+    <div className={styles.shareTools} aria-label='分享条目'>
+      <button
+        type='button'
+        className={styles.copyButton}
+        onClick={() => void navigator.clipboard.writeText(shareUrl)}
+      >
+        <LinkIcon />
+        复制
+      </button>
+      <span>分享</span>
+      <a
+        href={`https://service.weibo.com/share/share.php?url=${encodeURIComponent(
+          shareUrl,
+        )}&title=${encodeURIComponent(shareText)}`}
+        className={`${styles.shareIcon} ${styles.shareWeibo}`}
+        target='_blank'
+        rel='noopener noreferrer'
+        title='分享到微博'
+      >
+        微
+      </a>
+      <a
+        href={`https://www.douban.com/share/service?href=${encodeURIComponent(shareUrl)}`}
+        className={`${styles.shareIcon} ${styles.shareDouban}`}
+        target='_blank'
+        rel='noopener noreferrer'
+        title='分享到豆瓣'
+      >
+        豆
+      </a>
+      <a
+        href={`https://twitter.com/intent/tweet?url=${encodeURIComponent(
+          shareUrl,
+        )}&text=${encodeURIComponent(shareText)}`}
+        className={`${styles.shareIcon} ${styles.shareTwitter}`}
+        target='_blank'
+        rel='noopener noreferrer'
+        title='分享到 X'
+      >
+        X
+      </a>
+    </div>
+  );
+}
+
 const SubjectDetail: React.FC<{ data: SubjectHomeResponse }> = ({ data }) => {
   const { subject } = data;
   return (
-    <PageContainer as='main' className={styles.page}>
+    <>
       <SubjectHeader subject={subject} />
-      <div className={styles.columns}>
-        <div className={styles.columnLeft}>
-          <SubjectInfobox subject={subject} />
-          <SubjectIndexes indexes={data.indexes} />
-          <SubjectCollectStats subject={subject} />
+      <PageContainer as='main' className={styles.page}>
+        <div className={styles.columns}>
+          <div className={styles.columnLeft}>
+            <SubjectInfobox subject={subject} />
+            <SubjectIndexes indexes={data.indexes} />
+            <SubjectCollectStats subject={subject} />
+          </div>
+          <div className={styles.columnContent}>
+            <div className={styles.primaryColumns}>
+              <div className={styles.columnMain}>
+                <SubjectPrimaryBlocks data={data} />
+              </div>
+              <aside className={styles.columnRight}>
+                <CollectionPanel subject={subject} />
+                <SubjectShare subject={subject} />
+              </aside>
+            </div>
+            <SubjectSecondaryBlocks data={data} />
+          </div>
         </div>
-        <div className={styles.columnMain}>
-          <SubjectBlocks data={data} />
-        </div>
-        <aside className={styles.columnRight}>
-          <CollectionPanel subject={subject} />
-        </aside>
-      </div>
-    </PageContainer>
+      </PageContainer>
+    </>
   );
 };
 

--- a/packages/website/src/pages/index/subject/[id]/components/SubjectDetailBlocks.module.less
+++ b/packages/website/src/pages/index/subject/[id]/components/SubjectDetailBlocks.module.less
@@ -1,5 +1,38 @@
 @import '@bangumi/design/theme/base';
 
+.primarySection.primarySection {
+  margin: 0 0 10px;
+  padding: 0 0 5px;
+
+  > div {
+    justify-content: flex-start;
+    gap: 4px;
+  }
+
+  h2 {
+    font-size: 14px;
+    font-weight: normal;
+  }
+}
+
+.summarySection.summarySection {
+  margin: 0;
+  padding: 0 0 5px;
+  border-bottom: 0;
+}
+
+.tagSection.tagSection {
+  margin: 5px 0 10px;
+  padding: 10px;
+  border: 0;
+  border-radius: 5px;
+  background: #f7f7f7;
+
+  h2 {
+    font-size: 14px;
+  }
+}
+
 /* 章节/曲目 */
 .musicList {
   list-style: none;
@@ -50,17 +83,20 @@
   padding: 0;
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: 3px;
 }
 
 .epBtn {
   display: inline-block;
-  min-width: 28px;
-  padding: 3px 5px;
+  width: 24px;
+  height: 24px;
+  box-sizing: border-box;
+  padding: 0;
   text-align: center;
   border: 1px solid @gray-10;
   border-radius: 3px;
   font-size: 12px;
+  line-height: 22px;
   color: @gray-100;
 }
 
@@ -70,12 +106,143 @@
   color: #fff;
 }
 
+.epAired {
+  border-color: #00a8ff;
+  background: #e5f5ff;
+  color: #06c;
+}
+
+.epUpcoming {
+  border-color: #b6b6b6;
+  background: #e0e0e0;
+  color: #909090;
+}
+
+.epPopover {
+  vertical-align: top;
+
+  :global(.bgm-popover__container) {
+    align-items: flex-start;
+  }
+
+  :global(.bgm-popover__content) {
+    top: 5px;
+    left: 12px;
+    width: 275px;
+    overflow: visible;
+    border: 0;
+    border-radius: 5px;
+    box-shadow: 0 0 10px rgba(80, 80, 80, 0.5);
+  }
+
+  :global(.bgm-popover__content)::before {
+    position: absolute;
+    top: 0;
+    left: -10px;
+    width: 0;
+    height: 0;
+    border-top: 11px solid @primary-color;
+    border-bottom: 11px solid transparent;
+    border-left: 0;
+    border-right: 11px solid transparent;
+    content: '';
+  }
+
+  :global(.bgm-popover__content)::after {
+    position: absolute;
+    top: -5px;
+    left: -12px;
+    width: 36px;
+    height: 5px;
+    content: '';
+  }
+
+  &:focus-within :global(.bgm-popover__content) {
+    visibility: visible;
+    opacity: 1;
+  }
+}
+
+.epPopoverContent {
+  width: 275px;
+  border-radius: 5px;
+  background: rgba(254, 254, 254, 0.96);
+  color: @gray-100;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.epPopoverTitle {
+  padding: 8px 10px;
+  overflow: hidden;
+  border-radius: 5px 5px 0 0;
+  background: @primary-color;
+  color: #fff;
+  font-size: 13px;
+  line-height: 18px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.epPopoverBody {
+  padding: 5px 10px 7px;
+
+  p {
+    margin: 0;
+  }
+
+  hr {
+    height: 1px;
+    margin: 5px 0;
+    border: 0;
+    background: @gray-10;
+  }
+}
+
+.epDiscussionLink.epDiscussionLink {
+  color: @blue-100;
+
+  small {
+    color: @gray-60;
+  }
+}
+
 /* 简介 */
 .summary {
-  font-size: 13px;
-  line-height: 1.8;
+  color: @gray-100;
+  font-size: 14px;
+  line-height: 1.65;
   white-space: pre-wrap;
   word-break: break-all;
+}
+
+.summaryCollapsed {
+  position: relative;
+  max-height: 250px;
+  overflow: hidden;
+
+  &::after {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    height: 42px;
+    background: linear-gradient(to bottom, rgba(255, 255, 255, 0), #fff);
+    content: '';
+    pointer-events: none;
+  }
+}
+
+.summaryToggle {
+  display: block;
+  margin: -2px 0 0 auto;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: @blue-100;
+  cursor: pointer;
+  font-size: 11px;
+  line-height: 18px;
 }
 
 /* 标签 */
@@ -85,14 +252,22 @@
   padding: 0;
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: 2px 4px;
 }
 
 .tagList li {
-  padding: 2px 8px;
+  padding: 1px 5px;
   border: 1px solid @gray-10;
-  border-radius: 10px;
+  border-radius: 20px;
+  background: #fff;
   font-size: 12px;
+  line-height: 1.4;
+}
+
+.tagCount {
+  margin-left: 2px;
+  color: @gray-60;
+  font-size: 10px;
 }
 
 /* 封面网格（角色/关联/推荐） */
@@ -102,14 +277,15 @@
   padding: 0;
   display: flex;
   flex-wrap: wrap;
+  align-items: flex-start;
   gap: 10px;
-  align-items: flex-end;
 }
 
 .coverItem {
-  width: 72px;
-  text-align: center;
   position: relative;
+  width: 80px;
+  min-width: 0;
+  text-align: left;
 }
 
 .coverLink {
@@ -117,20 +293,67 @@
 }
 
 .cover {
-  width: 72px;
-  height: 96px;
+  display: block;
+  width: 75px;
+  height: 75px;
   object-fit: cover;
-  border-radius: 3px;
+  object-position: center top;
+  border-radius: 8px;
   background: @gray-10;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.2),
+    0 2px 10px rgba(0, 0, 0, 0.2);
+}
+
+.characterGrid {
+  flex-wrap: nowrap;
+  gap: 15px;
+  padding: 5px;
+  overflow-x: auto;
+
+  .coverItem {
+    flex: 0 0 85px;
+    width: 85px;
+  }
+
+  .coverTitle {
+    font-size: 13px;
+  }
+}
+
+.characterCover {
+  width: 85px;
+  height: auto;
+  min-height: 100px;
+  aspect-ratio: 3 / 4;
+}
+
+.relationGrid {
+  gap: 5px 10px;
+}
+
+.recommendationGrid {
+  flex-wrap: nowrap;
+  gap: 9px;
+  overflow-x: auto;
+
+  .coverItem {
+    flex: 0 0 80px;
+  }
+}
+
+.subjectCover {
+  aspect-ratio: 1;
 }
 
 .coverTitle {
-  margin: 4px 0 0;
-  font-size: 12px;
-  line-height: 1.4;
+  max-height: 52px;
+  margin: 5px 0 0;
+  font-size: 11px;
+  font-weight: 400;
+  line-height: 1.2;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: break-word;
 }
 
 .coverInfo {
@@ -145,9 +368,42 @@
 .relationSep {
   display: block;
   width: 100%;
-  font-size: 13px;
+  height: 18px;
+  font-size: 12px;
   color: @gray-60;
-  margin: 6px 0 0;
+  line-height: 18px;
+}
+
+@media (max-width: @sm) {
+  .epPopover {
+    :global(.bgm-popover__content) {
+      position: fixed;
+      top: 35vh;
+      right: 5vw;
+      left: 5vw;
+      width: auto;
+    }
+
+    :global(.bgm-popover__content)::before {
+      display: none;
+    }
+
+    :global(.bgm-popover__content)::after {
+      display: none;
+    }
+  }
+
+  .epPopoverContent {
+    width: auto;
+  }
+
+  .coverGrid {
+    margin-right: 0;
+  }
+
+  .characterGrid .coverItem {
+    flex-basis: 20vw;
+  }
 }
 
 /* 文本列表（评论/日志） */

--- a/packages/website/src/pages/index/subject/[id]/components/SubjectDetailBlocks.tsx
+++ b/packages/website/src/pages/index/subject/[id]/components/SubjectDetailBlocks.tsx
@@ -13,7 +13,7 @@ import type {
   Topic,
 } from '@bangumi/client/client';
 import { EpisodeCollectionStatus, EpisodeType, SubjectType } from '@bangumi/client/client';
-import { Avatar, Rate, Typography } from '@bangumi/design';
+import { Avatar, Popover, Rate, Typography } from '@bangumi/design';
 import {
   getBlogLink,
   getCharacterLink,
@@ -37,6 +37,37 @@ import SubjectSection from './SubjectSection';
 
 const { Link } = Typography;
 
+function EpisodePopover({ episode }: { episode: Episode }) {
+  const title = `ep.${episode.sort} ${episode.name || episode.nameCN}`;
+
+  return (
+    <div className={styles.epPopoverContent}>
+      <div className={styles.epPopoverTitle}>{title}</div>
+      <div className={styles.epPopoverBody}>
+        {episode.nameCN && (
+          <p>
+            <span>中文标题:</span> {episode.nameCN}
+          </p>
+        )}
+        {episode.airdate && (
+          <p>
+            <span>首播:</span> {episode.airdate}
+          </p>
+        )}
+        {episode.duration && (
+          <p>
+            <span>时长:</span> {episode.duration}
+          </p>
+        )}
+        <hr />
+        <Link to={getEpisodeLink(episode.id)} className={styles.epDiscussionLink}>
+          讨论 <small>(+{episode.comment})</small>
+        </Link>
+      </div>
+    </div>
+  );
+}
+
 /** 章节/曲目列表，对齐 PHP subject_box_prg */
 function EpListSection({ subject, episodes }: { subject: Subject; episodes: Episode[] }) {
   const isAnimeLike = subject.type === SubjectType.Anime || subject.type === SubjectType.Real;
@@ -48,7 +79,7 @@ function EpListSection({ subject, episodes }: { subject: Subject; episodes: Epis
 
   if (isMusic) {
     return (
-      <SubjectSection title='曲目列表'>
+      <SubjectSection title='曲目列表' className={styles.primarySection}>
         <ul className={styles.musicList}>
           {episodes.map((ep) => (
             <li key={ep.id}>
@@ -71,15 +102,24 @@ function EpListSection({ subject, episodes }: { subject: Subject; episodes: Epis
     <ul className={styles.epGrid}>
       {list.map((ep) => {
         const done = ep.collection?.status === EpisodeCollectionStatus.Done;
+        const upcoming =
+          ep.airdate !== '' &&
+          dayjs(ep.airdate).isValid() &&
+          dayjs(ep.airdate).isAfter(dayjs(), 'day');
         return (
           <li key={ep.id}>
-            <Link
-              to={getEpisodeLink(ep.id)}
-              className={classNames(styles.epBtn, done ? styles.epDone : undefined)}
-              title={`ep.${ep.sort} ${ep.name || ep.nameCN}`}
-            >
-              {String(ep.sort).padStart(2, '0')}
-            </Link>
+            <Popover className={styles.epPopover} content={<EpisodePopover episode={ep} />}>
+              <Link
+                to={getEpisodeLink(ep.id)}
+                className={classNames(
+                  styles.epBtn,
+                  done ? styles.epDone : upcoming ? styles.epUpcoming : styles.epAired,
+                )}
+                title={`ep.${ep.sort} ${ep.name || ep.nameCN}`}
+              >
+                {String(ep.sort).padStart(2, '0')}
+              </Link>
+            </Popover>
           </li>
         );
       })}
@@ -90,6 +130,7 @@ function EpListSection({ subject, episodes }: { subject: Subject; episodes: Epis
     <SubjectSection
       title='章节列表'
       extra={<Link to={getSubjectEpisodesLink(subject.id)}>[全部]</Link>}
+      className={styles.primarySection}
     >
       {renderEpGrid(normals)}
       {specials.length > 0 && (
@@ -104,25 +145,47 @@ function EpListSection({ subject, episodes }: { subject: Subject; episodes: Epis
 
 /** 简介，对齐 PHP subject_summary */
 function SummarySection({ summary }: { summary: string }) {
+  const contentRef = React.useRef<HTMLDivElement>(null);
+  const [collapsed, setCollapsed] = React.useState(true);
+  const [collapsible, setCollapsible] = React.useState(false);
+
+  React.useLayoutEffect(() => {
+    setCollapsible((contentRef.current?.scrollHeight ?? 0) > 250);
+  }, [summary]);
+
   return (
-    <SubjectSection>
-      <div className={styles.summary}>{summary}</div>
+    <SubjectSection className={styles.summarySection}>
+      <div
+        ref={contentRef}
+        className={`${styles.summary} ${collapsible && collapsed ? styles.summaryCollapsed : ''}`}
+      >
+        {summary}
+      </div>
+      {collapsible && (
+        <button
+          type='button'
+          className={styles.summaryToggle}
+          onClick={() => setCollapsed((value) => !value)}
+        >
+          {collapsed ? 'more...' : '收起'}
+        </button>
+      )}
     </SubjectSection>
   );
 }
 
 /** 标签，对齐 PHP subject_box_tag */
-function TagsSection({ tags }: { tags: Subject['tags'] }) {
-  if (tags.length === 0) {
+function TagsSection({ subject }: { subject: Subject }) {
+  if (subject.tags.length === 0) {
     return null;
   }
   return (
-    <SubjectSection title='标签'>
+    <SubjectSection title={`大家将 ${subject.name} 标注为`} className={styles.tagSection}>
       <ul className={styles.tagList}>
-        {tags.map((tag) => (
+        {subject.tags.map((tag) => (
           <li key={tag.name}>
             <Link to={getSubjectTagLink(tag.name)}>
-              {tag.name} ({tag.count})
+              {tag.name} <small className={styles.tagCount}>{tag.count}</small>
             </Link>
           </li>
         ))}
@@ -147,7 +210,7 @@ function CharactersSection({
       title='角色介绍'
       extra={<Link to={getSubjectCharactersLink(subjectId)}>更多角色 »</Link>}
     >
-      <ul className={styles.coverGrid}>
+      <ul className={classNames(styles.coverGrid, styles.characterGrid)}>
         {characters.map(({ character, casts }) => (
           <li key={character.id} className={styles.coverItem}>
             <Link
@@ -155,7 +218,12 @@ function CharactersSection({
               className={styles.coverLink}
               title={character.nameCN || character.name}
             >
-              <img src={character.images?.grid} className={styles.cover} loading='lazy' alt='' />
+              <img
+                src={character.images?.grid}
+                className={classNames(styles.cover, styles.characterCover)}
+                loading='lazy'
+                alt=''
+              />
             </Link>
             <p className={styles.coverTitle}>
               <Link to={getCharacterLink(character.id)}>{character.nameCN || character.name}</Link>
@@ -191,7 +259,7 @@ function RelationsSection({
       title='关联条目'
       extra={<Link to={getSubjectRelationsLink(subjectId)}>更多关联 »</Link>}
     >
-      <ul className={styles.coverGrid}>
+      <ul className={classNames(styles.coverGrid, styles.relationGrid)}>
         {relations.map(({ subject, relation }) => {
           const showSep = relation.id !== lastRelationId;
           lastRelationId = relation.id;
@@ -203,7 +271,12 @@ function RelationsSection({
                 className={styles.coverLink}
                 title={subject.nameCN || subject.name}
               >
-                <img src={subject.images?.grid} className={styles.cover} loading='lazy' alt='' />
+                <img
+                  src={subject.images?.grid}
+                  className={classNames(styles.cover, styles.subjectCover)}
+                  loading='lazy'
+                  alt=''
+                />
               </Link>
               <p className={styles.coverTitle}>
                 <Link to={getSubjectLink(subject.id)}>{subject.name}</Link>
@@ -223,7 +296,7 @@ function RecsSection({ recs }: { recs: SubjectRec[] }) {
   }
   return (
     <SubjectSection title='喜欢这部作品的会员大概会喜欢'>
-      <ul className={styles.coverGrid}>
+      <ul className={classNames(styles.coverGrid, styles.recommendationGrid)}>
         {recs.map(({ subject }) => (
           <li key={subject.id} className={styles.coverItem}>
             <Link
@@ -231,7 +304,12 @@ function RecsSection({ recs }: { recs: SubjectRec[] }) {
               className={styles.coverLink}
               title={subject.nameCN || subject.name}
             >
-              <img src={subject.images?.grid} className={styles.cover} loading='lazy' alt='' />
+              <img
+                src={subject.images?.grid}
+                className={classNames(styles.cover, styles.subjectCover)}
+                loading='lazy'
+                alt=''
+              />
             </Link>
             <p className={styles.coverTitle}>
               <Link to={getSubjectLink(subject.id)}>{subject.name}</Link>
@@ -355,7 +433,7 @@ function CommentsSection({
 }
 
 /** 主内容区块的组合，按 PHP 布局顺序渲染 */
-export const SubjectBlocks: React.FC<{ data: SubjectHomeResponse }> = ({ data }) => {
+export const SubjectPrimaryBlocks: React.FC<{ data: SubjectHomeResponse }> = ({ data }) => {
   const { subject } = data;
   return (
     <>
@@ -363,7 +441,15 @@ export const SubjectBlocks: React.FC<{ data: SubjectHomeResponse }> = ({ data })
       {subject.summary != null && subject.summary !== '' && (
         <SummarySection summary={subject.summary} />
       )}
-      <TagsSection tags={subject.tags} />
+      <TagsSection subject={subject} />
+    </>
+  );
+};
+
+export const SubjectSecondaryBlocks: React.FC<{ data: SubjectHomeResponse }> = ({ data }) => {
+  const { subject } = data;
+  return (
+    <>
       <CharactersSection subjectId={subject.id} characters={data.characters} />
       <RelationsSection subjectId={subject.id} relations={data.relations} />
       <RecsSection recs={data.recs} />
@@ -373,3 +459,10 @@ export const SubjectBlocks: React.FC<{ data: SubjectHomeResponse }> = ({ data })
     </>
   );
 };
+
+export const SubjectBlocks: React.FC<{ data: SubjectHomeResponse }> = ({ data }) => (
+  <>
+    <SubjectPrimaryBlocks data={data} />
+    <SubjectSecondaryBlocks data={data} />
+  </>
+);

--- a/packages/website/src/pages/index/subject/[id]/components/SubjectSection.module.less
+++ b/packages/website/src/pages/index/subject/[id]/components/SubjectSection.module.less
@@ -1,11 +1,9 @@
 @import '@bangumi/design/theme/base';
 
 .section {
-  background: #fff;
-  border: 1px solid @gray-10;
-  border-radius: 3px;
-  margin: 0 0 20px;
-  padding: 12px;
+  margin: 0 0 5px;
+  padding: 10px;
+  border-bottom: 1px solid @gray-10;
 }
 
 .header {
@@ -13,17 +11,19 @@
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  margin: 0 0 10px;
-  padding-bottom: 6px;
-  border-bottom: 1px solid @gray-10;
+  margin: 0 0 5px;
 }
 
 .title {
-  font-size: 15px;
-  font-weight: normal;
   margin: 0;
+  padding: 0 5px 0 0;
+  color: @gray-80;
+  font-size: 18px;
+  font-weight: 300;
+  line-height: 1.4;
 }
 
 .extra {
   flex: none;
+  font-size: 12px;
 }

--- a/packages/website/src/pages/index/subject/[id]/components/SubjectSection.tsx
+++ b/packages/website/src/pages/index/subject/[id]/components/SubjectSection.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import type { PropsWithChildren } from 'react';
 import React from 'react';
 
@@ -7,10 +8,10 @@ import styles from './SubjectSection.module.less';
  * 详情页右栏区块容器，对齐 PHP subject_section
  */
 const SubjectSection: React.FC<
-  PropsWithChildren<{ title?: React.ReactNode; extra?: React.ReactNode }>
-> = ({ title, extra, children }) => {
+  PropsWithChildren<{ title?: React.ReactNode; extra?: React.ReactNode; className?: string }>
+> = ({ title, extra, className, children }) => {
   return (
-    <section className={styles.section}>
+    <section className={classNames(styles.section, className)}>
       {title != null && (
         <div className={styles.header}>
           <h2 className={styles.title}>{title}</h2>


### PR DESCRIPTION
## Summary

Revamp the subject detail page to better align with the PHP subject page layout and improve anonymous browsing experience.

### Layout & header
- Rework `SubjectHeader`: align content with `PageContainer`, replace `Tab.Group` with styled `NavLink` tabs, and hide the Wiki tab for anonymous users.
- Restructure the page into: left column (infobox / indexes / collect stats), primary columns (main content + right column with collection panel & share tools), and secondary blocks (characters / relations / recs / comments) below.

### Collection panel
- Hide collection actions and edit form for anonymous users; show a simplified rating summary instead.
- Add rating emoji and move the rank line into the rating headline.

### Episodes
- Distinguish done / aired / upcoming episodes with different styles.
- Show an episode popover on hover with Chinese title, air date, duration and a discussion link.

### Other
- Collapse long summaries with a "more..." / expand toggle.
- Change tag section title to `大家将 <name> 标注为`.
- Add share tools (copy link, Weibo, Douban, X).