### PR TITLE
feat(website): add subject search page

### DIFF
--- a/packages/website/src/mocks/fixtures/p1/search/characters-POST.json
+++ b/packages/website/src/mocks/fixtures/p1/search/characters-POST.json
@@ -1,0 +1,127 @@
+{
+  "data": [
+    {
+      "id": 99657,
+      "name": "巨人",
+      "nameCN": "巨人",
+      "role": 1,
+      "info": "性别 女",
+      "comment": 14,
+      "lock": false,
+      "nsfw": false,
+      "images": {
+        "large": "https://lain.bgm.tv/pic/crt/l/32/4c/99657_crt_5ABYV.jpg?r=1629087437",
+        "medium": "https://lain.bgm.tv/r/200/pic/crt/l/32/4c/99657_crt_5ABYV.jpg?r=1629087437",
+        "small": "https://lain.bgm.tv/r/100/pic/crt/l/32/4c/99657_crt_5ABYV.jpg?r=1629087437",
+        "grid": "https://lain.bgm.tv/r/100x100/pic/crt/l/32/4c/99657_crt_5ABYV.jpg?r=1629087437"
+      }
+    },
+    {
+      "id": 216990,
+      "name": "巨人",
+      "nameCN": "",
+      "role": 1,
+      "info": "",
+      "comment": 0,
+      "lock": false,
+      "nsfw": false
+    },
+    {
+      "id": 152365,
+      "name": "Giants",
+      "nameCN": "巨人",
+      "role": 1,
+      "info": "",
+      "comment": 0,
+      "lock": false,
+      "nsfw": false,
+      "images": {
+        "large": "https://lain.bgm.tv/pic/crt/l/1a/2d/152365_crt_16A10.jpg",
+        "medium": "https://lain.bgm.tv/r/200/pic/crt/l/1a/2d/152365_crt_16A10.jpg",
+        "small": "https://lain.bgm.tv/r/100/pic/crt/l/1a/2d/152365_crt_16A10.jpg",
+        "grid": "https://lain.bgm.tv/r/100x100/pic/crt/l/1a/2d/152365_crt_16A10.jpg"
+      }
+    },
+    {
+      "id": 71811,
+      "name": "巨人ヨーム",
+      "nameCN": "巨人尤姆",
+      "role": 1,
+      "info": "性别 男",
+      "comment": 2,
+      "lock": false,
+      "nsfw": false,
+      "images": {
+        "large": "https://lain.bgm.tv/pic/crt/l/93/c8/71811_crt_XxWXo.jpg?r=1568610668",
+        "medium": "https://lain.bgm.tv/r/200/pic/crt/l/93/c8/71811_crt_XxWXo.jpg?r=1568610668",
+        "small": "https://lain.bgm.tv/r/100/pic/crt/l/93/c8/71811_crt_XxWXo.jpg?r=1568610668",
+        "grid": "https://lain.bgm.tv/r/100x100/pic/crt/l/93/c8/71811_crt_XxWXo.jpg?r=1568610668"
+      }
+    },
+    {
+      "id": 111695,
+      "name": "巨人族",
+      "nameCN": "",
+      "role": 1,
+      "info": "",
+      "comment": 0,
+      "lock": false,
+      "nsfw": false,
+      "images": {
+        "large": "https://lain.bgm.tv/pic/crt/l/9a/2a/111695_crt_aa32G.jpg",
+        "medium": "https://lain.bgm.tv/r/200/pic/crt/l/9a/2a/111695_crt_aa32G.jpg",
+        "small": "https://lain.bgm.tv/r/100/pic/crt/l/9a/2a/111695_crt_aa32G.jpg",
+        "grid": "https://lain.bgm.tv/r/100x100/pic/crt/l/9a/2a/111695_crt_aa32G.jpg"
+      }
+    },
+    {
+      "id": 116856,
+      "name": "MS-06R-WW-2 ザク・アルヴァルディ",
+      "nameCN": "巨人渣古",
+      "role": 2,
+      "info": "",
+      "comment": 0,
+      "lock": false,
+      "nsfw": false,
+      "images": {
+        "large": "https://lain.bgm.tv/pic/crt/l/20/00/116856_crt_vzX77.jpg",
+        "medium": "https://lain.bgm.tv/r/200/pic/crt/l/20/00/116856_crt_vzX77.jpg",
+        "small": "https://lain.bgm.tv/r/100/pic/crt/l/20/00/116856_crt_vzX77.jpg",
+        "grid": "https://lain.bgm.tv/r/100x100/pic/crt/l/20/00/116856_crt_vzX77.jpg"
+      }
+    },
+    {
+      "id": 157861,
+      "name": "ギガントマキア",
+      "nameCN": "巨人战争",
+      "role": 1,
+      "info": "性别 男",
+      "comment": 0,
+      "lock": false,
+      "nsfw": false,
+      "images": {
+        "large": "https://lain.bgm.tv/pic/crt/l/53/e4/157861_crt_to5WJ.jpg?r=1716209828",
+        "medium": "https://lain.bgm.tv/r/200/pic/crt/l/53/e4/157861_crt_to5WJ.jpg?r=1716209828",
+        "small": "https://lain.bgm.tv/r/100/pic/crt/l/53/e4/157861_crt_to5WJ.jpg?r=1716209828",
+        "grid": "https://lain.bgm.tv/r/100x100/pic/crt/l/53/e4/157861_crt_to5WJ.jpg?r=1716209828"
+      }
+    },
+    {
+      "id": 209742,
+      "name": "ギガントキョウリュウジン",
+      "nameCN": "巨人强龙神",
+      "role": 1,
+      "info": "",
+      "comment": 0,
+      "lock": false,
+      "nsfw": false,
+      "images": {
+        "large": "https://lain.bgm.tv/pic/crt/l/59/58/209742_crt_VyHoV.jpg",
+        "medium": "https://lain.bgm.tv/r/200/pic/crt/l/59/58/209742_crt_VyHoV.jpg",
+        "small": "https://lain.bgm.tv/r/100/pic/crt/l/59/58/209742_crt_VyHoV.jpg",
+        "grid": "https://lain.bgm.tv/r/100x100/pic/crt/l/59/58/209742_crt_VyHoV.jpg"
+      }
+    }
+  ],
+  "total": 40
+}

--- a/packages/website/src/mocks/fixtures/p1/search/index.ts
+++ b/packages/website/src/mocks/fixtures/p1/search/index.ts
@@ -1,0 +1,34 @@
+import type { ozaClient } from '@bangumi/client';
+
+import characterSearchJson from './characters-POST.json';
+import personSearchJson from './persons-POST.json';
+import subjectSearchJson from './subjects-POST.json';
+
+type ApiFunction = (...args: never[]) => Promise<unknown>;
+
+type SuccessfulData<T extends ApiFunction> = Extract<
+  Awaited<ReturnType<T>>,
+  { status: 200 }
+>['data'];
+
+type JsonFixture<T> = T extends number
+  ? number
+  : T extends string
+    ? string
+    : T extends boolean
+      ? boolean
+      : T extends (infer Item)[]
+        ? JsonFixture<Item>[]
+        : T extends object
+          ? { [Key in keyof T]: JsonFixture<T[Key]> }
+          : T;
+
+export const subjectSearchFixture: JsonFixture<SuccessfulData<typeof ozaClient.searchSubjects>> =
+  subjectSearchJson;
+
+export const characterSearchFixture: JsonFixture<
+  SuccessfulData<typeof ozaClient.searchCharacters>
+> = characterSearchJson;
+
+export const personSearchFixture: JsonFixture<SuccessfulData<typeof ozaClient.searchPersons>> =
+  personSearchJson;

--- a/packages/website/src/mocks/fixtures/p1/search/persons-POST.json
+++ b/packages/website/src/mocks/fixtures/p1/search/persons-POST.json
@@ -1,0 +1,50 @@
+{
+  "data": [
+    {
+      "id": 49410,
+      "name": "巨人网络",
+      "nameCN": "",
+      "type": 2,
+      "info": "生日 2004年11月18日",
+      "career": ["producer"],
+      "comment": 0,
+      "lock": false,
+      "nsfw": false,
+      "images": {
+        "large": "https://lain.bgm.tv/pic/crt/l/09/f9/49410_prsn_bSUAD.jpg",
+        "medium": "https://lain.bgm.tv/r/200/pic/crt/l/09/f9/49410_prsn_bSUAD.jpg",
+        "small": "https://lain.bgm.tv/r/100/pic/crt/l/09/f9/49410_prsn_bSUAD.jpg",
+        "grid": "https://lain.bgm.tv/r/100x100/pic/crt/l/09/f9/49410_prsn_bSUAD.jpg"
+      }
+    },
+    {
+      "id": 15791,
+      "name": "コロッサス",
+      "nameCN": "巨人",
+      "type": 1,
+      "info": "",
+      "career": ["producer"],
+      "comment": 0,
+      "lock": false,
+      "nsfw": false,
+      "images": {
+        "large": "https://lain.bgm.tv/pic/crt/l/d0/67/15791_prsn_VMmHi.jpg",
+        "medium": "https://lain.bgm.tv/r/200/pic/crt/l/d0/67/15791_prsn_VMmHi.jpg",
+        "small": "https://lain.bgm.tv/r/100/pic/crt/l/d0/67/15791_prsn_VMmHi.jpg",
+        "grid": "https://lain.bgm.tv/r/100x100/pic/crt/l/d0/67/15791_prsn_VMmHi.jpg"
+      }
+    },
+    {
+      "id": 50980,
+      "name": "石川森彦",
+      "nameCN": "",
+      "type": 1,
+      "info": "性别 男 / 生日 1951年7月1日",
+      "career": ["mangaka"],
+      "comment": 0,
+      "lock": false,
+      "nsfw": false
+    }
+  ],
+  "total": 3
+}

--- a/packages/website/src/mocks/fixtures/p1/search/subjects-POST.json
+++ b/packages/website/src/mocks/fixtures/p1/search/subjects-POST.json
@@ -1,0 +1,275 @@
+{
+  "data": [
+    {
+      "id": 41983,
+      "name": "巨人の星",
+      "nameCN": "巨人之星",
+      "type": 2,
+      "info": "182话 / 1968年3月30日 / 長浜忠夫(構成: 1-85 / 演出: 86-182) / 梶原一騎(作) 、川崎のぼる(画) / 楠部大吉郎",
+      "metaTags": ["TV", "日本", "漫画改"],
+      "rating": { "rank": 0, "count": [0, 0, 1, 0, 2, 6, 8, 6, 0, 2], "score": 6.92, "total": 25 },
+      "locked": false,
+      "nsfw": false,
+      "images": {
+        "large": "https://lain.bgm.tv/pic/cover/l/5f/68/41983_H0ipf.jpg",
+        "common": "https://lain.bgm.tv/r/400/pic/cover/l/5f/68/41983_H0ipf.jpg",
+        "medium": "https://lain.bgm.tv/r/200/pic/cover/l/5f/68/41983_H0ipf.jpg",
+        "small": "https://lain.bgm.tv/r/100/pic/cover/l/5f/68/41983_H0ipf.jpg",
+        "grid": "https://lain.bgm.tv/r/100x100/pic/cover/l/5f/68/41983_H0ipf.jpg"
+      }
+    },
+    {
+      "id": 274332,
+      "name": "巨人の星 行け行け飛雄馬",
+      "nameCN": "",
+      "type": 2,
+      "info": "1969年12月20日 / 梶原一騎(作) 、川崎のぼる(画)",
+      "metaTags": ["剧场版"],
+      "rating": { "rank": 0, "count": [0, 0, 0, 0, 0, 2, 0, 0, 0, 0], "score": 6, "total": 2 },
+      "locked": false,
+      "nsfw": false,
+      "images": {
+        "large": "https://lain.bgm.tv/pic/cover/l/90/1b/274332_ninFs.jpg",
+        "common": "https://lain.bgm.tv/r/400/pic/cover/l/90/1b/274332_ninFs.jpg",
+        "medium": "https://lain.bgm.tv/r/200/pic/cover/l/90/1b/274332_ninFs.jpg",
+        "small": "https://lain.bgm.tv/r/100/pic/cover/l/90/1b/274332_ninFs.jpg",
+        "grid": "https://lain.bgm.tv/r/100x100/pic/cover/l/90/1b/274332_ninFs.jpg"
+      }
+    },
+    {
+      "id": 274336,
+      "name": "巨人の星 劇場版",
+      "nameCN": "巨人之星 剧场版",
+      "type": 2,
+      "info": "1话 / 1969年7月26日 / 長浜忠夫",
+      "metaTags": ["剧场版"],
+      "rating": { "rank": 0, "count": [0, 0, 0, 0, 0, 5, 0, 1, 0, 0], "score": 6.33, "total": 6 },
+      "locked": false,
+      "nsfw": false,
+      "images": {
+        "large": "https://lain.bgm.tv/pic/cover/l/3f/bf/274336_5Ek3b.jpg",
+        "common": "https://lain.bgm.tv/r/400/pic/cover/l/3f/bf/274336_5Ek3b.jpg",
+        "medium": "https://lain.bgm.tv/r/200/pic/cover/l/3f/bf/274336_5Ek3b.jpg",
+        "small": "https://lain.bgm.tv/r/100/pic/cover/l/3f/bf/274336_5Ek3b.jpg",
+        "grid": "https://lain.bgm.tv/r/100x100/pic/cover/l/3f/bf/274336_5Ek3b.jpg"
+      }
+    },
+    {
+      "id": 274337,
+      "name": "巨人の星 大リーグボール",
+      "nameCN": "",
+      "type": 2,
+      "info": "1话 / 1970年3月21日 / 長浜忠夫",
+      "metaTags": ["剧场版"],
+      "rating": { "rank": 0, "count": [0, 0, 0, 0, 1, 2, 0, 0, 0, 1], "score": 6.75, "total": 4 },
+      "locked": false,
+      "nsfw": false,
+      "images": {
+        "large": "https://lain.bgm.tv/pic/cover/l/3e/e7/274337_Xd635.jpg",
+        "common": "https://lain.bgm.tv/r/400/pic/cover/l/3e/e7/274337_Xd635.jpg",
+        "medium": "https://lain.bgm.tv/r/200/pic/cover/l/3e/e7/274337_Xd635.jpg",
+        "small": "https://lain.bgm.tv/r/100/pic/cover/l/3e/e7/274337_Xd635.jpg",
+        "grid": "https://lain.bgm.tv/r/100x100/pic/cover/l/3e/e7/274337_Xd635.jpg"
+      }
+    },
+    {
+      "id": 274338,
+      "name": "巨人の星 宿命の対決",
+      "nameCN": "",
+      "type": 2,
+      "info": "1话 / 1970年8月1日 / 長浜忠夫",
+      "metaTags": ["剧场版"],
+      "rating": { "rank": 0, "count": [0, 0, 0, 0, 0, 2, 1, 0, 0, 1], "score": 7.25, "total": 4 },
+      "locked": false,
+      "nsfw": false,
+      "images": {
+        "large": "https://lain.bgm.tv/pic/cover/l/8d/69/274338_ewrbb.jpg",
+        "common": "https://lain.bgm.tv/r/400/pic/cover/l/8d/69/274338_ewrbb.jpg",
+        "medium": "https://lain.bgm.tv/r/200/pic/cover/l/8d/69/274338_ewrbb.jpg",
+        "small": "https://lain.bgm.tv/r/100/pic/cover/l/8d/69/274338_ewrbb.jpg",
+        "grid": "https://lain.bgm.tv/r/100x100/pic/cover/l/8d/69/274338_ewrbb.jpg"
+      }
+    },
+    {
+      "id": 312242,
+      "name": "巨人の星 (1982)",
+      "nameCN": "巨人之星 剧场版(1982)",
+      "type": 2,
+      "info": "1982年8月21日 / 出﨑哲、長浜忠夫 / 梶原一騎、川崎のぼる",
+      "metaTags": ["剧场版"],
+      "rating": { "rank": 0, "count": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], "score": 0, "total": 0 },
+      "locked": false,
+      "nsfw": false,
+      "images": {
+        "large": "https://lain.bgm.tv/pic/cover/l/d6/ca/312242_FN3Mz.jpg",
+        "common": "https://lain.bgm.tv/r/400/pic/cover/l/d6/ca/312242_FN3Mz.jpg",
+        "medium": "https://lain.bgm.tv/r/200/pic/cover/l/d6/ca/312242_FN3Mz.jpg",
+        "small": "https://lain.bgm.tv/r/100/pic/cover/l/d6/ca/312242_FN3Mz.jpg",
+        "grid": "https://lain.bgm.tv/r/100x100/pic/cover/l/d6/ca/312242_FN3Mz.jpg"
+      }
+    },
+    {
+      "id": 194396,
+      "name": "Gigantic",
+      "nameCN": "巨人国历险记",
+      "type": 2,
+      "info": "1话 / 2018-11-21",
+      "metaTags": ["剧场版"],
+      "rating": { "rank": 0, "count": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], "score": 0, "total": 0 },
+      "locked": false,
+      "nsfw": false,
+      "images": {
+        "large": "https://lain.bgm.tv/pic/cover/l/63/d7/194396_XBX7Q.jpg",
+        "common": "https://lain.bgm.tv/r/400/pic/cover/l/63/d7/194396_XBX7Q.jpg",
+        "medium": "https://lain.bgm.tv/r/200/pic/cover/l/63/d7/194396_XBX7Q.jpg",
+        "small": "https://lain.bgm.tv/r/100/pic/cover/l/63/d7/194396_XBX7Q.jpg",
+        "grid": "https://lain.bgm.tv/r/100x100/pic/cover/l/63/d7/194396_XBX7Q.jpg"
+      }
+    },
+    {
+      "id": 211435,
+      "name": "ルナたん~1万年のひみつ~",
+      "nameCN": "巨人鲁纳~1万年的秘密~",
+      "type": 2,
+      "info": "10话 / 2017-06-05 / 西健一",
+      "metaTags": ["WEB"],
+      "rating": { "rank": 0, "count": [0, 0, 0, 1, 0, 0, 0, 0, 0, 0], "score": 4, "total": 1 },
+      "locked": false,
+      "nsfw": false,
+      "images": {
+        "large": "https://lain.bgm.tv/pic/cover/l/15/ce/211435_0YBwU.jpg",
+        "common": "https://lain.bgm.tv/r/400/pic/cover/l/15/ce/211435_0YBwU.jpg",
+        "medium": "https://lain.bgm.tv/r/200/pic/cover/l/15/ce/211435_0YBwU.jpg",
+        "small": "https://lain.bgm.tv/r/100/pic/cover/l/15/ce/211435_0YBwU.jpg",
+        "grid": "https://lain.bgm.tv/r/100x100/pic/cover/l/15/ce/211435_0YBwU.jpg"
+      }
+    },
+    {
+      "id": 541410,
+      "name": "ジャイアントお嬢様",
+      "nameCN": "巨人大小姐",
+      "type": 2,
+      "info": "2027年1月 / 博史池畠 / 肉村Q / 満田一",
+      "metaTags": ["TV", "日本", "漫画改"],
+      "rating": { "rank": 0, "count": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], "score": 0, "total": 0 },
+      "locked": false,
+      "nsfw": false,
+      "images": {
+        "large": "https://lain.bgm.tv/pic/cover/l/64/f6/541410_4q4dg.jpg",
+        "common": "https://lain.bgm.tv/r/400/pic/cover/l/64/f6/541410_4q4dg.jpg",
+        "medium": "https://lain.bgm.tv/r/200/pic/cover/l/64/f6/541410_4q4dg.jpg",
+        "small": "https://lain.bgm.tv/r/100/pic/cover/l/64/f6/541410_4q4dg.jpg",
+        "grid": "https://lain.bgm.tv/r/100x100/pic/cover/l/64/f6/541410_4q4dg.jpg"
+      }
+    },
+    {
+      "id": 639271,
+      "name": "Suur Tõll",
+      "nameCN": "巨人托尔",
+      "type": 2,
+      "info": "1980年 / Rein Raamat",
+      "metaTags": ["短片", "苏联"],
+      "rating": { "rank": 0, "count": [0, 0, 0, 0, 0, 1, 0, 0, 0, 0], "score": 6, "total": 1 },
+      "locked": false,
+      "nsfw": false,
+      "images": {
+        "large": "https://lain.bgm.tv/pic/cover/l/1e/8c/639271_ntUJB.jpg",
+        "common": "https://lain.bgm.tv/r/400/pic/cover/l/1e/8c/639271_ntUJB.jpg",
+        "medium": "https://lain.bgm.tv/r/200/pic/cover/l/1e/8c/639271_ntUJB.jpg",
+        "small": "https://lain.bgm.tv/r/100/pic/cover/l/1e/8c/639271_ntUJB.jpg",
+        "grid": "https://lain.bgm.tv/r/100x100/pic/cover/l/1e/8c/639271_ntUJB.jpg"
+      }
+    },
+    {
+      "id": 53754,
+      "name": "新・巨人の星",
+      "nameCN": "新巨人之星",
+      "type": 2,
+      "info": "52话 / 1977年10月1日 / 梶原一騎、川崎のぼる（作画）",
+      "metaTags": ["TV", "日本", "运动", "漫画改"],
+      "rating": { "rank": 0, "count": [0, 0, 1, 2, 0, 3, 2, 0, 0, 0], "score": 5.38, "total": 8 },
+      "locked": false,
+      "nsfw": false,
+      "images": {
+        "large": "https://lain.bgm.tv/pic/cover/l/17/bf/53754_4c9ll.jpg",
+        "common": "https://lain.bgm.tv/r/400/pic/cover/l/17/bf/53754_4c9ll.jpg",
+        "medium": "https://lain.bgm.tv/r/200/pic/cover/l/17/bf/53754_4c9ll.jpg",
+        "small": "https://lain.bgm.tv/r/100/pic/cover/l/17/bf/53754_4c9ll.jpg",
+        "grid": "https://lain.bgm.tv/r/100x100/pic/cover/l/17/bf/53754_4c9ll.jpg"
+      }
+    },
+    {
+      "id": 121498,
+      "name": "小さな巨人 ミクロマン",
+      "nameCN": "微星小超人",
+      "type": 2,
+      "info": "52话 / 1999年1月4日 / 若林厚史",
+      "metaTags": ["机战", "TV", "日本", "原创"],
+      "rating": { "rank": 0, "count": [0, 0, 0, 1, 2, 8, 11, 2, 0, 2], "score": 6.73, "total": 26 },
+      "locked": false,
+      "nsfw": false,
+      "images": {
+        "large": "https://lain.bgm.tv/pic/cover/l/13/2d/121498_C1bUy.jpg",
+        "common": "https://lain.bgm.tv/r/400/pic/cover/l/13/2d/121498_C1bUy.jpg",
+        "medium": "https://lain.bgm.tv/r/200/pic/cover/l/13/2d/121498_C1bUy.jpg",
+        "small": "https://lain.bgm.tv/r/100/pic/cover/l/13/2d/121498_C1bUy.jpg",
+        "grid": "https://lain.bgm.tv/r/100x100/pic/cover/l/13/2d/121498_C1bUy.jpg"
+      }
+    },
+    {
+      "id": 213787,
+      "name": "新・巨人の星II",
+      "nameCN": "新巨人之星II",
+      "type": 2,
+      "info": "23话 / 1979年4月14日 / 梶原一騎、川崎のぼる（作画）",
+      "metaTags": ["TV", "日本", "漫画改"],
+      "rating": { "rank": 0, "count": [0, 0, 1, 1, 0, 3, 1, 0, 0, 0], "score": 5.33, "total": 6 },
+      "locked": false,
+      "nsfw": false,
+      "images": {
+        "large": "https://lain.bgm.tv/pic/cover/l/f8/27/213787_BKKL2.jpg",
+        "common": "https://lain.bgm.tv/r/400/pic/cover/l/f8/27/213787_BKKL2.jpg",
+        "medium": "https://lain.bgm.tv/r/200/pic/cover/l/f8/27/213787_BKKL2.jpg",
+        "small": "https://lain.bgm.tv/r/100/pic/cover/l/f8/27/213787_BKKL2.jpg",
+        "grid": "https://lain.bgm.tv/r/100x100/pic/cover/l/f8/27/213787_BKKL2.jpg"
+      }
+    },
+    {
+      "id": 222980,
+      "name": "小さな巨人 ミクロマン 大激戦! ミクロマンVS最強戦士ゴルゴン",
+      "nameCN": "微星小超人：大激战！微星小超人VS最强战士戈尔贡",
+      "type": 2,
+      "info": "1话 / 1999年7月31日 / 阿部記之 / 若林厚史",
+      "metaTags": ["剧场版"],
+      "rating": { "rank": 0, "count": [0, 0, 0, 0, 1, 0, 0, 0, 0, 0], "score": 5, "total": 1 },
+      "locked": false,
+      "nsfw": false,
+      "images": {
+        "large": "https://lain.bgm.tv/pic/cover/l/ab/ee/222980_ccNc3.jpg",
+        "common": "https://lain.bgm.tv/r/400/pic/cover/l/ab/ee/222980_ccNc3.jpg",
+        "medium": "https://lain.bgm.tv/r/200/pic/cover/l/ab/ee/222980_ccNc3.jpg",
+        "small": "https://lain.bgm.tv/r/100/pic/cover/l/ab/ee/222980_ccNc3.jpg",
+        "grid": "https://lain.bgm.tv/r/100x100/pic/cover/l/ab/ee/222980_ccNc3.jpg"
+      }
+    },
+    {
+      "id": 554519,
+      "name": "新・巨人の星",
+      "nameCN": "新巨人之星 剧场版",
+      "type": 2,
+      "info": "1977年12月1日",
+      "metaTags": ["剧场版"],
+      "rating": { "rank": 0, "count": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], "score": 0, "total": 0 },
+      "locked": false,
+      "nsfw": false,
+      "images": {
+        "large": "https://lain.bgm.tv/pic/cover/l/2b/7a/554519_T6fmF.jpg",
+        "common": "https://lain.bgm.tv/r/400/pic/cover/l/2b/7a/554519_T6fmF.jpg",
+        "medium": "https://lain.bgm.tv/r/200/pic/cover/l/2b/7a/554519_T6fmF.jpg",
+        "small": "https://lain.bgm.tv/r/100/pic/cover/l/2b/7a/554519_T6fmF.jpg",
+        "grid": "https://lain.bgm.tv/r/100x100/pic/cover/l/2b/7a/554519_T6fmF.jpg"
+      }
+    }
+  ],
+  "total": 62
+}

--- a/packages/website/src/mocks/handlers.ts
+++ b/packages/website/src/mocks/handlers.ts
@@ -3,6 +3,9 @@ import { mockAPI } from './utils';
 export const handlers = [
   mockAPI('/p1/me', 'get'),
   mockAPI('/p1/home', 'get'),
+  mockAPI('/p1/search/subjects', 'post'),
+  mockAPI('/p1/search/characters', 'post'),
+  mockAPI('/p1/search/persons', 'post'),
   mockAPI('/p1/users/:username', 'get'),
   mockAPI('/p1/users/:username/friends', 'get'),
   mockAPI('/p1/users/:username/groups', 'get'),

--- a/packages/website/src/pages/index/index/HomePage.spec.tsx
+++ b/packages/website/src/pages/index/index/HomePage.spec.tsx
@@ -9,28 +9,7 @@ import { renderPage } from '@bangumi/website/utils/test-utils';
 import homeFixture from '../../../mocks/fixtures/p1/home-GET.json';
 import HomePage from './components/HomePage';
 
-function createLocalStorage(): Storage {
-  const values = new Map<string, string>();
-  return {
-    get length() {
-      return values.size;
-    },
-    clear: () => values.clear(),
-    getItem: (key) => values.get(key) ?? null,
-    key: (index) => [...values.keys()][index] ?? null,
-    removeItem: (key) => values.delete(key),
-    setItem: (key, value) => values.set(key, String(value)),
-  };
-}
-
 describe('HomePage', () => {
-  beforeEach(() => {
-    Object.defineProperty(window, 'localStorage', {
-      configurable: true,
-      value: createLocalStorage(),
-    });
-  });
-
   const setupHome = () => {
     mockServer.use(
       http.get('http://localhost:3000/p1/home', () => {

--- a/packages/website/src/pages/index/subject_search/[keyword]/SubjectSearchPage.spec.tsx
+++ b/packages/website/src/pages/index/subject_search/[keyword]/SubjectSearchPage.spec.tsx
@@ -1,0 +1,61 @@
+import { act, fireEvent, screen } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import React, { Suspense } from 'react';
+import { useParams, useSearchParams } from 'react-router-dom';
+
+import {
+  characterSearchFixture,
+  personSearchFixture,
+  subjectSearchFixture,
+} from '@bangumi/website/mocks/fixtures/p1/search';
+import { server as mockServer } from '@bangumi/website/mocks/server';
+import { renderPage } from '@bangumi/website/utils/test-utils';
+
+import SubjectSearchPage from '.';
+
+vi.mock('react-router-dom', async () => ({
+  ...(await vi.importActual<typeof import('react-router-dom')>('react-router-dom')),
+  useParams: vi.fn(),
+  useSearchParams: vi.fn(),
+}));
+
+const mockedUseParams = vi.mocked(useParams);
+const mockedUseSearchParams = vi.mocked(useSearchParams);
+
+beforeEach(() => {
+  mockedUseParams.mockReturnValue({ keyword: '巨人' });
+  mockedUseSearchParams.mockReturnValue([new URLSearchParams('cat=2'), vi.fn()]);
+
+  mockServer.use(
+    http.post('http://localhost:3000/p1/search/subjects', () =>
+      HttpResponse.json(subjectSearchFixture),
+    ),
+    http.post('http://localhost:3000/p1/search/characters', () =>
+      HttpResponse.json(characterSearchFixture),
+    ),
+    http.post('http://localhost:3000/p1/search/persons', () =>
+      HttpResponse.json(personSearchFixture),
+    ),
+  );
+});
+
+it('renders typed search fixtures and persists the selected view', async () => {
+  await act(async () => {
+    renderPage(
+      <Suspense fallback={null}>
+        <SubjectSearchPage />
+      </Suspense>,
+    );
+  });
+
+  expect(await screen.findByRole('link', { name: '巨人之星' })).toHaveAttribute(
+    'href',
+    '/subject/41983',
+  );
+  expect(screen.getByText('找到 62 个条目')).toBeInTheDocument();
+  expect(screen.getByRole('link', { name: '动画' }).className).toContain('categorySelected');
+  expect(screen.getByRole('heading', { name: '相关人物' })).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole('button', { name: '网格视图' }));
+  expect(window.localStorage.getItem('bangumi-subject-search-view')).toBe('grid');
+});

--- a/packages/website/src/pages/index/subject_search/[keyword]/index.tsx
+++ b/packages/website/src/pages/index/subject_search/[keyword]/index.tsx
@@ -1,0 +1,373 @@
+import { ok } from '@oazapfts/runtime';
+import classNames from 'classnames';
+import React, { useEffect, useState } from 'react';
+import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import useSWR from 'swr';
+
+import { ozaClient } from '@bangumi/client';
+import type { SlimCharacter, SlimPerson, SlimSubject, SubjectType } from '@bangumi/client/client';
+import { SubjectType as SubjectTypeEnum } from '@bangumi/client/client';
+import { Pagination } from '@bangumi/design';
+import { EmptyStar, FilledStar, GridView, ListView, Search } from '@bangumi/icons';
+import {
+  getCharacterLink,
+  getLegacyPageLink,
+  getPersonLink,
+  getSubjectLink,
+} from '@bangumi/utils/pages';
+import { withErrorBoundary } from '@bangumi/website/components/ErrorBoundary';
+import Helmet from '@bangumi/website/components/Helmet';
+import { usePaginationParams } from '@bangumi/website/hooks/use-pagination';
+
+import styles from './style.module.less';
+
+const PAGE_SIZE = 15;
+const VIEW_STORAGE_KEY = 'bangumi-subject-search-view';
+
+type ViewMode = 'compact' | 'full' | 'grid';
+type SubjectCategory = 'all' | `${SubjectType}`;
+type RelatedMono =
+  | { kind: 'character'; item: SlimCharacter }
+  | { kind: 'person'; item: SlimPerson };
+
+const SUBJECT_CATEGORIES: { value: SubjectCategory; label: string }[] = [
+  { value: 'all', label: '全部' },
+  { value: `${SubjectTypeEnum.Anime}`, label: '动画' },
+  { value: `${SubjectTypeEnum.Book}`, label: '书籍' },
+  { value: `${SubjectTypeEnum.Music}`, label: '音乐' },
+  { value: `${SubjectTypeEnum.Game}`, label: '游戏' },
+  { value: `${SubjectTypeEnum.Real}`, label: '三次元' },
+];
+
+function parseCategory(value: string | null): SubjectCategory {
+  return SUBJECT_CATEGORIES.some((category) => category.value === value)
+    ? (value as SubjectCategory)
+    : 'all';
+}
+
+function getInitialView(): ViewMode {
+  if (typeof window === 'undefined') {
+    return 'full';
+  }
+
+  try {
+    const stored = window.localStorage.getItem(VIEW_STORAGE_KEY);
+    return stored === 'compact' || stored === 'grid' ? stored : 'full';
+  } catch {
+    return 'full';
+  }
+}
+
+function useSubjectSearch(keyword: string, category: SubjectCategory, offset: number) {
+  const subjectType = category === 'all' ? undefined : Number(category as `${SubjectType}`);
+  const { data } = useSWR(
+    ['subject-search', keyword, category, offset],
+    async () =>
+      ok(
+        ozaClient.searchSubjects(
+          {
+            keyword,
+            sort: ozaClient.SubjectSearchSort.Match,
+            filter: subjectType ? { type: [subjectType] } : undefined,
+          },
+          { limit: PAGE_SIZE, offset },
+        ),
+      ),
+    { keepPreviousData: true, suspense: true },
+  );
+
+  return { subjects: data?.data ?? [], total: data?.total ?? 0 };
+}
+
+function useRelatedMonos(keyword: string): RelatedMono[] {
+  const { data } = useSWR(
+    ['subject-search-related', keyword],
+    async () => {
+      const [characters, persons] = await Promise.allSettled([
+        ok(ozaClient.searchCharacters({ keyword }, { limit: 8, offset: 0 })),
+        ok(ozaClient.searchPersons({ keyword }, { limit: 4, offset: 0 })),
+      ]);
+
+      return [
+        ...(characters.status === 'fulfilled' && Array.isArray(characters.value.data)
+          ? characters.value.data.map((item): RelatedMono => ({ kind: 'character', item }))
+          : []),
+        ...(persons.status === 'fulfilled' && Array.isArray(persons.value.data)
+          ? persons.value.data.map((item): RelatedMono => ({ kind: 'person', item }))
+          : []),
+      ];
+    },
+    { suspense: true },
+  );
+
+  return data ?? [];
+}
+
+function SubjectRating({ subject }: { subject: SlimSubject }) {
+  if (subject.rating.total < 10) {
+    return <span className={styles.lowRating}>(少于10人评分)</span>;
+  }
+
+  const score = Math.round(subject.rating.score);
+  return (
+    <span className={styles.rating}>
+      <span className={styles.stars} aria-label={`评分 ${subject.rating.score.toFixed(1)}`}>
+        {Array.from({ length: 10 }, (_, index) =>
+          index < score ? <FilledStar key={index} /> : <EmptyStar key={index} />,
+        )}
+      </span>
+      <span className={styles.score}>{subject.rating.score.toFixed(1)}</span>
+      <span className={styles.ratingTotal}>({subject.rating.total}人评分)</span>
+    </span>
+  );
+}
+
+function SubjectItem({ subject, view }: { subject: SlimSubject; view: ViewMode }) {
+  const displayName = subject.nameCN || subject.name;
+  const showDetails = view === 'full';
+
+  return (
+    <li className={styles.resultItem}>
+      <Link className={styles.coverLink} to={getSubjectLink(subject.id)}>
+        {subject.images?.common ? (
+          <img className={styles.cover} src={subject.images.common} alt='' loading='lazy' />
+        ) : (
+          <span className={styles.coverPlaceholder} aria-hidden='true' />
+        )}
+      </Link>
+      <div className={styles.resultInfo}>
+        <h2 className={styles.resultTitle}>
+          <span className={styles.subjectTypeIcon} aria-hidden='true' />
+          <Link to={getSubjectLink(subject.id)}>{displayName}</Link>
+          {subject.nameCN && subject.nameCN !== subject.name && (
+            <small className={styles.originalName}>{subject.name}</small>
+          )}
+          {showDetails && subject.metaTags.length > 0 && (
+            <small className={styles.metaTags}>{subject.metaTags.join(' / ')}</small>
+          )}
+        </h2>
+        {showDetails && <p className={styles.subjectInfo}>{subject.info}</p>}
+        {view !== 'grid' && <SubjectRating subject={subject} />}
+      </div>
+      {subject.rating.rank > 0 && <span className={styles.rank}>Rank {subject.rating.rank}</span>}
+    </li>
+  );
+}
+
+function ViewSelector({ view, onChange }: { view: ViewMode; onChange: (view: ViewMode) => void }) {
+  const options: { value: ViewMode; label: string; icon: React.ReactNode }[] = [
+    {
+      value: 'compact',
+      label: '精简视图',
+      icon: <ListView className={styles.compactIcon} />,
+    },
+    { value: 'full', label: '列表视图', icon: <ListView /> },
+    { value: 'grid', label: '网格视图', icon: <GridView /> },
+  ];
+
+  return (
+    <div className={styles.viewSelector} aria-label='结果显示方式'>
+      {options.map((option) => (
+        <button
+          key={option.value}
+          type='button'
+          className={classNames(
+            styles.viewButton,
+            view === option.value && styles.viewButtonActive,
+          )}
+          title={option.label}
+          aria-label={option.label}
+          aria-pressed={view === option.value}
+          onClick={() => onChange(option.value)}
+        >
+          {option.icon}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function RelatedPanel({ monos }: { monos: RelatedMono[] }) {
+  if (monos.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className={styles.sidePanel}>
+      <h2>相关人物</h2>
+      <ul className={styles.monoGrid}>
+        {monos.map(({ kind, item }) => {
+          const displayName = item.nameCN || item.name;
+          return (
+            <li key={`${kind}-${item.id}`}>
+              <Link to={kind === 'character' ? getCharacterLink(item.id) : getPersonLink(item.id)}>
+                {item.images?.grid ? (
+                  <img src={item.images.grid} alt='' loading='lazy' />
+                ) : (
+                  <span className={styles.avatarPlaceholder}>{displayName.slice(0, 1)}</span>
+                )}
+                <span title={displayName}>{displayName}</span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}
+
+function SubjectSearchPage() {
+  const { keyword: routeKeyword = '' } = useParams<{ keyword: string }>();
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const category = parseCategory(searchParams.get('cat'));
+  const { curPage, offset } = usePaginationParams(PAGE_SIZE);
+  const [searchValue, setSearchValue] = useState(routeKeyword);
+  const [view, setView] = useState<ViewMode>(getInitialView);
+  const { subjects, total } = useSubjectSearch(routeKeyword, category, offset);
+  const relatedMonos = useRelatedMonos(routeKeyword);
+
+  useEffect(() => {
+    setSearchValue(routeKeyword);
+  }, [routeKeyword]);
+
+  const handleSearch = (event: React.FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    const nextKeyword = searchValue.trim();
+    if (nextKeyword) {
+      navigate(`/subject_search/${encodeURIComponent(nextKeyword)}?cat=${category}`);
+    }
+  };
+
+  const handleViewChange = (nextView: ViewMode): void => {
+    setView(nextView);
+    try {
+      window.localStorage.setItem(VIEW_STORAGE_KEY, nextView);
+    } catch {
+      // The selected view still applies for the current session when storage is unavailable.
+    }
+  };
+
+  const handlePageChange = (page: number): void => {
+    navigate(`?cat=${category}&page=${page}`);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  const exactKeyword = `"${routeKeyword}"`;
+
+  return (
+    <>
+      <Helmet title={`搜索: ${routeKeyword}`} />
+      <div className={styles.searchBand}>
+        <form className={styles.searchForm} onSubmit={handleSearch}>
+          <label htmlFor='subject-search-input'>条目搜索</label>
+          <input
+            id='subject-search-input'
+            name='search_text'
+            type='search'
+            value={searchValue}
+            onChange={(event) => setSearchValue(event.target.value)}
+          />
+          <button type='submit'>
+            <Search />
+            <span>搜索</span>
+          </button>
+        </form>
+      </div>
+
+      <main className={styles.page}>
+        <nav className={styles.categories} aria-label='搜索分类'>
+          <ul>
+            <li className={styles.categoryRoot}>条目</li>
+            {SUBJECT_CATEGORIES.map((item) => (
+              <li key={item.value}>
+                <Link
+                  className={category === item.value ? styles.categorySelected : undefined}
+                  to={`/subject_search/${encodeURIComponent(routeKeyword)}?cat=${item.value}`}
+                >
+                  {item.label}
+                </Link>
+              </li>
+            ))}
+            <li className={styles.categoryRoot}>人物</li>
+            <li>
+              <a
+                href={getLegacyPageLink(`/mono_search/${encodeURIComponent(routeKeyword)}?cat=all`)}
+              >
+                全部
+              </a>
+            </li>
+            <li>
+              <a
+                href={getLegacyPageLink(`/mono_search/${encodeURIComponent(routeKeyword)}?cat=crt`)}
+              >
+                虚构角色
+              </a>
+            </li>
+            <li>
+              <a
+                href={getLegacyPageLink(
+                  `/mono_search/${encodeURIComponent(routeKeyword)}?cat=prsn`,
+                )}
+              >
+                现实人物
+              </a>
+            </li>
+          </ul>
+        </nav>
+
+        <section className={styles.results} aria-label='搜索结果'>
+          <div className={styles.resultTools}>
+            <span>找到 {total} 个条目</span>
+            <ViewSelector view={view} onChange={handleViewChange} />
+          </div>
+          {subjects.length > 0 ? (
+            <ul
+              className={classNames(styles.resultsList, {
+                [styles.resultsListCompact!]: view === 'compact',
+                [styles.resultsListFull!]: view === 'full',
+                [styles.resultsListGrid!]: view === 'grid',
+              })}
+            >
+              {subjects.map((subject) => (
+                <SubjectItem key={subject.id} subject={subject} view={view} />
+              ))}
+            </ul>
+          ) : (
+            <p className={styles.empty}>没有找到相关条目</p>
+          )}
+          <Pagination
+            key={curPage}
+            wrapperClass={styles.pagination}
+            total={total}
+            pageSize={PAGE_SIZE}
+            currentPage={curPage}
+            onChange={handlePageChange}
+          />
+        </section>
+
+        <aside className={styles.sidebar}>
+          <RelatedPanel monos={relatedMonos} />
+          <div className={styles.exactSearch}>
+            <Link to={`/subject_search/${encodeURIComponent(exactKeyword)}?cat=${category}`}>
+              显示精准匹配结果
+            </Link>
+          </div>
+          <section className={styles.sidePanel}>
+            <h2>搜索提示</h2>
+            <ul className={styles.searchTips}>
+              <li>
+                搜索时使用引号 “关键词”，如 <i>“ちょびっツ”</i> 获取精确结果
+              </li>
+              <li>
+                使用减号 -，如 <i>马里奥 -gba</i> 排除关键词
+              </li>
+            </ul>
+          </section>
+        </aside>
+      </main>
+    </>
+  );
+}
+
+export default withErrorBoundary(SubjectSearchPage);

--- a/packages/website/src/pages/index/subject_search/[keyword]/style.module.less
+++ b/packages/website/src/pages/index/subject_search/[keyword]/style.module.less
@@ -1,0 +1,705 @@
+@import '@bangumi/design/theme/base';
+
+@search-width: 980px;
+@result-width: 655px;
+
+.searchBand {
+  border-bottom: 1px solid @gray-10;
+  background: #fafafa;
+}
+
+.searchForm {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: @search-width;
+  margin: 0 auto;
+  padding: 10px 0;
+  box-sizing: border-box;
+
+  label {
+    width: 100px;
+    margin-right: 9px;
+    color: @gray-80;
+    font-size: 16px;
+    font-weight: 600;
+    line-height: 35px;
+    text-align: right;
+  }
+
+  input {
+    width: 375px;
+    height: 34px;
+    padding: 6px 10px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    background: #fff;
+    color: @gray-100;
+    font-size: 14px;
+    outline: none;
+    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.08);
+
+    &:focus {
+      border-color: @primary-color;
+      box-shadow: 0 0 0 2px rgba(@primary-color, 0.18);
+    }
+  }
+
+  button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 5px;
+    height: 34px;
+    padding: 0 16px;
+    border: 0;
+    border-radius: 4px;
+    background: @blue-100;
+    color: #fff;
+    cursor: pointer;
+
+    &:hover {
+      background: #3aa4d2;
+    }
+
+    svg {
+      width: 14px;
+      height: 14px;
+      fill: currentcolor;
+    }
+  }
+}
+
+.page {
+  display: grid;
+  grid-template-columns: 100px minmax(0, @result-width) 200px;
+  gap: 10px;
+  width: @search-width;
+  margin: 0 auto;
+  padding: 20px 0 40px;
+  box-sizing: border-box;
+}
+
+.categories {
+  align-self: start;
+
+  ul {
+    overflow: hidden;
+    margin: 0;
+    padding: 0 2px 5px;
+    border: 1px solid @gray-10;
+    border-radius: 8px;
+    background: #fff;
+    box-shadow: 0 1px 5px rgba(50, 46, 46, 0.08);
+    list-style: none;
+  }
+
+  li a {
+    display: block;
+    margin: 5px 0;
+    padding: 3px 12px;
+    border-radius: 999px;
+    color: @blue-100;
+    font-size: 13px;
+    line-height: 18px;
+    text-decoration: none;
+
+    &:hover {
+      background: @pink-10;
+      color: @primary-color;
+    }
+  }
+
+  li a.categorySelected {
+    background: @primary-color;
+    color: #fff;
+  }
+}
+
+.categoryRoot {
+  margin: 0 -2px;
+  padding: 6px 14px 5px;
+  border-bottom: 1px solid @gray-10;
+  color: @gray-60;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.results {
+  min-width: 0;
+}
+
+.resultTools {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 24px;
+  padding: 0 4px 5px;
+  color: @gray-60;
+  font-size: 12px;
+}
+
+.viewSelector {
+  display: inline-flex;
+  overflow: hidden;
+  border: 1px solid @gray-10;
+  border-radius: 4px;
+}
+
+.viewButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 22px;
+  padding: 0;
+  border: 0;
+  border-right: 1px solid @gray-10;
+  background: #fff;
+  color: @gray-60;
+  cursor: pointer;
+
+  &:last-child {
+    border-right: 0;
+  }
+
+  &:hover {
+    color: @blue-100;
+  }
+
+  svg {
+    width: 14px;
+    height: 14px;
+    fill: currentcolor;
+  }
+}
+
+.viewButtonActive {
+  background: @blue-100;
+  color: #fff;
+}
+
+.compactIcon {
+  transform: scaleY(0.72);
+}
+
+.resultsList {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.resultItem {
+  position: relative;
+  min-width: 0;
+  border-bottom: 1px solid @gray-10;
+}
+
+.coverLink {
+  display: block;
+  flex-shrink: 0;
+}
+
+.cover,
+.coverPlaceholder {
+  display: block;
+  width: 80px;
+  aspect-ratio: 5 / 7;
+  border-radius: 3px;
+  object-fit: cover;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.22);
+}
+
+.coverPlaceholder {
+  background: @gray-10;
+}
+
+.resultInfo {
+  min-width: 0;
+}
+
+.resultTitle {
+  display: flex;
+  align-items: baseline;
+  min-width: 0;
+  margin: 0;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 20px;
+
+  > a {
+    overflow-wrap: anywhere;
+    color: @blue-100;
+    font-weight: 600;
+    text-decoration: none;
+
+    &:hover {
+      color: @primary-color;
+    }
+  }
+}
+
+.subjectTypeIcon {
+  flex: 0 0 auto;
+  width: 8px;
+  height: 10px;
+  margin-right: 5px;
+  border: 1px solid #c6d0d4;
+  border-radius: 1px;
+  box-sizing: border-box;
+}
+
+.originalName,
+.metaTags {
+  flex: 0 1 auto;
+  overflow: hidden;
+  margin-left: 5px;
+  color: @gray-60;
+  font-size: 10px;
+  font-weight: 400;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.metaTags {
+  color: #bbb;
+}
+
+.subjectInfo {
+  display: -webkit-box;
+  overflow: hidden;
+  margin: 8px 0 0;
+  color: @gray-60;
+  font-size: 12px;
+  line-height: 18px;
+  overflow-wrap: anywhere;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}
+
+.rating,
+.lowRating {
+  display: flex;
+  align-items: center;
+  margin-top: 9px;
+  color: @gray-60;
+  font-size: 11px;
+  line-height: 14px;
+}
+
+.stars {
+  display: inline-flex;
+  gap: 1px;
+  margin-right: 6px;
+
+  svg {
+    width: 10px;
+    height: 10px;
+    fill: #f6a623;
+  }
+}
+
+.score {
+  margin-right: 4px;
+  color: #f09b2d;
+}
+
+.ratingTotal {
+  color: @gray-60;
+}
+
+.rank {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  padding: 2px 5px;
+  border-radius: 4px;
+  background: #08a9ef;
+  color: #fff;
+  font-size: 10px;
+  line-height: 14px;
+}
+
+.resultsListFull {
+  .resultItem {
+    display: flex;
+    gap: 18px;
+    min-height: 126px;
+    padding: 8px 5px;
+    box-sizing: border-box;
+
+    &:nth-child(even) {
+      background: #fafafa;
+    }
+  }
+
+  .resultInfo {
+    flex: 1;
+    padding-top: 1px;
+  }
+}
+
+.resultsListCompact {
+  .resultItem {
+    display: flex;
+    gap: 14px;
+    min-height: 82px;
+    padding: 7px 5px;
+    box-sizing: border-box;
+
+    &:nth-child(even) {
+      background: #fafafa;
+    }
+  }
+
+  .cover,
+  .coverPlaceholder {
+    width: 48px;
+  }
+
+  .resultInfo {
+    flex: 1;
+    padding-top: 1px;
+  }
+
+  .rating,
+  .lowRating {
+    margin-top: 7px;
+  }
+}
+
+.resultsListGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(105px, 1fr));
+  gap: 16px 10px;
+  padding: 8px 0;
+
+  .resultItem {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    border: 0;
+    text-align: center;
+  }
+
+  .cover,
+  .coverPlaceholder {
+    width: 105px;
+  }
+
+  .resultInfo {
+    width: 105px;
+    margin-top: 7px;
+  }
+
+  .resultTitle {
+    display: block;
+    font-size: 12px;
+    line-height: 17px;
+  }
+
+  .subjectTypeIcon,
+  .originalName {
+    display: none;
+  }
+
+  .rank {
+    top: 4px;
+    right: 50%;
+    transform: translateX(52px);
+  }
+}
+
+.empty {
+  min-height: 240px;
+  margin: 0;
+  padding: 50px 20px;
+  border-top: 1px solid @gray-10;
+  color: @gray-60;
+  box-sizing: border-box;
+  text-align: center;
+}
+
+.pagination {
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 20px 0 0;
+
+  :global(.bgm-pagination-prev),
+  :global(.bgm-pagination-next),
+  :global(.bgm-pagination-pager) {
+    width: 26px;
+    height: 26px;
+    margin: 0;
+    border-width: 1px;
+    border-radius: 50%;
+    font-size: 11px;
+  }
+
+  :global(.bgm-pagination-pager + .bgm-pagination-pager) {
+    margin-left: 0;
+  }
+
+  :global(.bgm-pagination-prev),
+  :global(.bgm-pagination-next) {
+    width: 34px;
+    border-radius: 13px;
+  }
+
+  :global(.bgm-pagination-icon) {
+    width: 14px;
+    height: 14px;
+  }
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.sidePanel,
+.exactSearch {
+  padding: 10px;
+  border: 1px solid @gray-10;
+  border-radius: 8px;
+  background: #fff;
+  box-shadow: 0 1px 5px rgba(50, 46, 46, 0.06);
+}
+
+.sidePanel h2 {
+  margin: 0 0 8px;
+  padding-bottom: 7px;
+  border-bottom: 1px solid @gray-10;
+  color: @gray-60;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.monoGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px 4px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+
+  a {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    color: @blue-100;
+    font-size: 11px;
+    line-height: 16px;
+    text-align: center;
+    text-decoration: none;
+
+    &:hover {
+      color: @primary-color;
+    }
+
+    > span:last-child {
+      overflow: hidden;
+      width: 100%;
+      margin-top: 4px;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+
+  img,
+  .avatarPlaceholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    object-fit: cover;
+  }
+}
+
+.avatarPlaceholder {
+  background: @gray-10;
+  color: @gray-60;
+  font-size: 18px;
+}
+
+.exactSearch {
+  font-size: 12px;
+
+  a {
+    color: @blue-100;
+    text-decoration: none;
+
+    &:hover {
+      color: @primary-color;
+    }
+  }
+}
+
+.searchTips {
+  margin: 0;
+  padding: 0;
+  color: @gray-80;
+  font-size: 12px;
+  line-height: 18px;
+  list-style: none;
+
+  li + li {
+    margin-top: 8px;
+  }
+}
+
+@media (max-width: @lg) {
+  .searchForm,
+  .page {
+    width: calc(100% - 40px);
+  }
+
+  .page {
+    grid-template-columns: 100px minmax(0, 1fr) 200px;
+  }
+}
+
+@media (max-width: @md) {
+  .searchForm {
+    width: 100%;
+    padding-right: 16px;
+    padding-left: 16px;
+
+    label {
+      width: auto;
+      margin-right: 4px;
+      font-size: 13px;
+      white-space: nowrap;
+    }
+
+    input {
+      min-width: 0;
+      width: auto;
+      flex: 1;
+    }
+  }
+
+  .page {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    width: 100%;
+    padding: 10px 8px 24px;
+  }
+
+  .categories {
+    ul {
+      padding: 4px 6px;
+      border-radius: 6px;
+    }
+
+    li {
+      display: inline-block;
+    }
+
+    li a {
+      margin: 0;
+      padding: 3px 6px;
+      font-size: 12px;
+    }
+  }
+
+  .categoryRoot {
+    margin: 0;
+    padding: 3px 5px;
+    border: 0;
+  }
+
+  .results {
+    width: 100%;
+  }
+
+  .resultTools {
+    padding-right: 2px;
+    padding-left: 2px;
+  }
+
+  .resultsListFull {
+    .resultItem {
+      gap: 12px;
+      min-height: 116px;
+      padding: 7px 3px;
+    }
+
+    .cover,
+    .coverPlaceholder {
+      width: 72px;
+    }
+  }
+
+  .resultTitle {
+    padding-right: 0;
+    font-size: 13px;
+    line-height: 18px;
+  }
+
+  .metaTags {
+    display: none;
+  }
+
+  .subjectInfo {
+    margin-top: 5px;
+    font-size: 11px;
+    line-height: 16px;
+    -webkit-line-clamp: 3;
+  }
+
+  .rating,
+  .lowRating {
+    margin-top: 5px;
+  }
+
+  .rank {
+    top: 6px;
+    right: 3px;
+  }
+
+  .pagination {
+    margin-top: 14px;
+  }
+
+  .sidebar {
+    gap: 10px;
+  }
+
+  .monoGrid {
+    grid-template-columns: repeat(auto-fill, minmax(54px, 1fr));
+  }
+}
+
+@media (max-width: @sm) {
+  .searchForm button {
+    width: 38px;
+    padding: 0;
+
+    span {
+      display: none;
+    }
+  }
+
+  .resultTools > span {
+    display: none;
+  }
+
+  .resultTools {
+    justify-content: flex-end;
+  }
+
+  .resultsListGrid {
+    grid-template-columns: repeat(auto-fill, minmax(96px, 1fr));
+
+    .cover,
+    .coverPlaceholder,
+    .resultInfo {
+      width: 96px;
+    }
+  }
+}

--- a/packages/website/src/routes.tsx
+++ b/packages/website/src/routes.tsx
@@ -19,6 +19,7 @@ const GroupTopicEdit = lazy(async () => import('./pages/index/group/topic/[id]/e
 const GroupTopicHome = lazy(async () => import('./pages/index/group/topic/[id]/index'));
 const Subject = lazy(async () => import('./pages/index/subject/[id]/index'));
 const SubjectEpisodes = lazy(async () => import('./pages/index/subject/[id]/ep'));
+const SubjectSearch = lazy(async () => import('./pages/index/subject_search/[keyword]'));
 const Wiki = lazy(async () => import('./pages/index/subject/[id]/wiki'));
 const WikiEdit = lazy(async () => import('./pages/index/subject/[id]/wiki/edit'));
 const WikiEditDetail = lazy(async () => import('./pages/index/subject/[id]/wiki/edit_detail'));
@@ -159,6 +160,10 @@ export const pageRoutes: RouteObject[] = [
             ],
           },
         ],
+      },
+      {
+        path: 'subject_search/:keyword',
+        element: <SubjectSearch />,
       },
       {
         path: 'user',

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -7,3 +7,38 @@ expect.extend(matchers);
 afterEach(() => {
   cleanup();
 });
+
+// jsdom does not provide localStorage (Node >= 22 ships its own that conflicts
+// with jsdom), so install an in-memory implementation for the whole test run.
+class LocalStorageMock implements Storage {
+  private values = new Map<string, string>();
+
+  get length(): number {
+    return this.values.size;
+  }
+
+  clear(): void {
+    this.values.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return [...this.values.keys()][index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, String(value));
+  }
+}
+
+Object.defineProperty(window, 'localStorage', {
+  configurable: true,
+  value: new LocalStorageMock(),
+});


### PR DESCRIPTION
## Summary

Add a subject search page at `/subject_search/:keyword`, accessible from the new route registered in `routes.tsx`.

## Features

- Keyword search with category filtering (全部/动画/书籍/音乐/游戏/三次元)
- Three result view modes: compact, full list, and grid; the selected view persists to `localStorage`
- Related characters and persons shown in a sidebar
- Pagination via the shared `Pagination` component
- Responsive layout for md/sm viewports

## Implementation notes

- New API mocks: `/p1/search/subjects|characters|persons` POST fixtures
- Unit test with MSW typed fixtures; local view-mode persistence covered
- An in-memory `localStorage` mock is now installed in the global vitest setup (`tests/setup.ts`), replacing the duplicated per-spec helpers in `HomePage.spec.tsx` and `SubjectSearchPage.spec.tsx`

## Verification

- `pnpm vitest run` — 276 tests pass
- `pnpm type-check`, `pnpm lint`, `pnpm lint:style`, `pnpm prettier:check` — pass
- `pnpm build --mode stage` — builds successfully