### PR TITLE
feat(website): render episode actions based on collection status

### DIFF
--- a/packages/website/src/mocks/fixtures/p1/home-GET.ts
+++ b/packages/website/src/mocks/fixtures/p1/home-GET.ts
@@ -1,0 +1,5 @@
+import type { HomeResponse } from '@bangumi/client/client';
+
+import data from './home-GET.json';
+
+export const homeResponseFixture: HomeResponse = data;

--- a/packages/website/src/pages/index/index/HomePage.spec.tsx
+++ b/packages/website/src/pages/index/index/HomePage.spec.tsx
@@ -6,7 +6,7 @@ import { SWRConfig } from 'swr';
 import { server as mockServer } from '@bangumi/website/mocks/server';
 import { renderPage } from '@bangumi/website/utils/test-utils';
 
-import homeFixture from '../../../mocks/fixtures/p1/home-GET.json';
+import { homeResponseFixture as homeFixture } from '../../../mocks/fixtures/p1/home-GET';
 import HomePage from './components/HomePage';
 
 describe('HomePage', () => {
@@ -337,6 +337,60 @@ describe('HomePage', () => {
 
     await waitFor(() => {
       expect(patchedBody).toEqual({ type: 2 });
+    });
+  });
+
+  it('should render episode actions based on collection status', async () => {
+    const progress = homeFixture.progress[0]!;
+    const [done, wish, dropped, none] = progress.eps;
+    let patchedBody: unknown = null;
+    mockServer.use(
+      http.get('http://localhost:3000/p1/home', () =>
+        HttpResponse.json({
+          ...homeFixture,
+          progress: [
+            {
+              ...progress,
+              eps: [
+                { ...done, collection: { status: 2, updatedAt: 1775000000 } },
+                { ...wish, collection: { status: 1, updatedAt: 1775000000 } },
+                { ...dropped, collection: { status: 3, updatedAt: 1775000000 } },
+                { ...none, collection: undefined },
+              ],
+            },
+          ],
+        }),
+      ),
+      http.patch(
+        `http://localhost:3000/p1/collections/episodes/${none!.id}`,
+        async ({ request }) => {
+          patchedBody = await request.json();
+          return HttpResponse.json({}, { status: 200 });
+        },
+      ),
+    );
+    await renderHome();
+
+    const doneDetail = document.querySelector(`[data-ep-id='${done!.id}']`)!;
+    expect(within(doneDetail as HTMLElement).queryByRole('button', { name: '看过' })).toBeNull();
+    expect(within(doneDetail as HTMLElement).getByText('看过')).toBeInTheDocument();
+    expect(
+      within(doneDetail as HTMLElement).getByRole('button', { name: '撤消' }),
+    ).toBeInTheDocument();
+
+    const wishDetail = document.querySelector(`[data-ep-id='${wish!.id}']`)!;
+    expect(within(wishDetail as HTMLElement).queryByRole('button', { name: '想看' })).toBeNull();
+    expect(within(wishDetail as HTMLElement).getByText('想看')).toBeInTheDocument();
+
+    const droppedDetail = document.querySelector(`[data-ep-id='${dropped!.id}']`)!;
+    expect(within(droppedDetail as HTMLElement).queryByRole('button', { name: '抛弃' })).toBeNull();
+    expect(within(droppedDetail as HTMLElement).getByText('抛弃')).toBeInTheDocument();
+
+    const noneDetail = document.querySelector(`[data-ep-id='${none!.id}']`)!;
+    expect(within(noneDetail as HTMLElement).queryByRole('button', { name: '撤消' })).toBeNull();
+    fireEvent.click(within(noneDetail as HTMLElement).getByRole('button', { name: '看到' }));
+    await waitFor(() => {
+      expect(patchedBody).toEqual({ batch: true });
     });
   });
 });

--- a/packages/website/src/pages/index/index/components/PrgManager.module.less
+++ b/packages/website/src/pages/index/index/components/PrgManager.module.less
@@ -5,7 +5,7 @@
   border: 1px solid @gray-10;
   border-radius: 14px;
   margin: 0 0 20px;
-  overflow: hidden;
+  overflow: visible;
   box-shadow: 0 0 3px rgba(0, 0, 0, 0.1);
 }
 
@@ -181,7 +181,7 @@
   min-width: 0;
   margin: 0;
   padding: 0;
-  overflow: hidden;
+  overflow: visible;
   list-style: none;
 
   .card {
@@ -674,6 +674,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
+  min-height: 31px;
   padding: 8px 10px;
   border-bottom: 1px solid @gray-10;
 }
@@ -696,24 +697,14 @@
   }
 }
 
-.epWatchedBtn {
+.epCurrentStatus {
   margin-left: auto;
-  border: none;
   background: @primary-color;
   color: #fff;
   border-radius: 3px;
   padding: 3px 12px;
   font-size: 12px;
-  cursor: pointer;
-
-  &:hover {
-    filter: brightness(0.95);
-  }
-
-  &:disabled {
-    opacity: 0.6;
-    cursor: default;
-  }
+  white-space: nowrap;
 }
 
 .epInfoLine {

--- a/packages/website/src/pages/index/index/components/PrgManager.tsx
+++ b/packages/website/src/pages/index/index/components/PrgManager.tsx
@@ -3,7 +3,12 @@ import { DateTime } from 'luxon';
 import React, { useState } from 'react';
 
 import { ozaClient } from '@bangumi/client';
-import type { Episode, ProgressItem, UpdateSubjectProgress } from '@bangumi/client/client';
+import type {
+  Episode,
+  ProgressItem,
+  UpdateEpisodeProgress,
+  UpdateSubjectProgress,
+} from '@bangumi/client/client';
 import { EpisodeCollectionStatus, EpisodeType, SubjectType } from '@bangumi/client/client';
 import { Popover, toast, Typography } from '@bangumi/design';
 import { GridView, ListView } from '@bangumi/icons';
@@ -97,7 +102,7 @@ function EpDetail({
 }: {
   ep: Episode;
   submitting: boolean;
-  onUpdate: (type: EpisodeCollectionStatus) => void;
+  onUpdate: (body: UpdateEpisodeProgress) => void;
 }) {
   const status = ep.collection?.status;
   return (
@@ -108,38 +113,70 @@ function EpDetail({
         </span>
       </div>
       <div className={styles.epActions}>
-        <button
-          type='button'
-          className={styles.epActionBtn}
-          disabled={submitting}
-          onClick={() => onUpdate(EpisodeCollectionStatus.Wish)}
-        >
-          想看
-        </button>
-        <button
-          type='button'
-          className={styles.epActionBtn}
-          disabled={submitting}
-          onClick={() => onUpdate(EpisodeCollectionStatus.Dropped)}
-        >
-          抛弃
-        </button>
-        <button
-          type='button'
-          className={styles.epActionBtn}
-          disabled={submitting}
-          onClick={() => onUpdate(EpisodeCollectionStatus.None)}
-        >
-          撤消
-        </button>
-        <button
-          type='button'
-          className={styles.epWatchedBtn}
-          disabled={submitting}
-          onClick={() => onUpdate(EpisodeCollectionStatus.Done)}
-        >
-          看过
-        </button>
+        {status !== EpisodeCollectionStatus.Done && (
+          <>
+            <button
+              type='button'
+              className={styles.epActionBtn}
+              disabled={submitting}
+              onClick={() => onUpdate({ type: EpisodeCollectionStatus.Done })}
+            >
+              看过
+            </button>
+            {ep.type === EpisodeType.Normal && (
+              <button
+                type='button'
+                className={styles.epActionBtn}
+                disabled={submitting}
+                onClick={() => onUpdate({ batch: true })}
+              >
+                看到
+              </button>
+            )}
+          </>
+        )}
+        {status !== EpisodeCollectionStatus.Wish && (
+          <button
+            type='button'
+            className={styles.epActionBtn}
+            disabled={submitting}
+            onClick={() => onUpdate({ type: EpisodeCollectionStatus.Wish })}
+          >
+            想看
+          </button>
+        )}
+        {status !== EpisodeCollectionStatus.Dropped && (
+          <button
+            type='button'
+            className={styles.epActionBtn}
+            disabled={submitting}
+            onClick={() => onUpdate({ type: EpisodeCollectionStatus.Dropped })}
+          >
+            抛弃
+          </button>
+        )}
+        {ep.collection && (
+          <button
+            type='button'
+            className={styles.epActionBtn}
+            disabled={submitting}
+            onClick={() => onUpdate({ type: EpisodeCollectionStatus.None })}
+          >
+            撤消
+          </button>
+        )}
+        {ep.collection && (
+          <span
+            className={styles.epCurrentStatus}
+            title={
+              ep.collection.updatedAt
+                ? DateTime.fromSeconds(ep.collection.updatedAt).toFormat('yyyy-M-d HH:mm')
+                : undefined
+            }
+          >
+            {STATUS_TEXT[ep.collection.status]}
+          </span>
+        )}
       </div>
       {ep.nameCN && (
         <p className={styles.epInfoLine}>
@@ -178,7 +215,7 @@ function EpButton({
 }: {
   ep: Episode;
   submitting: boolean;
-  onUpdate: (type: EpisodeCollectionStatus) => void;
+  onUpdate: (body: UpdateEpisodeProgress) => void;
 }) {
   const watched = ep.collection?.status === EpisodeCollectionStatus.Done;
   const unavailable = Boolean(ep.airdate) && isEpisodeUnavailable(ep.airdate);
@@ -282,10 +319,10 @@ function PrgCard({ item, detailed = false }: { item: ProgressItem; detailed?: bo
     void submit(body);
   };
 
-  const handleEpStatus = async (ep: Episode, type: EpisodeCollectionStatus) => {
+  const handleEpStatus = async (ep: Episode, body: UpdateEpisodeProgress) => {
     setSubmitting(true);
     try {
-      await ok(ozaClient.updateEpisodeProgress(ep.id, { type }));
+      await ok(ozaClient.updateEpisodeProgress(ep.id, body));
       await mutate();
     } catch (error) {
       toast(getErrorMessage(error), { type: 'error' });
@@ -413,7 +450,7 @@ function PrgCard({ item, detailed = false }: { item: ProgressItem; detailed?: bo
                     key={ep.id}
                     ep={ep}
                     submitting={submitting}
-                    onUpdate={(epType) => void handleEpStatus(ep, epType)}
+                    onUpdate={(body) => void handleEpStatus(ep, body)}
                   />
                 ))}
               </li>


### PR DESCRIPTION
## Summary

Rework episode action buttons in the home progress manager (`PrgManager`) so they adapt to the episode's current collection status:

- Episodes already marked "watched" no longer show a "watched" button; instead they display the current status text (with a tooltip showing the update time) and an "undo" action
- Add a "watched up to" (`看到`) batch-marking button, shown only for regular episodes (`episodeType === normal`)
- Hide "wish" / "dropped" buttons when the episode already has that status
- Show "undo" only when the episode has a collection entry
- `onUpdate` now passes an `UpdateEpisodeProgress` body instead of a bare `EpisodeCollectionStatus`, enabling `{ batch: true }`

## Changes

- `PrgManager.tsx`: dynamic action buttons + batch mark logic
- `PrgManager.module.less`: style adjustments (`overflow: visible` for popovers, new `.epCurrentStatus` style)
- `HomePage.spec.tsx`: new test covering action rendering per collection status
- `mocks/fixtures/p1/home-GET.ts`: typed fixture export

## Validation

- `HomePage.spec.tsx`: 10 tests pass
- `pnpm type-check`, `pnpm lint`, `pnpm lint:style`: pass
- Prettier clean on changed files (repo has a pre-existing `.kilo/agent-manager.json` format issue unrelated to this PR)