### PR TITLE
feat(website): add character home page

### DIFF
--- a/packages/website/src/components/PageRoutes/LegacyRedirect.spec.tsx
+++ b/packages/website/src/components/PageRoutes/LegacyRedirect.spec.tsx
@@ -29,7 +29,6 @@ it.each([
   '/subject/12/collections',
   '/subject/12/stats',
   '/subject/topic/42',
-  '/character/8',
 ])('registers %s as a legacy route', (path) => {
   const matches = matchRoutes(pageRoutes, path);
   const element = matches?.at(-1)?.route.element;

--- a/packages/website/src/hooks/use-character-home.ts
+++ b/packages/website/src/hooks/use-character-home.ts
@@ -1,0 +1,70 @@
+import { ok } from '@oazapfts/runtime';
+import useSWR from 'swr';
+
+import { ozaClient } from '@bangumi/client';
+import type {
+  Character,
+  CharacterRelation,
+  CharacterSubject,
+  MonoPhoto,
+  PersonCollect,
+  SlimIndex,
+} from '@bangumi/client/client';
+
+type SuccessData<T extends (...args: never[]) => unknown> =
+  Extract<Awaited<ReturnType<T>>, { status: 200 }> extends { data: infer Data } ? Data : never;
+
+export type CharacterComment = SuccessData<typeof ozaClient.getCharacterComments>[number];
+
+export interface CharacterHomeResponse {
+  character: Character;
+  casts: CharacterSubject[];
+  castTotal: number;
+  relations: CharacterRelation[];
+  relationTotal: number;
+  collects: PersonCollect[];
+  collectTotal: number;
+  comments: CharacterComment[];
+  photos: MonoPhoto[];
+  photoTotal: number;
+  indexes: SlimIndex[];
+  indexTotal: number;
+}
+
+export function useCharacterHome(characterID: number): {
+  data: CharacterHomeResponse | undefined;
+  mutate: () => Promise<unknown>;
+} {
+  const { data, mutate } = useSWR(
+    `character-home ${characterID}`,
+    async () => {
+      const [character, casts, relations, collects, comments, photos, indexes] = await Promise.all([
+        ok(ozaClient.getCharacter(characterID)),
+        ok(ozaClient.getCharacterCasts(characterID, { limit: 10 })),
+        ok(ozaClient.getCharacterRelations(characterID, { limit: 8 })),
+        ok(ozaClient.getCharacterCollects(characterID, { limit: 5 })),
+        ok(ozaClient.getCharacterComments(characterID)),
+        ok(ozaClient.getCharacterPhotoPreview(characterID, { limit: 8 })),
+        ok(ozaClient.getCharacterIndexes(characterID, { limit: 5 })),
+      ]);
+
+      return {
+        character,
+        casts: casts.data,
+        castTotal: casts.total,
+        relations: relations.data,
+        relationTotal: relations.total,
+        collects: collects.data,
+        collectTotal: collects.total,
+        comments,
+        photos: photos.data,
+        photoTotal: photos.total,
+        indexes: indexes.data,
+        indexTotal: indexes.total,
+      };
+    },
+    { suspense: true },
+  );
+
+  return { data, mutate };
+}

--- a/packages/website/src/pages/index/character/[id]/CharacterDetail.module.less
+++ b/packages/website/src/pages/index/character/[id]/CharacterDetail.module.less
@@ -1,0 +1,593 @@
+@import '@bangumi/design/theme/base';
+
+.headerInner,
+.tabsInner,
+.page {
+  width: 100%;
+  max-width: 1000px;
+  margin-right: auto;
+  margin-left: auto;
+  box-sizing: border-box;
+}
+
+.name {
+  margin: 15px 0;
+  font-size: 20px;
+  font-weight: bold;
+  line-height: 1.3;
+
+  a {
+    color: @gray-100;
+    font-weight: bold;
+
+    &:hover {
+      color: @blue-100;
+    }
+  }
+
+  small {
+    margin-left: 8px;
+    color: @gray-60;
+    font-size: 12px;
+    font-weight: normal;
+  }
+}
+
+.tabs {
+  border-top: 1px solid #fefefe;
+  border-bottom: 1px solid @gray-10;
+  background: #fbfbfb;
+}
+
+.tabsInner {
+  overflow-x: auto;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+.tabList {
+  display: flex;
+  width: 100%;
+  min-width: max-content;
+  margin: 0;
+  padding: 0;
+  gap: 5px;
+  list-style: none;
+}
+
+.tabLink {
+  display: block;
+  padding: 10px 10px 9px;
+  border-bottom: 2px solid transparent;
+  color: #888;
+  font-size: 14px;
+  white-space: nowrap;
+
+  &:hover {
+    border-bottom-color: @blue-100;
+    color: @blue-100;
+    text-decoration: none;
+  }
+}
+
+.tabLinkActive {
+  border-bottom-color: @primary-color;
+  color: @primary-color;
+}
+
+.collectAction {
+  display: flex;
+  align-items: center;
+  margin-left: auto;
+  padding: 0 10px;
+
+  button {
+    padding: 3px 8px;
+    border: 1px solid @pink-60;
+    border-radius: 3px;
+    background: @pink-10;
+    color: @primary-color;
+    font-size: 12px;
+
+    &:disabled {
+      cursor: wait;
+      opacity: 0.6;
+    }
+  }
+}
+
+.page {
+  display: grid;
+  grid-template-columns: 250px minmax(0, 720px);
+  align-items: flex-start;
+  gap: 15px;
+  padding-bottom: 30px;
+}
+
+.sidebar,
+.content {
+  min-width: 0;
+  margin-top: 10px;
+}
+
+.infobox {
+  margin: 0 0 15px;
+  overflow-wrap: anywhere;
+}
+
+.portraitWrapper {
+  margin-bottom: 12px;
+  text-align: center;
+}
+
+.portrait {
+  display: block;
+  width: 240px;
+  max-width: 100%;
+  height: auto;
+  aspect-ratio: auto 3 / 4;
+  margin: 0 auto;
+  box-sizing: border-box;
+  border: 1px solid #a9a9ab;
+  border-top-color: #c7c7c9;
+  border-bottom-color: #858486;
+  background: #f4f2f2;
+  color: transparent;
+  box-shadow: 0 1px 5px #aaa;
+  object-fit: contain;
+}
+
+.infoList,
+.indexList,
+.collectorList,
+.photoList,
+.castList,
+.castPeople,
+.relationList,
+.commentList,
+.replyList {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.infoList {
+  font-size: 13px;
+  line-height: 1.55;
+
+  li {
+    padding: 5px;
+    border-bottom: 1px solid @gray-10;
+  }
+}
+
+.infoKey,
+.infoSubKey,
+.sideMeta {
+  color: @gray-60;
+}
+
+.infoSubKey {
+  font-size: 12px;
+}
+
+.sidePanel {
+  margin-bottom: 20px;
+  font-size: 12px;
+
+  > h2 {
+    margin: 0 0 5px;
+    padding: 5px 0;
+    border-bottom: 1px solid @gray-10;
+    color: @gray-80;
+    font-size: 14px;
+    font-weight: normal;
+  }
+}
+
+.indexList {
+  margin: 0 5px 5px;
+
+  li {
+    padding: 5px 0;
+    overflow: hidden;
+    border-bottom: 1px solid @gray-10;
+  }
+
+  li > a {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  small {
+    display: block;
+    margin-top: 2px;
+    color: @gray-60;
+  }
+}
+
+.collectorList {
+  margin: 0 5px 5px;
+
+  > li {
+    display: flex;
+    min-height: 32px;
+    gap: 8px;
+    padding: 5px 0;
+    overflow: hidden;
+    border-bottom: 1px solid @gray-10;
+  }
+
+  > li > div {
+    min-width: 0;
+    padding-top: 1px;
+  }
+
+  small {
+    display: block;
+    margin-top: 3px;
+    color: @gray-60;
+  }
+}
+
+.avatarLink {
+  flex: 0 0 32px;
+}
+
+.sideMeta {
+  display: block;
+  margin: 5px;
+}
+
+.summary {
+  padding: 10px 0 15px;
+  border-bottom: 1px solid @gray-10;
+  color: @gray-80;
+  font-size: 14px;
+  line-height: 1.8;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.contentSection {
+  padding: 13px 0 15px;
+  border-bottom: 1px solid @gray-10;
+}
+
+.sectionTitle {
+  margin: 0 0 10px;
+  padding: 0 5px 0 0;
+  color: @gray-80;
+  font-size: 18px;
+  font-weight: 300;
+  line-height: 1.4;
+
+  small {
+    color: @gray-60;
+    font-size: 11px;
+    font-weight: normal;
+  }
+}
+
+.photoList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 9px;
+
+  img {
+    display: block;
+    width: 80px;
+    height: 80px;
+    border-radius: 3px;
+    object-fit: cover;
+  }
+}
+
+.castList > li {
+  display: grid;
+  grid-template-columns: minmax(0, 330px) minmax(0, 350px);
+  justify-content: space-between;
+  padding: 7px 5px;
+  border-bottom: 1px solid @gray-10;
+
+  &:nth-child(even) {
+    border-top: 1px solid #fff;
+    background: #f8f8f8;
+  }
+
+  &:last-child {
+    border-bottom: 0;
+  }
+}
+
+.castSubject {
+  display: flex;
+  min-width: 0;
+  gap: 12px;
+}
+
+.castCoverLink,
+.castSubject img {
+  flex: 0 0 48px;
+  width: 48px;
+  height: 48px;
+}
+
+.castSubject img {
+  display: block;
+  border-radius: 4px;
+  object-fit: cover;
+}
+
+.castSubjectInfo {
+  min-width: 0;
+
+  > a {
+    display: block;
+    margin-bottom: 3px;
+    overflow: hidden;
+    font-size: 13px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  > small {
+    display: block;
+    margin-bottom: 4px;
+    overflow: hidden;
+    color: @gray-60;
+    font-size: 11px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+.badge {
+  display: inline-block;
+  margin-right: 4px;
+  padding: 2px 5px;
+  border-radius: 3px;
+  background: @gray-10;
+  color: @gray-80;
+  font-size: 10px;
+  line-height: 1;
+}
+
+.castPeople > li {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 5px 0;
+  border-bottom: 1px dotted #ddd;
+  text-align: right;
+
+  &:last-child {
+    border-bottom: 0;
+  }
+
+  img {
+    display: block;
+    width: 32px;
+    height: 32px;
+    border-radius: 4px;
+    object-fit: cover;
+  }
+
+  > div {
+    order: -1;
+    min-width: 0;
+  }
+
+  a,
+  small {
+    display: block;
+  }
+
+  a {
+    overflow: hidden;
+    font-size: 12px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  small {
+    margin-top: 3px;
+    color: @gray-60;
+    font-size: 10px;
+  }
+}
+
+.relationList {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, 80px);
+  gap: 9px;
+
+  > li {
+    min-width: 0;
+    font-size: 12px;
+  }
+
+  > li > small {
+    display: block;
+    height: 18px;
+    overflow: hidden;
+    color: @gray-60;
+    font-size: 10px;
+    line-height: 18px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  img,
+  .imagePlaceholder {
+    display: block;
+    width: 75px;
+    height: 75px;
+    margin-bottom: 5px;
+    border-radius: 8px;
+    background: @gray-10;
+    object-fit: cover;
+    object-position: center top;
+  }
+
+  > li > a:last-child {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+.commentsSection {
+  padding-top: 15px;
+}
+
+.commentList > li {
+  display: flex;
+  gap: 10px;
+  padding: 10px 5px;
+  border-bottom: 1px solid @gray-10;
+}
+
+.commentAvatar {
+  flex: 0 0 32px;
+}
+
+.commentBody {
+  min-width: 0;
+  flex: 1;
+}
+
+.commentHeader {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 12px;
+
+  time {
+    flex: none;
+    color: @gray-60;
+    font-size: 10px;
+  }
+}
+
+.commentContent,
+.replyContent {
+  margin-top: 5px;
+  color: @gray-100;
+  font-size: 13px;
+  line-height: 1.6;
+  overflow-wrap: anywhere;
+
+  p {
+    margin: 0;
+  }
+}
+
+.replyList {
+  margin-top: 8px;
+  padding: 6px 10px;
+  border-radius: 3px;
+  background: #f7f7f7;
+
+  li + li {
+    margin-top: 7px;
+    padding-top: 7px;
+    border-top: 1px solid @gray-10;
+  }
+
+  strong {
+    color: @gray-80;
+    font-size: 11px;
+    font-weight: normal;
+  }
+}
+
+.replyContent {
+  display: inline;
+  margin-left: 6px;
+  font-size: 12px;
+}
+
+@media (max-width: 1000px) {
+  .headerInner,
+  .tabsInner,
+  .page {
+    padding-right: 15px;
+    padding-left: 15px;
+  }
+
+  .page {
+    grid-template-columns: minmax(200px, 250px) minmax(0, 720px);
+  }
+}
+
+@media (max-width: @sm) {
+  .headerInner,
+  .tabsInner {
+    padding-right: 10px;
+    padding-left: 10px;
+  }
+
+  .name {
+    margin: 10px 0;
+  }
+
+  .page {
+    display: block;
+    padding: 0 5px 24px;
+  }
+
+  .sidebar {
+    margin-top: 10px;
+  }
+
+  .content {
+    margin-top: 0;
+  }
+
+  .portrait {
+    width: min(240px, 72vw);
+  }
+
+  .collectorsPanel {
+    display: none;
+  }
+
+  .sidePanel {
+    margin-bottom: 10px;
+  }
+
+  .summary {
+    padding: 0 5px 10px;
+  }
+
+  .castList > li {
+    grid-template-columns: minmax(0, 1fr) minmax(120px, 1fr);
+    gap: 8px;
+  }
+
+  .relationList {
+    grid-template-columns: repeat(auto-fill, minmax(75px, 1fr));
+  }
+
+  .commentList > li {
+    padding-right: 0;
+    padding-left: 0;
+  }
+
+  .commentHeader {
+    display: block;
+
+    time {
+      display: block;
+      margin-top: 2px;
+    }
+  }
+}

--- a/packages/website/src/pages/index/character/[id]/CharacterDetail.spec.tsx
+++ b/packages/website/src/pages/index/character/[id]/CharacterDetail.spec.tsx
@@ -1,0 +1,124 @@
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import React from 'react';
+import { SWRConfig } from 'swr';
+
+import { server as mockServer } from '@bangumi/website/mocks/server';
+import { renderPage } from '@bangumi/website/utils/test-utils';
+
+import CharacterDetail from './CharacterDetail';
+import { character174916Fixture as fixture } from './fixtures/character-174916';
+
+describe('CharacterDetail', () => {
+  const characterID = fixture.character.id;
+
+  const setup = () => {
+    const { character, casts, relations, collects, comments, indexes } = fixture;
+    mockServer.use(
+      http.get(`http://localhost:3000/p1/characters/${characterID}`, () =>
+        HttpResponse.json(character, { status: 200 }),
+      ),
+      http.get(`http://localhost:3000/p1/characters/${characterID}/casts`, () =>
+        HttpResponse.json({ data: casts, total: fixture.castTotal }, { status: 200 }),
+      ),
+      http.get(`http://localhost:3000/p1/characters/${characterID}/relations`, () =>
+        HttpResponse.json({ data: relations, total: fixture.relationTotal }, { status: 200 }),
+      ),
+      http.get(`http://localhost:3000/p1/characters/${characterID}/collects`, () =>
+        HttpResponse.json({ data: collects, total: fixture.collectTotal }, { status: 200 }),
+      ),
+      http.get(`http://localhost:3000/p1/characters/${characterID}/comments`, () =>
+        HttpResponse.json(comments, { status: 200 }),
+      ),
+      http.get(`http://localhost:3000/p1/characters/${characterID}/photos/preview`, () =>
+        HttpResponse.json({ data: fixture.photos, total: fixture.photoTotal }, { status: 200 }),
+      ),
+      http.get(`http://localhost:3000/p1/characters/${characterID}/indexes`, () =>
+        HttpResponse.json({ data: indexes, total: fixture.indexTotal }, { status: 200 }),
+      ),
+    );
+  };
+
+  const renderCharacter = async (data: typeof fixture = fixture) => {
+    await act(async () => {
+      renderPage(
+        <SWRConfig value={{ provider: () => new Map() }}>
+          <React.Suspense fallback={null}>
+            <CharacterDetail data={data} />
+          </React.Suspense>
+        </SWRConfig>,
+      );
+    });
+  };
+
+  it('should render all blocks', async () => {
+    setup();
+    await renderCharacter();
+
+    // header 标题（出演区同名条目重复出现）
+    expect((await screen.findAllByText('ヤニねこ')).length).toBeGreaterThan(0);
+    // 信息框
+    expect(await screen.findByText(/简体中文名/)).toBeInTheDocument();
+    // 推荐目录
+    expect(await screen.findByText('推荐本角色的目录')).toBeInTheDocument();
+    expect(await screen.findByText('杯子测评')).toBeInTheDocument();
+    // 收藏者
+    expect(await screen.findByText('谁收藏了ヤニねこ?')).toBeInTheDocument();
+    expect(await screen.findByText('柊镜司姐妹盖饭')).toBeInTheDocument();
+    // 出演（夏吉ゆうこ 在两个出演条目中重复出现）
+    expect(await screen.findByText('出演')).toBeInTheDocument();
+    expect((await screen.findAllByText('夏吉ゆうこ')).length).toBeGreaterThan(0);
+    // 关联角色
+    expect(await screen.findByText('关联角色')).toBeInTheDocument();
+    expect(await screen.findByText('妹子')).toBeInTheDocument();
+    // 吐槽箱
+    expect(await screen.findByText('吐槽箱')).toBeInTheDocument();
+    expect(await screen.findByText('年度神人奖你至少要有个提名')).toBeInTheDocument();
+    expect(await screen.findByText('算了你还是拿冠军吧')).toBeInTheDocument();
+    // 相册为空不渲染（tabs 中的"相册"链接不算）
+    expect(screen.queryByRole('heading', { name: '相册' })).not.toBeInTheDocument();
+  });
+
+  it('should collect character when not collected', async () => {
+    setup();
+    let collected = false;
+    mockServer.use(
+      http.put(`http://localhost:3000/p1/collections/characters/${characterID}`, () => {
+        collected = true;
+        return HttpResponse.json({}, { status: 200 });
+      }),
+    );
+
+    await renderCharacter();
+
+    fireEvent.click(await screen.findByRole('button', { name: '加入收藏' }));
+
+    await waitFor(() => {
+      expect(collected).toBe(true);
+    });
+  });
+
+  it('should uncollect character when collected', async () => {
+    setup();
+    let deleted = false;
+    mockServer.use(
+      http.delete(`http://localhost:3000/p1/collections/characters/${characterID}`, () => {
+        deleted = true;
+        return HttpResponse.json({}, { status: 200 });
+      }),
+    );
+    // 已收藏状态由传入的 data 决定，而非 API 返回值
+    const collectedFixture = {
+      ...fixture,
+      character: { ...fixture.character, collectedAt: 1775000000 },
+    };
+
+    await renderCharacter(collectedFixture);
+
+    fireEvent.click(await screen.findByRole('button', { name: '取消收藏' }));
+
+    await waitFor(() => {
+      expect(deleted).toBe(true);
+    });
+  });
+});

--- a/packages/website/src/pages/index/character/[id]/CharacterDetail.tsx
+++ b/packages/website/src/pages/index/character/[id]/CharacterDetail.tsx
@@ -1,0 +1,382 @@
+import { ok } from '@oazapfts/runtime';
+import dayjs from 'dayjs';
+import React, { useState } from 'react';
+import { NavLink } from 'react-router-dom';
+
+import { ozaClient } from '@bangumi/client';
+import type {
+  Character,
+  CharacterRelation,
+  CharacterSubject,
+  Infobox,
+  MonoPhoto,
+  PersonCollect,
+  SlimIndex,
+} from '@bangumi/client/client';
+import { Avatar, RichContent, toast, Typography } from '@bangumi/design';
+import {
+  getCharacterLink,
+  getIndexLink,
+  getPersonLink,
+  getSubjectLink,
+  getUserProfileLink,
+} from '@bangumi/utils/pages';
+import { makeDescriptiveTime } from '@bangumi/website/components/TimelineDescription';
+import type {
+  CharacterComment,
+  CharacterHomeResponse,
+} from '@bangumi/website/hooks/use-character-home';
+import { useCharacterHome } from '@bangumi/website/hooks/use-character-home';
+import { useUser } from '@bangumi/website/hooks/use-user';
+
+import styles from './CharacterDetail.module.less';
+
+const { Link } = Typography;
+
+function CharacterHeader({ character }: { character: Character }) {
+  const { user } = useUser();
+  const { mutate } = useCharacterHome(character.id);
+  const [sending, setSending] = useState(false);
+  const collected = character.collectedAt != null;
+
+  const toggleCollection = async () => {
+    setSending(true);
+    try {
+      if (collected) {
+        await ok(ozaClient.deleteCharacterCollection(character.id));
+      } else {
+        await ok(ozaClient.addCharacterCollection(character.id));
+      }
+      await mutate();
+    } catch (error) {
+      toast(error instanceof Error ? error.message : '操作失败，请稍后再试', { type: 'error' });
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const baseLink = getCharacterLink(character.id);
+  const tabs = [
+    { label: '概览', to: baseLink, end: true },
+    { label: '相册', to: `${baseLink}/album`, end: false },
+    { label: '收藏', to: `${baseLink}/collections`, end: false },
+  ];
+
+  return (
+    <header className={styles.header}>
+      <div className={styles.headerInner}>
+        <h1 className={styles.name}>
+          <Link to={baseLink} title={character.nameCN}>
+            {character.name}
+          </Link>
+          {character.nameCN !== '' && <small>{character.nameCN}</small>}
+        </h1>
+      </div>
+      <nav className={styles.tabs} aria-label='角色导航'>
+        <div className={styles.tabsInner}>
+          <ul className={styles.tabList}>
+            {tabs.map((tab) => (
+              <li key={tab.to}>
+                <NavLink
+                  to={tab.to}
+                  end={tab.end}
+                  className={({ isActive }) =>
+                    isActive ? `${styles.tabLink} ${styles.tabLinkActive}` : styles.tabLink
+                  }
+                >
+                  {tab.label}
+                </NavLink>
+              </li>
+            ))}
+            {user && (
+              <li className={styles.collectAction}>
+                <button type='button' disabled={sending} onClick={() => void toggleCollection()}>
+                  {collected ? '取消收藏' : '加入收藏'}
+                </button>
+              </li>
+            )}
+          </ul>
+        </div>
+      </nav>
+    </header>
+  );
+}
+
+function CharacterInfobox({ character }: { character: Character }) {
+  const visibleInfo = character.infobox
+    .map((item) => ({ ...item, values: item.values.filter((value) => value.v !== '') }))
+    .filter((item) => item.values.length > 0);
+
+  return (
+    <section className={styles.infobox}>
+      {character.images && (
+        <div className={styles.portraitWrapper}>
+          <a
+            href={character.images.large}
+            target='_blank'
+            rel='noopener noreferrer'
+            title={character.name}
+          >
+            <img className={styles.portrait} src={character.images.large} alt={character.name} />
+          </a>
+        </div>
+      )}
+      <InfoboxList infobox={visibleInfo} />
+    </section>
+  );
+}
+
+function InfoboxList({ infobox }: { infobox: Infobox }) {
+  return (
+    <ul className={styles.infoList}>
+      {infobox.map((item) => (
+        <li key={item.key}>
+          <span className={styles.infoKey}>{item.key}: </span>
+          {item.values.map((value, index) => (
+            <span key={`${value.k ?? ''}-${value.v}`}>
+              {value.k && <span className={styles.infoSubKey}>{value.k}: </span>}
+              {value.v}
+              {index < item.values.length - 1 && <br />}
+            </span>
+          ))}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function IndexPanel({ indexes, total }: { indexes: SlimIndex[]; total: number }) {
+  if (indexes.length === 0) return null;
+
+  return (
+    <section className={styles.sidePanel}>
+      <h2>推荐本角色的目录</h2>
+      <ul className={styles.indexList}>
+        {indexes.map((index) => (
+          <li key={index.id}>
+            <Link to={getIndexLink(index.id)} title={index.title}>
+              {index.title}
+            </Link>
+            {index.user && (
+              <small>
+                by <Link to={getUserProfileLink(index.user.username)}>{index.user.nickname}</Link>
+              </small>
+            )}
+          </li>
+        ))}
+      </ul>
+      {total > indexes.length && <span className={styles.sideMeta}>共 {total} 个目录</span>}
+    </section>
+  );
+}
+
+function CollectorsPanel({
+  character,
+  collects,
+  total,
+}: {
+  character: Character;
+  collects: PersonCollect[];
+  total: number;
+}) {
+  if (collects.length === 0) return null;
+
+  return (
+    <section className={`${styles.sidePanel} ${styles.collectorsPanel}`}>
+      <h2>谁收藏了{character.name}?</h2>
+      <ul className={styles.collectorList}>
+        {collects.map(({ user, createdAt }) => (
+          <li key={user.id}>
+            <Link to={getUserProfileLink(user.username)} noStyle className={styles.avatarLink}>
+              <Avatar src={user.avatar.small} size='small' alt='' />
+            </Link>
+            <div>
+              <Link to={getUserProfileLink(user.username)}>{user.nickname}</Link>
+              <small title={dayjs.unix(createdAt).format('YYYY-MM-DD HH:mm')}>
+                {makeDescriptiveTime(createdAt)}
+              </small>
+            </div>
+          </li>
+        ))}
+      </ul>
+      <Link to={`${getCharacterLink(character.id)}/collections`}>全部 {total} 位收藏会员 »</Link>
+    </section>
+  );
+}
+
+function SectionTitle({ children, count }: { children: React.ReactNode; count?: number }) {
+  return (
+    <h2 className={styles.sectionTitle}>
+      {children}
+      {count != null && <small> · {count}</small>}
+    </h2>
+  );
+}
+
+function PhotosSection({ photos, total }: { photos: MonoPhoto[]; total: number }) {
+  if (photos.length === 0) return null;
+
+  return (
+    <section className={styles.contentSection}>
+      <SectionTitle count={total}>相册</SectionTitle>
+      <ul className={styles.photoList}>
+        {photos.map((photo) => (
+          <li key={photo.id}>
+            <a href={photo.images.large} target='_blank' rel='noopener noreferrer'>
+              <img src={photo.images.grid} alt={photo.title} loading='lazy' />
+            </a>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function CastsSection({ casts }: { casts: CharacterSubject[] }) {
+  if (casts.length === 0) return null;
+
+  return (
+    <section className={styles.contentSection}>
+      <SectionTitle>出演</SectionTitle>
+      <ul className={styles.castList}>
+        {casts.map(({ subject, casts: people }) => (
+          <li key={subject.id}>
+            <div className={styles.castSubject}>
+              {subject.images && (
+                <Link to={getSubjectLink(subject.id)} noStyle className={styles.castCoverLink}>
+                  <img src={subject.images.grid} alt='' loading='lazy' />
+                </Link>
+              )}
+              <div className={styles.castSubjectInfo}>
+                <Link to={getSubjectLink(subject.id)}>{subject.name}</Link>
+                {subject.nameCN && <small>{subject.nameCN}</small>}
+                <span className={styles.badge}>主角</span>
+              </div>
+            </div>
+            <ul className={styles.castPeople}>
+              {people.map(({ person, relation }) => (
+                <li key={`${person.id}-${relation}`}>
+                  {person.images && (
+                    <Link to={getPersonLink(person.id)} noStyle>
+                      <img src={person.images.grid} alt='' loading='lazy' />
+                    </Link>
+                  )}
+                  <div>
+                    <Link to={getPersonLink(person.id)}>{person.name}</Link>
+                    <small>{relation === 0 ? 'CV' : '出演'}</small>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function RelationsSection({ relations }: { relations: CharacterRelation[] }) {
+  if (relations.length === 0) return null;
+
+  return (
+    <section className={styles.contentSection}>
+      <SectionTitle>关联角色</SectionTitle>
+      <ul className={styles.relationList}>
+        {relations.map(({ character, relation, ended }) => (
+          <li key={character.id}>
+            <small>
+              {ended && <span className={styles.badge}>已结束</span>}
+              {relation.cn}
+            </small>
+            <Link to={getCharacterLink(character.id)} noStyle>
+              {character.images ? (
+                <img src={character.images.grid} alt='' loading='lazy' />
+              ) : (
+                <span className={styles.imagePlaceholder} />
+              )}
+            </Link>
+            <Link to={getCharacterLink(character.id)}>{character.name}</Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function CommentsSection({ comments }: { comments: CharacterComment[] }) {
+  if (comments.length === 0) return null;
+
+  return (
+    <section className={styles.commentsSection}>
+      <SectionTitle>吐槽箱</SectionTitle>
+      <ul className={styles.commentList}>
+        {comments.map((comment) => (
+          <li key={comment.id} id={`post_${comment.id}`}>
+            {comment.user && (
+              <Link
+                to={getUserProfileLink(comment.user.username)}
+                noStyle
+                className={styles.commentAvatar}
+              >
+                <Avatar src={comment.user.avatar.small} size='small' alt='' />
+              </Link>
+            )}
+            <div className={styles.commentBody}>
+              <div className={styles.commentHeader}>
+                {comment.user ? (
+                  <Link to={getUserProfileLink(comment.user.username)}>
+                    {comment.user.nickname}
+                  </Link>
+                ) : (
+                  <span>已注销用户</span>
+                )}
+                <time dateTime={dayjs.unix(comment.createdAt).toISOString()}>
+                  {dayjs.unix(comment.createdAt).format('YYYY-M-D HH:mm')}
+                </time>
+              </div>
+              <RichContent bbcode={comment.content} classname={styles.commentContent} />
+              {comment.replies.length > 0 && (
+                <ul className={styles.replyList}>
+                  {comment.replies.map((reply) => (
+                    <li key={reply.id}>
+                      <strong>{reply.user?.nickname ?? '已注销用户'}</strong>
+                      <RichContent bbcode={reply.content} classname={styles.replyContent} />
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export default function CharacterDetail({ data }: { data: CharacterHomeResponse }) {
+  const { character } = data;
+
+  return (
+    <>
+      <CharacterHeader character={character} />
+      <main className={styles.page}>
+        <aside className={styles.sidebar}>
+          <CharacterInfobox character={character} />
+          <IndexPanel indexes={data.indexes} total={data.indexTotal} />
+          <CollectorsPanel
+            character={character}
+            collects={data.collects}
+            total={data.collectTotal}
+          />
+        </aside>
+        <div className={styles.content}>
+          {character.summary && <div className={styles.summary}>{character.summary}</div>}
+          <PhotosSection photos={data.photos} total={data.photoTotal} />
+          <CastsSection casts={data.casts} />
+          <RelationsSection relations={data.relations} />
+          <CommentsSection comments={data.comments} />
+        </div>
+      </main>
+    </>
+  );
+}

--- a/packages/website/src/pages/index/character/[id]/fixtures/character-174916.json
+++ b/packages/website/src/pages/index/character/[id]/fixtures/character-174916.json
@@ -1,0 +1,481 @@
+{
+  "character": {
+    "id": 174916,
+    "name": "ヤニねこ",
+    "nameCN": "尼古喵喵",
+    "role": 1,
+    "infobox": [
+      { "key": "简体中文名", "values": [{ "v": "尼古喵喵" }] },
+      {
+        "key": "别名",
+        "values": [
+          { "v": "佐藤尼古子", "k": "第二中文名" },
+          { "v": "", "k": "英文名" },
+          { "v": "佐藤ヤニ子", "k": "日文名" },
+          { "v": "", "k": "纯假名" },
+          { "v": "", "k": "罗马字" },
+          { "v": "", "k": "昵称" }
+        ]
+      },
+      { "key": "性别", "values": [{ "v": "女" }] },
+      { "key": "生日", "values": [{ "v": "" }] },
+      { "key": "血型", "values": [{ "v": "" }] },
+      { "key": "身高", "values": [{ "v": "" }] },
+      { "key": "体重", "values": [{ "v": "" }] },
+      { "key": "BWH", "values": [{ "v": "" }] },
+      { "key": "引用来源", "values": [] }
+    ],
+    "info": "性别 女",
+    "summary": "21歳、獣人、ヘビースモーカー。本名、佐藤ヤニ子。\r\nすべての物事においてタバコが最優先で、ヤニ臭い汚部屋で怠惰に暮らしている。\r\n妹からは「顔と身体しか取り柄がない」と言われ、近所の子どもたちからの呼び名は「ヤニカス」。\r\nこんな猫がいたっていいじゃん。",
+    "comment": 66,
+    "collects": 47,
+    "lock": false,
+    "redirect": 0,
+    "nsfw": false,
+    "images": {
+      "large": "https://lain.bgm.tv/pic/crt/l/18/c7/174916_crt_5olY8.jpg",
+      "medium": "https://lain.bgm.tv/r/200/pic/crt/l/18/c7/174916_crt_5olY8.jpg",
+      "small": "https://lain.bgm.tv/r/100/pic/crt/l/18/c7/174916_crt_5olY8.jpg",
+      "grid": "https://lain.bgm.tv/r/100x100/pic/crt/l/18/c7/174916_crt_5olY8.jpg"
+    }
+  },
+  "casts": [
+    {
+      "subject": {
+        "id": 445083,
+        "name": "ヤニねこ",
+        "nameCN": "尼古喵喵",
+        "type": 1,
+        "info": "2023-08-04 / にゃんにゃんファクトリー / 講談社",
+        "metaTags": ["日本", "漫画", "原创", "系列", "连载中"],
+        "rating": {
+          "rank": 7970,
+          "count": [0, 0, 3, 1, 1, 12, 19, 4, 1, 0],
+          "score": 6.44,
+          "total": 41
+        },
+        "locked": false,
+        "nsfw": false,
+        "images": {
+          "large": "https://lain.bgm.tv/pic/cover/l/90/31/445083_37keV.jpg",
+          "common": "https://lain.bgm.tv/r/400/pic/cover/l/90/31/445083_37keV.jpg",
+          "medium": "https://lain.bgm.tv/r/200/pic/cover/l/90/31/445083_37keV.jpg",
+          "small": "https://lain.bgm.tv/r/100/pic/cover/l/90/31/445083_37keV.jpg",
+          "grid": "https://lain.bgm.tv/r/100x100/pic/cover/l/90/31/445083_37keV.jpg"
+        }
+      },
+      "casts": [],
+      "type": 1
+    },
+    {
+      "subject": {
+        "id": 622206,
+        "name": "ヤニねこ",
+        "nameCN": "尼古喵喵",
+        "type": 2,
+        "info": "2026年7月2日 / 木村拓 / にゃんにゃんファクトリー（講談社「ヤングマガジン」連載） / 松浦力",
+        "metaTags": ["TV", "喜剧", "日常", "日本", "漫画改", "青年向"],
+        "rating": {
+          "rank": 1862,
+          "count": [36, 12, 21, 37, 116, 402, 1255, 981, 178, 119],
+          "score": 7.19,
+          "total": 3157
+        },
+        "locked": false,
+        "nsfw": false,
+        "images": {
+          "large": "https://lain.bgm.tv/pic/cover/l/6a/b3/622206_dpWcC.jpg",
+          "common": "https://lain.bgm.tv/r/400/pic/cover/l/6a/b3/622206_dpWcC.jpg",
+          "medium": "https://lain.bgm.tv/r/200/pic/cover/l/6a/b3/622206_dpWcC.jpg",
+          "small": "https://lain.bgm.tv/r/100/pic/cover/l/6a/b3/622206_dpWcC.jpg",
+          "grid": "https://lain.bgm.tv/r/100x100/pic/cover/l/6a/b3/622206_dpWcC.jpg"
+        }
+      },
+      "casts": [
+        {
+          "person": {
+            "id": 36024,
+            "name": "夏吉ゆうこ",
+            "nameCN": "夏吉优子",
+            "type": 1,
+            "info": "性别 女 / 生日 199?年5月1日",
+            "career": ["seiyu"],
+            "comment": 110,
+            "lock": false,
+            "nsfw": false,
+            "images": {
+              "large": "https://lain.bgm.tv/pic/crt/l/7d/6d/36024_prsn_8HVVQ.jpg",
+              "medium": "https://lain.bgm.tv/r/200/pic/crt/l/7d/6d/36024_prsn_8HVVQ.jpg",
+              "small": "https://lain.bgm.tv/r/100/pic/crt/l/7d/6d/36024_prsn_8HVVQ.jpg",
+              "grid": "https://lain.bgm.tv/r/100x100/pic/crt/l/7d/6d/36024_prsn_8HVVQ.jpg"
+            }
+          },
+          "relation": 0,
+          "summary": ""
+        }
+      ],
+      "type": 1
+    },
+    {
+      "subject": {
+        "id": 630665,
+        "name": "『ヤニねこ』ミニアニメ",
+        "nameCN": "尼古喵喵 迷你动画",
+        "type": 2,
+        "info": "2026年2月21日",
+        "metaTags": ["日本", "WEB"],
+        "rating": {
+          "rank": 7181,
+          "count": [0, 0, 1, 4, 32, 70, 19, 1, 0, 0],
+          "score": 5.83,
+          "total": 127
+        },
+        "locked": false,
+        "nsfw": false,
+        "images": {
+          "large": "https://lain.bgm.tv/pic/cover/l/7b/01/630665_wAc8h.jpg",
+          "common": "https://lain.bgm.tv/r/400/pic/cover/l/7b/01/630665_wAc8h.jpg",
+          "medium": "https://lain.bgm.tv/r/200/pic/cover/l/7b/01/630665_wAc8h.jpg",
+          "small": "https://lain.bgm.tv/r/100/pic/cover/l/7b/01/630665_wAc8h.jpg",
+          "grid": "https://lain.bgm.tv/r/100x100/pic/cover/l/7b/01/630665_wAc8h.jpg"
+        }
+      },
+      "casts": [
+        {
+          "person": {
+            "id": 36024,
+            "name": "夏吉ゆうこ",
+            "nameCN": "夏吉优子",
+            "type": 1,
+            "info": "性别 女 / 生日 199?年5月1日",
+            "career": ["seiyu"],
+            "comment": 110,
+            "lock": false,
+            "nsfw": false,
+            "images": {
+              "large": "https://lain.bgm.tv/pic/crt/l/7d/6d/36024_prsn_8HVVQ.jpg",
+              "medium": "https://lain.bgm.tv/r/200/pic/crt/l/7d/6d/36024_prsn_8HVVQ.jpg",
+              "small": "https://lain.bgm.tv/r/100/pic/crt/l/7d/6d/36024_prsn_8HVVQ.jpg",
+              "grid": "https://lain.bgm.tv/r/100x100/pic/crt/l/7d/6d/36024_prsn_8HVVQ.jpg"
+            }
+          },
+          "relation": 0,
+          "summary": ""
+        }
+      ],
+      "type": 1
+    }
+  ],
+  "castTotal": 3,
+  "relations": [
+    {
+      "character": {
+        "id": 174918,
+        "name": "妹子",
+        "nameCN": "妹子",
+        "role": 1,
+        "info": "性别 女",
+        "comment": 56,
+        "lock": false,
+        "nsfw": false,
+        "images": {
+          "large": "https://lain.bgm.tv/pic/crt/l/01/48/174918_crt_CWKC0.jpg",
+          "medium": "https://lain.bgm.tv/r/200/pic/crt/l/01/48/174918_crt_CWKC0.jpg",
+          "small": "https://lain.bgm.tv/r/100/pic/crt/l/01/48/174918_crt_CWKC0.jpg",
+          "grid": "https://lain.bgm.tv/r/100x100/pic/crt/l/01/48/174918_crt_CWKC0.jpg"
+        }
+      },
+      "relation": {
+        "id": 2006,
+        "cn": "亲属",
+        "desc": "父母子女、祖孙等直系亲属及其兄弟姐妹关系。涵盖生物学亲属、法律收养亲属以及再婚家庭形成的亲属关系"
+      },
+      "spoiler": false,
+      "ended": false,
+      "comment": ""
+    }
+  ],
+  "relationTotal": 1,
+  "collects": [
+    {
+      "user": {
+        "id": 738695,
+        "username": "738695",
+        "nickname": "柊镜司姐妹盖饭",
+        "avatar": {
+          "small": "https://lain.bgm.tv/r/100/pic/user/l/000/73/86/738695.jpg?r=1691924486&hd=1",
+          "medium": "https://lain.bgm.tv/r/200/pic/user/l/000/73/86/738695.jpg?r=1691924486&hd=1",
+          "large": "https://lain.bgm.tv/pic/user/l/000/73/86/738695.jpg?r=1691924486&hd=1"
+        },
+        "group": 10,
+        "sign": "动漫真好看，不好看，好看",
+        "joinedAt": 1667374389
+      },
+      "createdAt": 1786378405
+    },
+    {
+      "user": {
+        "id": 1151593,
+        "username": "niran",
+        "nickname": "NairaMelon",
+        "avatar": {
+          "small": "https://lain.bgm.tv/r/100/pic/user/l/001/15/15/1151593_c5i4w.jpg?r=1776052535&hd=1",
+          "medium": "https://lain.bgm.tv/r/200/pic/user/l/001/15/15/1151593_c5i4w.jpg?r=1776052535&hd=1",
+          "large": "https://lain.bgm.tv/pic/user/l/001/15/15/1151593_c5i4w.jpg?r=1776052535&hd=1"
+        },
+        "group": 10,
+        "sign": "什么也不知道~",
+        "joinedAt": 1758366699
+      },
+      "createdAt": 1786282494
+    },
+    {
+      "user": {
+        "id": 1155587,
+        "username": "1155587",
+        "nickname": "X",
+        "avatar": {
+          "small": "https://lain.bgm.tv/r/100/pic/user/l/icon.jpg",
+          "medium": "https://lain.bgm.tv/r/200/pic/user/l/icon.jpg",
+          "large": "https://lain.bgm.tv/pic/user/l/icon.jpg"
+        },
+        "group": 10,
+        "sign": "",
+        "joinedAt": 1759005462
+      },
+      "createdAt": 1786054723
+    },
+    {
+      "user": {
+        "id": 560158,
+        "username": "560158",
+        "nickname": "ddltmac",
+        "avatar": {
+          "small": "https://lain.bgm.tv/r/100/pic/user/l/000/56/01/560158.jpg?r=1603280782",
+          "medium": "https://lain.bgm.tv/r/200/pic/user/l/000/56/01/560158.jpg?r=1603280782",
+          "large": "https://lain.bgm.tv/pic/user/l/000/56/01/560158.jpg?r=1603280782"
+        },
+        "group": 10,
+        "sign": "",
+        "joinedAt": 1603107817
+      },
+      "createdAt": 1785767534
+    },
+    {
+      "user": {
+        "id": 1254152,
+        "username": "wnlaaa1145",
+        "nickname": "FengfanL",
+        "avatar": {
+          "small": "https://lain.bgm.tv/r/100/pic/user/l/001/25/41/1254152_SADrs.jpg?r=1785701441&hd=1",
+          "medium": "https://lain.bgm.tv/r/200/pic/user/l/001/25/41/1254152_SADrs.jpg?r=1785701441&hd=1",
+          "large": "https://lain.bgm.tv/pic/user/l/001/25/41/1254152_SADrs.jpg?r=1785701441&hd=1"
+        },
+        "group": 10,
+        "sign": "夕暮れの涙が出そうな赤",
+        "joinedAt": 1780341859
+      },
+      "createdAt": 1785606323
+    }
+  ],
+  "collectTotal": 47,
+  "comments": [
+    {
+      "id": 414222,
+      "mainID": 174916,
+      "creatorID": 658426,
+      "relatedID": 0,
+      "createdAt": 1778829996,
+      "content": "年度神人奖你至少要有个提名",
+      "state": 0,
+      "replies": [
+        {
+          "id": 416646,
+          "mainID": 174916,
+          "creatorID": 658426,
+          "relatedID": 414222,
+          "createdAt": 1780279028,
+          "content": "算了你还是拿冠军吧",
+          "state": 0,
+          "relatedPhotoID": 0,
+          "user": {
+            "id": 658426,
+            "username": "zheer",
+            "nickname": "折耳",
+            "avatar": {
+              "small": "https://lain.bgm.tv/r/100/pic/user/l/icon.jpg",
+              "medium": "https://lain.bgm.tv/r/200/pic/user/l/icon.jpg",
+              "large": "https://lain.bgm.tv/pic/user/l/icon.jpg"
+            },
+            "group": 10,
+            "sign": "",
+            "joinedAt": 1641544401
+          }
+        }
+      ],
+      "relatedPhotoID": 0,
+      "user": {
+        "id": 658426,
+        "username": "zheer",
+        "nickname": "折耳",
+        "avatar": {
+          "small": "https://lain.bgm.tv/r/100/pic/user/l/icon.jpg",
+          "medium": "https://lain.bgm.tv/r/200/pic/user/l/icon.jpg",
+          "large": "https://lain.bgm.tv/pic/user/l/icon.jpg"
+        },
+        "group": 10,
+        "sign": "",
+        "joinedAt": 1641544401
+      }
+    },
+    {
+      "id": 418591,
+      "mainID": 174916,
+      "creatorID": 890738,
+      "relatedID": 0,
+      "createdAt": 1781522348,
+      "content": "尼古丁真说是",
+      "state": 0,
+      "replies": [],
+      "relatedPhotoID": 0,
+      "user": {
+        "id": 890738,
+        "username": "890738",
+        "nickname": "望海散人",
+        "avatar": {
+          "small": "https://lain.bgm.tv/r/100/pic/user/l/000/89/07/890738.jpg?r=1720021744&hd=1",
+          "medium": "https://lain.bgm.tv/r/200/pic/user/l/000/89/07/890738.jpg?r=1720021744&hd=1",
+          "large": "https://lain.bgm.tv/pic/user/l/000/89/07/890738.jpg?r=1720021744&hd=1"
+        },
+        "group": 10,
+        "sign": "爱写歪诗评动画，糖精厕纸也风流。",
+        "joinedAt": 1720020786
+      }
+    },
+    {
+      "id": 420980,
+      "mainID": 174916,
+      "creatorID": 515909,
+      "relatedID": 0,
+      "createdAt": 1783011072,
+      "content": "？？？感觉我的人设被偷了，还被加上了奇怪的东西。(bgm38)",
+      "state": 0,
+      "replies": [],
+      "relatedPhotoID": 0,
+      "user": {
+        "id": 515909,
+        "username": "omico",
+        "nickname": "Omico",
+        "avatar": {
+          "small": "https://lain.bgm.tv/r/100/pic/user/l/000/51/59/515909_wOoU4.jpg?r=1758389799&hd=1",
+          "medium": "https://lain.bgm.tv/r/200/pic/user/l/000/51/59/515909_wOoU4.jpg?r=1758389799&hd=1",
+          "large": "https://lain.bgm.tv/pic/user/l/000/51/59/515909_wOoU4.jpg?r=1758389799&hd=1"
+        },
+        "group": 10,
+        "sign": "",
+        "joinedAt": 1576886626
+      }
+    }
+  ],
+  "photos": [],
+  "photoTotal": 0,
+  "indexes": [
+    {
+      "id": 98833,
+      "uid": 855941,
+      "type": 0,
+      "title": "杯子测评",
+      "private": false,
+      "total": 49,
+      "stats": { "subject": {}, "character": 46, "person": 3 },
+      "createdAt": 1779044179,
+      "updatedAt": 1785772801,
+      "user": {
+        "id": 855941,
+        "username": "855941",
+        "nickname": "刷； ；牙",
+        "avatar": {
+          "small": "https://lain.bgm.tv/r/100/pic/user/l/000/85/59/855941_36W4W.jpg?r=1771217925&hd=1",
+          "medium": "https://lain.bgm.tv/r/200/pic/user/l/000/85/59/855941_36W4W.jpg?r=1771217925&hd=1",
+          "large": "https://lain.bgm.tv/pic/user/l/000/85/59/855941_36W4W.jpg?r=1771217925&hd=1"
+        },
+        "group": 10,
+        "sign": "你喜欢这所学校吗？我非常非常喜欢......",
+        "joinedAt": 1707618431
+      }
+    },
+    {
+      "id": 101868,
+      "uid": 933598,
+      "type": 0,
+      "title": "一群可悲的穷逼，不禁潸然泪下",
+      "private": false,
+      "total": 28,
+      "stats": { "subject": { "game": 1 }, "character": 27 },
+      "createdAt": 1785313049,
+      "updatedAt": 1786065871,
+      "user": {
+        "id": 933598,
+        "username": "kesson",
+        "nickname": "徐铁娘",
+        "avatar": {
+          "small": "https://lain.bgm.tv/r/100/pic/user/l/000/93/35/933598_2B184.jpg?r=1783069731&hd=1",
+          "medium": "https://lain.bgm.tv/r/200/pic/user/l/000/93/35/933598_2B184.jpg?r=1783069731&hd=1",
+          "large": "https://lain.bgm.tv/pic/user/l/000/93/35/933598_2B184.jpg?r=1783069731&hd=1"
+        },
+        "group": 10,
+        "sign": "中国农民,热爱土地与种子",
+        "joinedAt": 1731408688
+      }
+    },
+    {
+      "id": 85888,
+      "uid": 868301,
+      "type": 0,
+      "title": "我印象深刻/喜歡的角色",
+      "private": false,
+      "total": 37,
+      "stats": { "subject": {}, "character": 36, "blog": 1 },
+      "createdAt": 1765128640,
+      "updatedAt": 1785432201,
+      "user": {
+        "id": 868301,
+        "username": "868301",
+        "nickname": "12300",
+        "avatar": {
+          "small": "https://lain.bgm.tv/r/100/pic/user/l/icon.jpg",
+          "medium": "https://lain.bgm.tv/r/200/pic/user/l/icon.jpg",
+          "large": "https://lain.bgm.tv/pic/user/l/icon.jpg"
+        },
+        "group": 10,
+        "sign": "",
+        "joinedAt": 1712486906
+      }
+    },
+    {
+      "id": 85649,
+      "uid": 691012,
+      "type": 0,
+      "title": "有兴趣的女角色们",
+      "private": false,
+      "total": 4575,
+      "stats": { "subject": {}, "character": 4575 },
+      "createdAt": 1764823259,
+      "updatedAt": 1786234755,
+      "user": {
+        "id": 691012,
+        "username": "691012",
+        "nickname": "moret",
+        "avatar": {
+          "small": "https://lain.bgm.tv/r/100/pic/user/l/000/69/10/691012.jpg?r=1734349059&hd=1",
+          "medium": "https://lain.bgm.tv/r/200/pic/user/l/000/69/10/691012.jpg?r=1734349059&hd=1",
+          "large": "https://lain.bgm.tv/pic/user/l/000/69/10/691012.jpg?r=1734349059&hd=1"
+        },
+        "group": 10,
+        "sign": "再看一部番",
+        "joinedAt": 1651858223
+      }
+    }
+  ],
+  "indexTotal": 11
+}

--- a/packages/website/src/pages/index/character/[id]/fixtures/character-174916.ts
+++ b/packages/website/src/pages/index/character/[id]/fixtures/character-174916.ts
@@ -1,0 +1,5 @@
+import type { CharacterHomeResponse } from '@bangumi/website/hooks/use-character-home';
+
+import data from './character-174916.json';
+
+export const character174916Fixture: CharacterHomeResponse = data;

--- a/packages/website/src/pages/index/character/[id]/index.tsx
+++ b/packages/website/src/pages/index/character/[id]/index.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+import { UnreadableCodeError } from '@bangumi/utils';
+import { withErrorBoundary } from '@bangumi/website/components/ErrorBoundary';
+import { useCharacterHome } from '@bangumi/website/hooks/use-character-home';
+
+import CharacterDetail from './CharacterDetail';
+
+function CharacterPage() {
+  const { id } = useParams();
+  const characterID = Number(id);
+
+  if (!Number.isInteger(characterID) || characterID <= 0) {
+    throw new UnreadableCodeError('BUG: character id is invalid');
+  }
+
+  const { data } = useCharacterHome(characterID);
+
+  if (!data) {
+    return null;
+  }
+
+  return <CharacterDetail data={data} />;
+}
+
+export default withErrorBoundary(CharacterPage, {
+  404: () => <div>没有找到角色</div>,
+});

--- a/packages/website/src/routes.tsx
+++ b/packages/website/src/routes.tsx
@@ -17,6 +17,7 @@ const GroupReplyEdit = lazy(async () => import('./pages/index/group/reply/[id]/e
 const GroupTopic = lazy(async () => import('./pages/index/group/topic/[id]'));
 const GroupTopicEdit = lazy(async () => import('./pages/index/group/topic/[id]/edit'));
 const GroupTopicHome = lazy(async () => import('./pages/index/group/topic/[id]/index'));
+const Character = lazy(async () => import('./pages/index/character/[id]/index'));
 const Subject = lazy(async () => import('./pages/index/subject/[id]/index'));
 const SubjectEpisodes = lazy(async () => import('./pages/index/subject/[id]/ep'));
 const SubjectSearch = lazy(async () => import('./pages/index/subject_search/[keyword]'));
@@ -40,7 +41,6 @@ const legacyPagePaths = [
   'award/2021',
   'blog/:id',
   'calendar',
-  'character/:id',
   'dev/app',
   'dollars',
   'ep/:id',
@@ -137,6 +137,10 @@ export const pageRoutes: RouteObject[] = [
             ],
           },
         ],
+      },
+      {
+        path: 'character/:id',
+        element: <Character />,
       },
       {
         path: 'subject',


### PR DESCRIPTION
## 改动内容

新增角色主页（概览页）：

- `character/:id` 路由注册，从 legacy 重定向列表中移除
- 新增 `useCharacterHome` hook，并行请求角色信息、出演、关联角色、收藏者、吐槽箱、相册预览、推荐目录
- `CharacterDetail` 组件渲染：信息框、推荐本角色的目录、谁收藏了、出演、关联角色、相册（无数据时不渲染）、吐槽箱
- 登录用户可收藏 / 取消收藏角色

## 测试

- 新增 `CharacterDetail.spec.tsx`：覆盖整体渲染、未收藏时收藏、已收藏时取消收藏
- 更新 `LegacyRedirect.spec.tsx`：`/character/:id` 不再是 legacy 路由

## 验证

- `pnpm test`：279 passed
- `pnpm type-check`、`pnpm lint`、`pnpm lint:style`、`pnpm prettier:check`（本次改动文件）通过
- `pnpm build` 成功