### PR TITLE
fix(website): improve PrgManager responsive layout

### DIFF
--- a/packages/website/src/pages/index/index/components/PrgManager.module.less
+++ b/packages/website/src/pages/index/index/components/PrgManager.module.less
@@ -581,8 +581,14 @@
   }
 
   .splitView {
-    grid-template-columns: 132px minmax(0, 1fr);
-    height: 300px;
+    grid-template-columns: 1fr;
+    grid-template-rows: 160px auto;
+    height: auto;
+  }
+
+  .subjectList {
+    border-right: none;
+    border-bottom: 1px solid @gray-10;
   }
 
   .navButton {
@@ -619,6 +625,10 @@
 
   .subjectActions {
     flex-wrap: wrap;
+  }
+
+  .gridList {
+    grid-template-columns: 1fr;
   }
 }
 


### PR DESCRIPTION
按参考实现 `bangumi/Bangumi`（PHP 版）的窄屏行为修复首页进度管理器 `PrgManager` 的响应式布局：

- 列表视图（章节详情布局）：`@media (max-width: @sm)`（640px）下由两列（左侧条目导航 + 右侧详情）改为上下堆叠——条目导航全宽、限高 160px 可滚动（每个条目一行），章节详情全宽在下方，对齐 PHP 版 `#listWrapper` 160px + 详情全宽的行为。
- 网格视图（平铺模式）：窄屏下由两列改为单列，对齐 PHP 版 tiny 模式 640px 下 `grid-template-columns: 1fr` 的行为。

改动仅涉及 `PrgManager.module.less` 的样式，不涉及组件逻辑。已运行 stylelint、prettier、`HomePage.spec.tsx` 验证通过。
