### PR TITLE
fix(website): align mobile header gutter

### DIFF
--- a/packages/website/e2e/specs/main.spec.ts
+++ b/packages/website/e2e/specs/main.spec.ts
@@ -7,10 +7,20 @@ test.describe('main page', () => {
     await page.goto('/');
     await expect(page).toHaveTitle('Bangumi 番组计划');
   });
+
+  test('移动端 Header 与页面主体使用相同的水平留白', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto('/');
+
+    const headerContent = page.locator('header > div').first();
+    await expect(headerContent).toHaveCSS('padding-left', '16px');
+    await expect(headerContent).toHaveCSS('padding-right', '16px');
+  });
 });
 
 test.describe('已登录用户', () => {
   testAsUser('treeholechan');
+
   test('应该能够看到收藏菜单', async ({ page }) => {
     await page.goto('/');
     await expect(

--- a/packages/website/src/components/Header/style.module.less
+++ b/packages/website/src/components/Header/style.module.less
@@ -244,6 +244,13 @@
   }
 }
 
+@media screen and (max-width: @sm) {
+  .main {
+    padding-right: 16px;
+    padding-left: 16px;
+  }
+}
+
 @media screen and (max-width: 576px) {
   .container {
     height: 50px;
@@ -251,7 +258,6 @@
 
   .logo {
     width: 110px;
-    margin-left: 12px;
 
     .musume {
       display: none;


### PR DESCRIPTION
## Summary

- Align the mobile Header gutter with `PageContainer` below the shared `@sm` breakpoint.
- Remove the extra mobile Logo offset.
- Add a 375px Playwright regression assertion.

## Verification

- `pnpm build`
- Prettier and Stylelint on changed files
- 375px homepage screenshot

## Test Note

The focused Playwright run could not complete locally because the existing authentication setup depends on Cloudflare Turnstile, and a subsequent public-only run stalled while starting the configured web server.