### PR TITLE
fix(website): compact progress chapter controls

### DIFF
--- a/packages/website/e2e/specs/main.spec.ts
+++ b/packages/website/e2e/specs/main.spec.ts
@@ -15,7 +15,9 @@ test.describe('main page', () => {
     const headerContent = page.locator('header > div').first();
     await expect(headerContent).toHaveCSS('padding-left', '16px');
     await expect(headerContent).toHaveCSS('padding-right', '16px');
-    await expect.poll(async () => page.evaluate(() => document.documentElement.scrollWidth)).toBe(375);
+    await expect
+      .poll(async () => page.evaluate(() => document.documentElement.scrollWidth))
+      .toBe(375);
   });
 });
 

--- a/packages/website/src/pages/index/index/HomePage.spec.tsx
+++ b/packages/website/src/pages/index/index/HomePage.spec.tsx
@@ -3,6 +3,7 @@ import { http, HttpResponse } from 'msw';
 import React from 'react';
 import { SWRConfig } from 'swr';
 
+import { SubjectType } from '@bangumi/client/client';
 import { server as mockServer } from '@bangumi/website/mocks/server';
 import { renderPage } from '@bangumi/website/utils/test-utils';
 
@@ -300,6 +301,32 @@ describe('HomePage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: '列表视图' }));
     expect(window.localStorage.getItem('bangumi-home-progress-view')).toBe('list');
+  });
+
+  it('should hide books from the default progress filter', async () => {
+    const progress = homeFixture.progress[0]!;
+    const bookProgress = {
+      ...progress,
+      subject: {
+        ...progress.subject,
+        id: 13,
+        type: SubjectType.Book,
+        name: 'Test Book',
+        nameCN: '测试书籍',
+      },
+      eps: [],
+    };
+    mockServer.use(
+      http.get('http://localhost:3000/p1/home', () =>
+        HttpResponse.json({ ...homeFixture, progress: [progress, bookProgress] }, { status: 200 }),
+      ),
+    );
+    await renderHome();
+
+    expect(screen.queryByText('Test Book')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '书籍' }));
+    expect(await screen.findByText('Test Book')).toBeInTheDocument();
   });
 
   it('should update episode status from the grid view detail popover', async () => {

--- a/packages/website/src/pages/index/index/components/PrgManager.module.less
+++ b/packages/website/src/pages/index/index/components/PrgManager.module.less
@@ -84,7 +84,7 @@
 .splitView {
   display: grid;
   grid-template-columns: 225px minmax(0, 1fr);
-  height: 234px;
+  height: 280px;
   min-height: 0;
 }
 
@@ -181,11 +181,12 @@
   min-width: 0;
   margin: 0;
   padding: 0;
-  overflow: visible;
+  overflow-x: hidden;
+  overflow-y: auto;
   list-style: none;
 
   .card {
-    height: 100%;
+    min-height: 100%;
     box-sizing: border-box;
   }
 
@@ -201,7 +202,7 @@
 
   .epList {
     margin-top: 10px;
-    padding-top: 8px;
+    padding: 8px 0 28px;
     border-top: 1px solid @gray-10;
   }
 }
@@ -418,6 +419,8 @@
   position: absolute;
   right: 10px;
   bottom: 7px;
+  padding-left: 8px;
+  background: #fff;
   font-size: 14px;
 }
 
@@ -546,7 +549,7 @@
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 4px;
+  gap: 3px;
 }
 
 .epSubtitle {
@@ -558,12 +561,12 @@
 .epBtn,
 .epBtnWatched,
 .epBtnUnavailable {
-  min-width: 29px;
-  padding: 3px 5px;
+  min-width: 24px;
+  padding: 2px 4px;
   border: 1px solid @gray-10;
   border-radius: 4px;
-  font-size: 13px;
-  line-height: 18px;
+  font-size: 12px;
+  line-height: 16px;
   text-align: center;
   cursor: pointer;
   font-family: 'Lucida Grande', 'Lucida Sans', Helvetica, Arial, Verdana, sans-serif;
@@ -629,6 +632,14 @@
 
   .gridList {
     grid-template-columns: 1fr;
+  }
+
+  .epBtn,
+  .epBtnWatched,
+  .epBtnUnavailable {
+    min-width: 22px;
+    padding: 1px 3px;
+    font-size: 11px;
   }
 }
 

--- a/packages/website/src/pages/index/index/components/PrgManager.tsx
+++ b/packages/website/src/pages/index/index/components/PrgManager.tsx
@@ -476,8 +476,9 @@ const PrgManager: React.FC<{ progress: ProgressItem[] }> = ({ progress }) => {
   const [view, setView] = useState<ViewMode>(getInitialView);
   const [selectedSubjectId, setSelectedSubjectId] = useState(progress[0]?.subject.id);
 
-  const filtered =
-    activeType === 0 ? progress : progress.filter((item) => item.subject.type === activeType);
+  const filtered = progress.filter((item) =>
+    activeType === 0 ? item.subject.type !== SubjectType.Book : item.subject.type === activeType,
+  );
   const selected =
     filtered.find((item) => item.subject.id === selectedSubjectId) ?? filtered[0] ?? null;
 


### PR DESCRIPTION
## Summary

- Keep split-view chapter details inside a 280px scrollable panel.
- Compact chapter controls to match the legacy implementation and reserve space for the all-episodes link.
- Hide books from the default progress filter; show them only in the Books tab.

## Verification

- `pnpm test packages/website/src/pages/index/index/HomePage.spec.tsx`
- `pnpm build`
- Prettier, Stylelint, and `git diff --check`
- Fixture-backed desktop and 375px mobile screenshots