### PR TITLE
fix(website): restore mobile header menu

### DIFF
--- a/packages/website/e2e/specs/main.spec.ts
+++ b/packages/website/e2e/specs/main.spec.ts
@@ -19,6 +19,49 @@ test.describe('main page', () => {
       .poll(async () => page.evaluate(() => document.documentElement.scrollWidth))
       .toBe(375);
   });
+
+  test('移动端可以展开导航菜单', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto('/');
+
+    const toggle = page.getByRole('button', { name: '菜单' });
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+    await toggle.click();
+
+    const navigation = page.locator('#mobile-navigation');
+    await expect(toggle).toHaveAccessibleName('关闭菜单');
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    await expect(navigation).toBeVisible();
+    await expect(navigation.getByRole('textbox', { name: '搜索' })).toBeVisible();
+    await expect(navigation.getByRole('link', { name: '动画' })).toBeVisible();
+  });
+
+  test('移动端已登录操作区保持水平对齐', async ({ page }) => {
+    await page.route('**/p1/me', async (route) => {
+      await route.fulfill({
+        json: {
+          id: 1,
+          username: 'test-user',
+          nickname: '测试用户',
+          avatar: {
+            small: '/favicon.ico',
+            medium: '/favicon.ico',
+            large: '/favicon.ico',
+          },
+        },
+      });
+    });
+    await page.setViewportSize({ width: 436, height: 812 });
+    await page.goto('/');
+
+    const actions = page.locator('header > div > div:last-child');
+    await expect(actions).toHaveCSS('display', 'flex');
+    await expect(actions).toHaveCSS('align-items', 'center');
+    await expect(page.getByRole('button', { name: '搜索' })).toBeVisible();
+    await expect(page.locator('a[href="/notifications"]')).toBeVisible();
+    await expect(page.locator('header a[href="/user/test-user"]')).toBeVisible();
+  });
 });
 
 test.describe('已登录用户', () => {

--- a/packages/website/src/components/Header/index.spec.tsx
+++ b/packages/website/src/components/Header/index.spec.tsx
@@ -1,10 +1,11 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 
 import { UserProvider } from '@bangumi/website/hooks/use-user';
 
 import Header from '.';
+import style from './style.module.less';
 
 const renderHeader = () =>
   render(
@@ -35,5 +36,26 @@ describe('Header', () => {
     await waitFor(() => {
       expect(container.querySelector('a[href="/user/382951"]')).toBeInTheDocument();
     });
+  });
+
+  it('点击菜单按钮会切换移动端导航', () => {
+    const { container } = renderHeader();
+
+    const toggle = screen.getByRole('button', { name: '菜单' });
+    const navigation = container.querySelector('#mobile-navigation');
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(navigation).toHaveAttribute('hidden');
+    expect(navigation).not.toHaveClass(style.mobileNavigationOpen!);
+
+    fireEvent.click(toggle);
+
+    expect(screen.getByRole('button', { name: '关闭菜单' })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+    expect(navigation).not.toHaveAttribute('hidden');
+    expect(navigation).toHaveClass(style.mobileNavigationOpen!);
+    expect(screen.getByRole('textbox', { name: '搜索' })).toBeInTheDocument();
   });
 });

--- a/packages/website/src/components/Header/index.tsx
+++ b/packages/website/src/components/Header/index.tsx
@@ -86,6 +86,8 @@ const navRight = [
   },
 ];
 
+const mobileNav = [...navLeft, ...navRight];
+
 function getRandomNumber(n: number): number {
   return Math.floor(Math.random() * n);
 }
@@ -107,7 +109,7 @@ const Header: FC = () => {
     <header className={style.container}>
       <div className={style.main}>
         {/* left */}
-        <div className='flex items-center'>
+        <div className={cn('flex items-center', style.headerLeft)}>
           {/* Logo */}
           <a className={style.logo} href='/'>
             <Musume className={style.musume} />
@@ -115,13 +117,18 @@ const Header: FC = () => {
           </a>
           {/* Mobile Menu Toggle Button */}
           <Button
-            className={style.mobileMenuToggle}
-            color={showMobileMenu ? 'default' : 'gray'}
+            className={cn(style.mobileMenuToggle, {
+              [style.mobileMenuToggleOpen!]: showMobileMenu,
+            })}
+            color='gray'
+            aria-controls='mobile-navigation'
+            aria-expanded={showMobileMenu}
+            aria-label={showMobileMenu ? '关闭菜单' : '菜单'}
             onClick={() => {
               setShowMobileMenu((show) => !show);
             }}
           >
-            {showMobileMenu ? '关闭' : '菜单'}
+            <span className={style.mobileMenuIcon} aria-hidden='true' />
           </Button>
           {/* Menu */}
           <div className={style.nav}>
@@ -133,6 +140,9 @@ const Header: FC = () => {
 
         {/* right */}
         <div className={style.headerRight}>
+          <button className={style.mobileSearchButton} type='button' aria-label='搜索'>
+            <SearchIcon />
+          </button>
           <div className={style.infoBox}>
             {/* Search Todo */}
             <Input
@@ -183,6 +193,41 @@ const Header: FC = () => {
           )}
         </div>
       </div>
+      <nav
+        id='mobile-navigation'
+        aria-label='主导航'
+        hidden={!showMobileMenu}
+        className={cn(style.mobileNavigation, {
+          [style.mobileNavigationOpen!]: showMobileMenu,
+        })}
+      >
+        <Input
+          aria-label='搜索'
+          prefix={
+            <>
+              <select name='mobile-cat' className={style.mobileSearchSelect} defaultValue='value1'>
+                <option value='value1'>动画</option>
+                <option value='value2'>书籍</option>
+                <option value='value3'>音乐</option>
+                <option value='value4'>游戏</option>
+                <option value='value5'>三次元</option>
+                <option value='value6'>人物</option>
+              </select>
+              <Divider orientation='vertical' className={style.mobileSearchDivider} />
+            </>
+          }
+          suffix={<SearchIcon className={style.mobileSearchInputIcon} />}
+          wrapperClass={style.mobileSearch}
+        />
+        <Menu
+          items={mobileNav}
+          mode='vertical'
+          onClick={() => {
+            setShowMobileMenu(false);
+          }}
+          wrapperClass={style.mobileNavigationMenu}
+        />
+      </nav>
     </header>
   );
 };

--- a/packages/website/src/components/Header/style.module.less
+++ b/packages/website/src/components/Header/style.module.less
@@ -3,6 +3,7 @@
 @header-height: 60px;
 
 .container {
+  position: relative;
   height: @header-height;
   box-sizing: border-box;
   background: rgba(255, 255, 255, 0.95);
@@ -55,6 +56,15 @@
   display: none;
 }
 
+.mobileNavigation,
+.mobileSearchButton {
+  display: none;
+}
+
+.headerLeft {
+  min-width: 0;
+}
+
 .nav {
   display: flex;
   align-items: center;
@@ -83,7 +93,7 @@
   }
 }
 
-.header-right {
+.headerRight {
   .flex();
   .items-center();
 
@@ -234,37 +244,216 @@
   }
 }
 
-@media screen and (max-width: 768px) {
-  .mobileMenuToggle {
-    display: block;
+@media screen and (max-width: @sm) {
+  .nav {
+    display: none;
   }
 
-  .navLeft {
-    display: none !important;
+  .mobileMenuToggle {
+    display: block;
+    flex: 0 0 40px;
+    width: 40px;
+    height: 32px;
+    padding: 0;
+    margin-left: 10px;
+    color: @gray-60;
+    background: transparent;
+    border: 1px solid @gray-10;
+
+    --height: 32px;
+  }
+
+  .mobileMenuToggle.mobileMenuToggleOpen {
+    color: #fff;
+    background: @primary-color;
+    border-color: @primary-color;
+  }
+
+  .mobileMenuIcon {
+    position: relative;
+    width: 14px;
+    height: 2px;
+    background: currentcolor;
+    border-radius: 1px;
+
+    &::before,
+    &::after {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 14px;
+      height: 2px;
+      content: '';
+      background: currentcolor;
+      border-radius: 1px;
+    }
+
+    &::before {
+      top: -5px;
+    }
+
+    &::after {
+      top: 5px;
+    }
+  }
+
+  .mobileMenuToggleOpen .mobileMenuIcon {
+    background: transparent;
+
+    &::before,
+    &::after {
+      top: 0;
+    }
+
+    &::before {
+      transform: rotate(45deg);
+    }
+
+    &::after {
+      transform: rotate(-45deg);
+    }
+  }
+
+  .mobileNavigation {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    z-index: 1;
+    width: 100%;
+    padding: 4px 10px 0;
+    box-sizing: border-box;
+    background: rgba(254, 254, 254, 0.9);
+    border-bottom: rgba(249, 188, 193, 0.95) solid 1px;
+    box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.04);
+    backdrop-filter: blur(5px);
+
+    &.mobileNavigationOpen {
+      display: block;
+    }
+  }
+
+  .mobileSearch {
+    display: flex;
+    width: 100%;
+    height: 34px;
+    padding: 3px 12px;
+    margin-bottom: 16px;
+
+    .mobileSearchSelect {
+      appearance: none;
+      padding: 0;
+      outline: none;
+      border: none;
+      color: @gray-80;
+      background: transparent;
+      font-weight: 600;
+    }
+
+    .mobileSearchDivider {
+      display: inline-block;
+      height: 20px;
+      margin: 0 9px 0 7px;
+      flex-shrink: 0;
+    }
+
+    .mobileSearchInputIcon {
+      width: 18px;
+      height: 18px;
+      margin-left: 8px;
+    }
+  }
+
+  .mobileNavigationMenu {
+    display: flex;
+    align-items: stretch;
+    width: calc(100% + 20px);
+    padding: 0;
+    margin: 0 -10px;
+
+    > :global(.bgm-menu-item) {
+      width: 100%;
+      padding: 5px 0;
+      box-sizing: border-box;
+      color: @gray-60;
+      font-size: 14px;
+      font-weight: 600;
+      line-height: 30px;
+      text-align: center;
+
+      &:nth-child(-n + 5) {
+        background: #f7f7f7;
+      }
+
+      &:first-child {
+        color: #fff;
+        background: @primary-color;
+      }
+    }
+  }
+
+  .infoBox {
+    display: none;
+  }
+
+  .mobileSearchButton {
+    display: flex;
+    padding: 0;
+    color: @pink-80;
+    background: transparent;
+    border: 0;
+
+    svg {
+      width: 20px;
+      height: 20px;
+    }
   }
 }
 
 @media screen and (max-width: @sm) {
   .main {
-    padding-right: 16px;
-    padding-left: 16px;
+    padding-right: 5px;
+    padding-left: 5px;
   }
-}
 
-@media screen and (max-width: 576px) {
   .container {
     height: 50px;
   }
 
   .logo {
-    width: 110px;
+    width: 143px;
+    height: 50px;
 
     .musume {
-      display: none;
+      display: block;
+      width: 36px;
+      height: 42px;
     }
 
     .textLogo {
+      top: 5px;
       width: 110px;
+      height: 32px;
+    }
+  }
+
+  .headerRight {
+    gap: 18px;
+  }
+
+  .userLogin {
+    width: 78px;
+
+    a {
+      font-size: 12px;
+
+      &:first-of-type {
+        padding-right: 7px;
+      }
+
+      &:last-of-type {
+        padding-left: 7px;
+      }
     }
   }
 }


### PR DESCRIPTION
## 变更

- 恢复移动端 Header 菜单的展开与关闭行为，并按旧版断点调整布局。
- 修正登录态操作区的 CSS Modules 类名冲突和移动端错位。
- 补充 Header 单测与移动端 Playwright 覆盖。

## 验证

- 本次未重新执行完整测试，按请求直接创建 PR。