### PR TITLE
fix(website): hide empty subject infobox values and apply predefined order

### DIFF
--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -7,6 +7,8 @@ export {
 } from '@bgm38/wiki';
 export { toWikiElement, fromWikiElement, WikiElement, mergeWiki, WikiTemplate } from './wiki';
 export type { Wiki } from '@bgm38/wiki';
+export { formatSubjectInfobox } from './infobox';
+export type { Infobox, InfoboxItem, InfoboxValue } from './infobox';
 export * from './bbcode';
 
 /**

--- a/packages/utils/infobox.spec.ts
+++ b/packages/utils/infobox.spec.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatSubjectInfobox } from './infobox';
+
+describe('formatSubjectInfobox', () => {
+  it('应隐藏 values 为空数组的项', () => {
+    const infobox = [
+      { key: '中文名', values: [] },
+      { key: '话数', values: [{ v: '12' }] },
+    ];
+    expect(formatSubjectInfobox(infobox)).toEqual([{ key: '话数', values: [{ v: '12' }] }]);
+  });
+
+  it('应隐藏 values 全为空字符串的项', () => {
+    const infobox = [
+      { key: '导演', values: [{ v: '' }] },
+      { key: '话数', values: [{ v: '12' }] },
+    ];
+    expect(formatSubjectInfobox(infobox)).toEqual([{ key: '话数', values: [{ v: '12' }] }]);
+  });
+
+  it('应过滤纯空白的 value 并只保留非空子项', () => {
+    const infobox = [
+      { key: '别名', values: [{ v: 'ワンピース エルバフ編' }, { v: '  ' }, { v: '' }] },
+    ];
+    expect(formatSubjectInfobox(infobox)).toEqual([
+      { key: '别名', values: [{ v: 'ワンピース エルバフ編' }] },
+    ]);
+  });
+
+  it('应隐藏 key 为空字符串的项', () => {
+    const infobox = [
+      { key: '', values: [{ v: 'x' }] },
+      { key: '话数', values: [{ v: '12' }] },
+    ];
+    expect(formatSubjectInfobox(infobox)).toEqual([{ key: '话数', values: [{ v: '12' }] }]);
+  });
+
+  it('应将置顶 key 按预定顺序排在最前', () => {
+    const infobox = [
+      { key: '放送星期', values: [{ v: '星期日' }] },
+      { key: '放送开始', values: [{ v: '2026年4月5日' }] },
+      { key: '话数', values: [{ v: '*' }] },
+      { key: '中文名', values: [{ v: '航海王 埃鲁巴夫篇' }] },
+      { key: '别名', values: [{ v: '海贼王' }] },
+    ];
+    expect(formatSubjectInfobox(infobox).map((item) => item.key)).toEqual([
+      '中文名',
+      '话数',
+      '放送开始',
+      '放送星期',
+      '别名',
+    ]);
+  });
+
+  it('应将链接类 key 按预定顺序排到最后', () => {
+    const infobox = [
+      { key: '官方网站', values: [{ v: 'https://one-piece.com/' }] },
+      { key: '话数', values: [{ v: '*' }] },
+      { key: 'Blog', values: [{ v: 'https://blog.example' }] },
+      { key: '播放电视台', values: [{ v: 'フジテレビ' }] },
+    ];
+    expect(formatSubjectInfobox(infobox).map((item) => item.key)).toEqual([
+      '话数',
+      '播放电视台',
+      '官方网站',
+      'Blog',
+    ]);
+  });
+
+  it('应保持非置顶非置底项的原顺序', () => {
+    const infobox = [
+      { key: '音乐', values: [{ v: '田中公平' }] },
+      { key: '原作', values: [{ v: '尾田栄一郎' }] },
+      { key: '动画制作', values: [{ v: '東映アニメーション' }] },
+    ];
+    expect(formatSubjectInfobox(infobox).map((item) => item.key)).toEqual([
+      '音乐',
+      '原作',
+      '动画制作',
+    ]);
+  });
+
+  it('组合场景：过滤空值后按 置顶 → 原顺序 → 链接 排列', () => {
+    const infobox = [
+      { key: '导演', values: [{ v: '' }] },
+      { key: '话数', values: [{ v: '*' }] },
+      { key: '官方网站', values: [{ v: 'https://one-piece.com/' }] },
+      { key: '别名', values: [{ v: '海贼王' }] },
+      { key: '播放电视台', values: [{ v: '' }] },
+      { key: '放送开始', values: [{ v: '2026年4月5日' }] },
+      { key: '中文名', values: [{ v: '航海王 埃鲁巴夫篇' }] },
+    ];
+    expect(formatSubjectInfobox(infobox).map((item) => item.key)).toEqual([
+      '中文名',
+      '话数',
+      '放送开始',
+      '别名',
+      '官方网站',
+    ]);
+  });
+});

--- a/packages/utils/infobox.ts
+++ b/packages/utils/infobox.ts
@@ -1,0 +1,69 @@
+/**
+ * infobox 展示格式化工具，对齐 PHP 旧站 ChiiCodeCore::formatWikiCode 的规则：
+ * - 空值项不显示（解析阶段 PHP 会跳过空值，API 返回仍可能携带空项）
+ * - 置顶 key 优先显示，链接类 key 排到末尾，其余保持原顺序
+ */
+
+export interface InfoboxValue {
+  k?: string;
+  v: string;
+}
+
+export interface InfoboxItem {
+  key: string;
+  values: InfoboxValue[];
+}
+
+export type Infobox = InfoboxItem[];
+
+/** 置顶 key，按此顺序排列在 infobox 最前（对应 PHP $wiki_pin_set） */
+const PIN_KEYS = ['中文名', '册数', '话数', '放送开始', '放送星期'];
+
+/** 置底 key，按此顺序排列在 infobox 末尾（对应 PHP $wiki_link_set） */
+const LINK_KEYS = [
+  '链接',
+  '相关链接',
+  '官网',
+  '官方网站',
+  'website',
+  '引用来源',
+  'HP',
+  '个人博客',
+  '博客',
+  'Blog',
+  '主页',
+];
+
+/**
+ * 过滤空值并按预定顺序重排 subject infobox。
+ *
+ * @param infobox 服务端返回的 infobox
+ * @returns 过滤空值后的 infobox，顺序为：置顶 key → 其余原顺序 → 链接类 key
+ */
+export function formatSubjectInfobox(infobox: Infobox): Infobox {
+  const items = infobox
+    .map((item) => ({
+      ...item,
+      values: item.values.filter((value) => value.v.trim() !== ''),
+    }))
+    .filter((item) => item.key !== '' && item.values.length > 0);
+
+  const pinItems: InfoboxItem[] = [];
+  const restItems: InfoboxItem[] = [];
+  const linkItems: InfoboxItem[] = [];
+
+  for (const item of items) {
+    if (PIN_KEYS.includes(item.key)) {
+      pinItems.push(item);
+    } else if (LINK_KEYS.includes(item.key)) {
+      linkItems.push(item);
+    } else {
+      restItems.push(item);
+    }
+  }
+
+  pinItems.sort((a, b) => PIN_KEYS.indexOf(a.key) - PIN_KEYS.indexOf(b.key));
+  linkItems.sort((a, b) => LINK_KEYS.indexOf(a.key) - LINK_KEYS.indexOf(b.key));
+
+  return [...pinItems, ...restItems, ...linkItems];
+}

--- a/packages/website/src/pages/index/subject/[id]/components/SubjectDetail.tsx
+++ b/packages/website/src/pages/index/subject/[id]/components/SubjectDetail.tsx
@@ -5,6 +5,7 @@ import type { SlimIndex, Subject, SubjectHomeResponse } from '@bangumi/client/cl
 import { CollectionType, SubjectType } from '@bangumi/client/client';
 import { Typography } from '@bangumi/design';
 import { Link as LinkIcon } from '@bangumi/icons';
+import { formatSubjectInfobox } from '@bangumi/utils';
 import {
   getIndexLink,
   getSubjectBoardLink,
@@ -147,6 +148,7 @@ export function SubjectHeader({ subject }: { subject: Subject }) {
 
 /** 左栏：封面与信息框，对齐 PHP subject_infobox */
 function SubjectInfobox({ subject }: { subject: Subject }) {
+  const infobox = formatSubjectInfobox(subject.infobox);
   return (
     <div className={styles.infobox}>
       {subject.images?.large != null && (
@@ -163,7 +165,7 @@ function SubjectInfobox({ subject }: { subject: Subject }) {
         </div>
       )}
       <ul className={styles.infoList}>
-        {subject.infobox.map((item) => (
+        {infobox.map((item) => (
           <li key={item.key}>
             <span className={styles.tip}>{item.key}: </span>
             <span>


### PR DESCRIPTION
## 改动内容

subject 详情页 infobox 之前会显示值为空的条目（如 `/subject/602059` 有一堆空 `key:`），且顺序与旧站不一致。

### 变更

- 新增 `packages/utils/infobox.ts` 的 `formatSubjectInfobox`，对齐 PHP 旧站 `ChiiCodeCore::formatWikiCode`：
  - 过滤空值：`values` 为空、所有 `v` 为空/纯空白或 `key` 为空的项不显示，item 内空子值也剔除
  - 排序：置顶 key（`中文名`/`册数`/`话数`/`放送开始`/`放送星期`）排最前，链接类 key（`链接`/`相关链接`/`官网`/`官方网站`/`website`/`引用来源`/`HP`/`个人博客`/`博客`/`Blog`/`主页`）按序排末尾，其余保持 API 返回顺序
- `SubjectInfobox` 渲染前先经 `formatSubjectInfobox` 处理
- 新增 `infobox.spec.ts` 单测（空值过滤 + 排序各分支）

### 限制

PHP 中 staff 部分按数据库 `prsn_position` 排序，前端 API 返回的 infobox 不含该信息，因此 staff 项保持 API 顺序，仅复刻 pin/link 置顶置底规则。

## 验证

- utils 全量 98 个测试通过（含新增 8 个）
- subject 相关页面测试 12 个通过
- `pnpm type-check`、eslint、prettier 通过