### PR TITLE
fix(subject): allow episode buttons to fit long numbers

### DIFF
--- a/packages/website/src/pages/index/subject/[id]/components/SubjectDetailBlocks.module.less
+++ b/packages/website/src/pages/index/subject/[id]/components/SubjectDetailBlocks.module.less
@@ -88,10 +88,11 @@
 
 .epBtn {
   display: inline-block;
-  width: 24px;
+  width: auto;
+  min-width: 24px;
   height: 24px;
   box-sizing: border-box;
-  padding: 0;
+  padding: 0 4px;
   text-align: center;
   border: 1px solid @gray-10;
   border-radius: 3px;


### PR DESCRIPTION
## Summary

- Keep the existing minimum episode button size while allowing long episode numbers to expand to their content.
- Preserve the current height, status styles, popover behavior, and responsive wrapping.

## Verification

- pnpm run lint
- pnpm run lint:style
- pnpm run build
- Playwright visual check at desktop and 390px mobile widths with episode numbers 98, 99, 100, 101, 115, and 1174

Tests and Prettier were not run as requested.