### PR TITLE
fix(website): keep Panda styles hot-reloading in Vite dev

### DIFF
--- a/packages/design/postcss.config.js
+++ b/packages/design/postcss.config.js
@@ -1,3 +1,10 @@
+const path = require('node:path');
+
 module.exports = {
-  plugins: [require('@pandacss/dev/postcss'), require('autoprefixer')],
+  // panda 插件需要基于仓库根解析 include glob；
+  // Vite dev 进程的 cwd 是包目录，不传 cwd 会匹配不到任何源文件。
+  plugins: [
+    require('@pandacss/dev/postcss')({ cwd: path.resolve(__dirname, '../..') }),
+    require('autoprefixer'),
+  ],
 };

--- a/packages/website/panda-dev-hmr.ts
+++ b/packages/website/panda-dev-hmr.ts
@@ -1,0 +1,42 @@
+import path from 'node:path';
+
+import type { EnvironmentModuleNode, Plugin } from 'vite';
+import { normalizePath } from 'vite';
+
+// 入口 CSS：postcss 在这里执行 @pandacss/dev/postcss，生成最新 utilities。
+// 该模块在 moduleGraph 中不依赖任何 panda 源文件，需要手动加入 HMR 更新集合。
+const ENTRY_CSS = normalizePath(path.resolve(__dirname, 'src/index.css'));
+// panda 配置，变化时需要重新生成 tokens/recipes 产物与 CSS。
+const PANDA_CONFIG = normalizePath(path.resolve(__dirname, '../../panda.config.ts'));
+
+// 与 panda.config.ts 的 include 保持一致；styled-system 是 codegen/cssgen 产物目录，
+// config 变化时产物会被重写，同样需要重新处理入口 CSS。
+const PANDA_WATCH_DIRS = ['src', '../design', '../icons', '../styled-system'].map((dir) =>
+  normalizePath(path.resolve(__dirname, dir)),
+);
+
+/**
+ * 修复 Vite dev 下 panda 样式不随源文件更新（Vite 不会把 postcss 插件注册的
+ * dependency 关联到入口 CSS 模块，导致 `index.css` 永不失效）。当 panda 相关
+ * 文件变化时，把入口 CSS 模块追加进 HMR 更新集合，触发其重新编译；
+ * panda 插件随即重新 extract 并写入最新 utilities。
+ */
+export const pandaDevHmr = (): Plugin => {
+  return {
+    name: 'panda-dev-hmr',
+    apply: 'serve',
+    hotUpdate({ file, server, modules }) {
+      const isPandaSource =
+        file === PANDA_CONFIG || PANDA_WATCH_DIRS.some((dir) => file.startsWith(dir));
+      if (!isPandaSource) {
+        return;
+      }
+
+      const cssMods = server.environments.client.moduleGraph.getModulesByFile(ENTRY_CSS);
+      if (!cssMods) {
+        return;
+      }
+      return [...new Set<EnvironmentModuleNode>([...modules, ...cssMods])];
+    },
+  };
+};

--- a/packages/website/postcss.config.js
+++ b/packages/website/postcss.config.js
@@ -1,3 +1,10 @@
+const path = require('node:path');
+
 module.exports = {
-  plugins: [require('@pandacss/dev/postcss'), require('autoprefixer')],
+  // panda 插件需要基于仓库根解析 include glob；
+  // Vite dev 进程的 cwd 是包目录，不传 cwd 会匹配不到任何源文件。
+  plugins: [
+    require('@pandacss/dev/postcss')({ cwd: path.resolve(__dirname, '../..') }),
+    require('autoprefixer'),
+  ],
 };

--- a/packages/website/tsconfig.json
+++ b/packages/website/tsconfig.json
@@ -11,5 +11,12 @@
       }
     ]
   },
-  "include": ["./src", "vite.config.ts", "test-setup.ts", "playwright.config.ts", "./e2e"]
+  "include": [
+    "./src",
+    "vite.config.ts",
+    "panda-dev-hmr.ts",
+    "test-setup.ts",
+    "playwright.config.ts",
+    "./e2e"
+  ]
 }

--- a/packages/website/vite.config.ts
+++ b/packages/website/vite.config.ts
@@ -10,6 +10,7 @@ import { defineConfig, loadEnv } from 'vite';
 import svgr from 'vite-plugin-svgr';
 
 import { version } from '../../package.json';
+import { pandaDevHmr } from './panda-dev-hmr';
 
 let COMMIT_HASH = '';
 
@@ -104,6 +105,7 @@ export default defineConfig(({ mode }) => {
       },
     },
     plugins: [
+      pandaDevHmr(),
       react(
         mode === 'production'
           ? {


### PR DESCRIPTION
## Summary

Fix Panda CSS styles not hot-reloading in Vite dev mode.

## Problem

`@pandacss/dev/postcss` registers panda source files as postcss dependencies of the entry CSS, but Vite does not link postcss-plugin-registered dependencies into its module graph, so `src/index.css` never invalidates and panda styles stay stale until a manual refresh.

Additionally, the Vite dev process runs with the package directory as cwd (`packages/website`), so the panda postcss plugin resolves its include globs relative to the package dir and matches no source files.

## Changes

- Add a `panda-dev-hmr` Vite plugin (`packages/website/panda-dev-hmr.ts`): when a panda-related file changes (`src`, `../design`, `../icons`, `../styled-system` or `panda.config.ts`), append the entry CSS module to the HMR update set so it is recompiled and the panda plugin regenerates the latest utilities.
- Pass the repo root as `cwd` to `@pandacss/dev/postcss` in both `packages/website` and `packages/design` `postcss.config.js`.
- Register the plugin in `packages/website/vite.config.ts` and include the new file in `packages/website/tsconfig.json`.

## Note

Per request, local tests were skipped.
