### PR TITLE
refactor(website): extract JsonFixture into shared mocks utils

### DIFF
--- a/packages/website/src/mocks/fixtures/p1/episodes/1704816/index.ts
+++ b/packages/website/src/mocks/fixtures/p1/episodes/1704816/index.ts
@@ -1,27 +1,9 @@
 import type { ozaClient } from '@bangumi/client';
+import type { JsonFixture, SuccessfulData } from '@bangumi/website/mocks/utils';
 
 import episodesJson from '../../subjects/501963/episodes-GET.json';
 import episodeJson from '../1704816-GET.json';
 import commentsJson from './comments-GET.json';
-
-type ApiFunction = (...args: never[]) => Promise<unknown>;
-
-type SuccessfulData<T extends ApiFunction> = Extract<
-  Awaited<ReturnType<T>>,
-  { status: 200 }
->['data'];
-
-type JsonFixture<T> = T extends number
-  ? number
-  : T extends string
-    ? string
-    : T extends boolean
-      ? boolean
-      : T extends (infer Item)[]
-        ? JsonFixture<Item>[]
-        : T extends object
-          ? { [Key in keyof T]: JsonFixture<T[Key]> }
-          : T;
 
 export const episodeFixture: JsonFixture<SuccessfulData<typeof ozaClient.getEpisode>> = episodeJson;
 

--- a/packages/website/src/mocks/fixtures/p1/persons/21884/index.ts
+++ b/packages/website/src/mocks/fixtures/p1/persons/21884/index.ts
@@ -1,4 +1,5 @@
 import type { ozaClient } from '@bangumi/client';
+import type { JsonFixture, SuccessfulData } from '@bangumi/website/mocks/utils';
 
 import personJson from '../21884-GET.json';
 import castsJson from './casts-GET.json';
@@ -7,25 +8,6 @@ import commentsJson from './comments-GET.json';
 import indexesJson from './indexes-GET.json';
 import relationsJson from './relations-GET.json';
 import worksJson from './works-GET.json';
-
-type ApiFunction = (...args: never[]) => Promise<unknown>;
-
-type SuccessfulData<T extends ApiFunction> = Extract<
-  Awaited<ReturnType<T>>,
-  { status: 200 }
->['data'];
-
-type JsonFixture<T> = T extends number
-  ? number
-  : T extends string
-    ? string
-    : T extends boolean
-      ? boolean
-      : T extends (infer Item)[]
-        ? JsonFixture<Item>[]
-        : T extends object
-          ? { [Key in keyof T]: JsonFixture<T[Key]> }
-          : T;
 
 export const personFixture: JsonFixture<SuccessfulData<typeof ozaClient.getPerson>> = personJson;
 

--- a/packages/website/src/mocks/fixtures/p1/search/index.ts
+++ b/packages/website/src/mocks/fixtures/p1/search/index.ts
@@ -1,27 +1,9 @@
 import type { ozaClient } from '@bangumi/client';
+import type { JsonFixture, SuccessfulData } from '@bangumi/website/mocks/utils';
 
 import characterSearchJson from './characters-POST.json';
 import personSearchJson from './persons-POST.json';
 import subjectSearchJson from './subjects-POST.json';
-
-type ApiFunction = (...args: never[]) => Promise<unknown>;
-
-type SuccessfulData<T extends ApiFunction> = Extract<
-  Awaited<ReturnType<T>>,
-  { status: 200 }
->['data'];
-
-type JsonFixture<T> = T extends number
-  ? number
-  : T extends string
-    ? string
-    : T extends boolean
-      ? boolean
-      : T extends (infer Item)[]
-        ? JsonFixture<Item>[]
-        : T extends object
-          ? { [Key in keyof T]: JsonFixture<T[Key]> }
-          : T;
 
 export const subjectSearchFixture: JsonFixture<SuccessfulData<typeof ozaClient.searchSubjects>> =
   subjectSearchJson;

--- a/packages/website/src/mocks/fixtures/p1/trending/index.ts
+++ b/packages/website/src/mocks/fixtures/p1/trending/index.ts
@@ -1,26 +1,8 @@
 import type { ozaClient } from '@bangumi/client';
+import type { JsonFixture, SuccessfulData } from '@bangumi/website/mocks/utils';
 
 import trendingSubjectTopicsJson from './subjects/topics-GET.json';
 import trendingSubjectsJson from './subjects-GET.json';
-
-type ApiFunction = (...args: never[]) => Promise<unknown>;
-
-type SuccessfulData<T extends ApiFunction> = Extract<
-  Awaited<ReturnType<T>>,
-  { status: 200 }
->['data'];
-
-type JsonFixture<T> = T extends number
-  ? number
-  : T extends string
-    ? string
-    : T extends boolean
-      ? boolean
-      : T extends (infer Item)[]
-        ? JsonFixture<Item>[]
-        : T extends object
-          ? { [Key in keyof T]: JsonFixture<T[Key]> }
-          : T;
 
 export const trendingSubjectsFixture: JsonFixture<
   SuccessfulData<typeof ozaClient.getTrendingSubjects>

--- a/packages/website/src/mocks/utils.ts
+++ b/packages/website/src/mocks/utils.ts
@@ -39,3 +39,23 @@ export function mockAPI(url: string, method: HTTPMethods): HttpHandler {
     return HttpResponse.json(data, { status: 200 });
   });
 }
+
+export type ApiFunction = (...args: never[]) => Promise<unknown>;
+
+export type SuccessfulData<T extends ApiFunction> = Extract<
+  Awaited<ReturnType<T>>,
+  { status: 200 }
+>['data'];
+
+/** 将 API 响应类型递归映射为纯 JSON 可赋值的类型，用于类型化 mock fixture */
+export type JsonFixture<T> = T extends number
+  ? number
+  : T extends string
+    ? string
+    : T extends boolean
+      ? boolean
+      : T extends (infer Item)[]
+        ? JsonFixture<Item>[]
+        : T extends object
+          ? { [Key in keyof T]: JsonFixture<T[Key]> }
+          : T;


### PR DESCRIPTION
## Summary

- Extract the `JsonFixture`, `ApiFunction` and `SuccessfulData` types into `packages/website/src/mocks/utils.ts` and export them from there.
- Remove duplicated local type definitions from 4 fixture files (`episodes/1704816`, `persons/21884`, `search`, `trending`) and import them via the `@bangumi/website/mocks/utils` path alias instead of deep relative paths.

## Verification

- `pnpm type-check` passes
- ESLint / Prettier pass on changed files
- 4 related spec files (12 tests) pass: `EpisodeDetail`, `PersonDetail`, `SubjectSearchPage`, `channel/index`