### PR TITLE
feat(website): add static pages without backend API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,8 +84,9 @@ pnpm prettier:check      # 检查 Prettier 格式
 - 遵循根目录 Prettier 配置：单引号、JSX 单引号、分号、尾随逗号、行宽 100。
 - ESLint 会检查未使用导入、导入顺序、Node 内置模块的 `node:` 协议、TypeScript 类型导入等。
   保持导入分组和 `simple-import-sort` 可通过，不要用禁用规则掩盖问题。
-- 新代码和新样式使用 Panda CSS，并从 `@bangumi/styled-system` 导入类型化样式 API。现有 Less
-  和 CSS Modules 保持可用并逐步迁移；修改存量样式时沿用其 CSS Modules 或 BEM 命名约定。
+- 新代码和新样式使用 Panda CSS，并从 `@bangumi/styled-system` 导入类型化样式 API。不允许在
+  `*.module.less` 文件中添加新的内容，所有新样式必须通过 Panda CSS 添加。现有 Less 和 CSS
+  Modules 保持可用并逐步迁移；修改存量样式时沿用其 CSS Modules 或 BEM 命名约定。
 - 注释只写必要的设计或行为说明。函数、变量、类的文档使用 TSDoc `/** ... */`，不要用
   `//` 代替可被 TypeScript 工具识别的文档注释，也不要在 TSDoc 中重复 TypeScript 类型。
 - 优先复用 `@bangumi/design`、`@bangumi/icons`、`@bangumi/utils` 和现有 hooks；新增跨页面

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
       "eslint --fix"
     ],
     "*.{css,less}": [
-      "stylelint --fix"
+      "stylelint --fix --allow-empty-input"
     ],
     "*.{md,html,js,ts,mts,cts,tsx,css,less,cjs,mjs,yaml,yml,json}": "prettier --write"
   },

--- a/packages/styled-system/styles.css
+++ b/packages/styled-system/styles.css
@@ -580,6 +580,78 @@
     margin: 0 -10px;
 }
 
+  .m_0_auto {
+    margin: 0 auto;
+}
+
+  .m_0_0_16px {
+    margin: 0 0 16px;
+}
+
+  .m_0_0_12px {
+    margin: 0 0 12px;
+}
+
+  .m_0 {
+    margin: var(--spacing-0);
+}
+
+  .p_40px_0 {
+    padding: 40px 0;
+}
+
+  .p_8px_0 {
+    padding: 8px 0;
+}
+
+  .m_0_0_8px {
+    margin: 0 0 8px;
+}
+
+  .m_0_0_24px {
+    margin: 0 0 24px;
+}
+
+  .p_12px_0 {
+    padding: 12px 0;
+}
+
+  .m_0_0_6px {
+    margin: 0 0 6px;
+}
+
+  .bg_\#f4f4f4 {
+    background: #f4f4f4;
+}
+
+  .bd_1px_solid_\#e6e6e6 {
+    border: 1px solid #e6e6e6;
+}
+
+  .p_2px_6px {
+    padding: 2px 6px;
+}
+
+  .m_16px_0_0 {
+    margin: 16px 0 0;
+}
+
+  .p_12px {
+    padding: 12px;
+}
+
+  .bd_1px_solid_\#ccc {
+    border: 1px solid #ccc;
+}
+
+  .p_16px {
+    padding: 16px;
+}
+
+  .bg_\#fafafa {
+    background: #fafafa;
+}
+
   .m_5px_0 {
     margin: 5px 0;
 }
@@ -590,10 +662,6 @@
 
   .bg_\#f09199 {
     background: #f09199;
-}
-
-  .m_0 {
-    margin: var(--spacing-0);
 }
 
   .p_5px_0 {
@@ -668,8 +736,40 @@
     border-radius: 9999px;
 }
 
+  .gap_24px {
+    gap: 24px;
+}
+
+  .bd-b_1px_solid_\#e8e3e3 {
+    border-bottom: 1px solid #e8e3e3;
+}
+
+  .li-s_none {
+    list-style: none;
+}
+
   .bdr_true {
     border-radius: true;
+}
+
+  .gap_40px {
+    gap: 40px;
+}
+
+  .flex_1_1_40\% {
+    flex: 1 1 40%;
+}
+
+  .flex_1_1_60\% {
+    flex: 1 1 60%;
+}
+
+  .bd-b_1px_solid_\#eee {
+    border-bottom: 1px solid #eee;
+}
+
+  .bdr_4px {
+    border-radius: 4px;
 }
 
   .gap_10px {
@@ -678,10 +778,6 @@
 
   .bdr_50px {
     border-radius: 50px;
-}
-
-  .li-s_none {
-    list-style: none;
 }
 
   .flex_0_0_50px {
@@ -726,10 +822,6 @@
 
   .bd-c_\#369cf8 {
     border-color: #369cf8;
-}
-
-  .bdr_4px {
-    border-radius: 4px;
 }
 
   .fw_bold {
@@ -833,12 +925,128 @@
     color: gray;
 }
 
+  .flex-wrap_wrap {
+    flex-wrap: wrap;
+}
+
+  .c_\#595555 {
+    color: #595555;
+}
+
+  .c_\#3db3f5 {
+    color: #3db3f5;
+}
+
+  .c_\#1f1c1c {
+    color: #1f1c1c;
+}
+
+  .fs_26px {
+    font-size: 26px;
+}
+
+  .fs_18px {
+    font-size: 18px;
+}
+
+  .lh_1\.8 {
+    line-height: 1.8;
+}
+
+  .wb_break-all {
+    word-break: break-all;
+}
+
+  .fs_28px {
+    font-size: 28px;
+}
+
+  .lh_38px {
+    line-height: 38px;
+}
+
+  .c_\#9f9b9b {
+    color: #9f9b9b;
+}
+
+  .fs_15px {
+    font-size: 15px;
+}
+
+  .lh_24px {
+    line-height: 24px;
+}
+
+  .fs_20px {
+    font-size: 20px;
+}
+
+  .lh_28px {
+    line-height: 28px;
+}
+
+  .lh_1\.4 {
+    line-height: 1.4;
+}
+
+  .c_\#54b5df {
+    color: #54b5df;
+}
+
   .c_blue {
     color: blue;
 }
 
   .inset-e_true {
     inset-inline-end: true;
+}
+
+  .fs_24px {
+    font-size: 24px;
+}
+
+  .ai_flex-start {
+    align-items: flex-start;
+}
+
+  .ai_baseline {
+    align-items: baseline;
+}
+
+  .fw_normal {
+    font-weight: var(--font-weights-normal);
+}
+
+  .fs_16px {
+    font-size: 16px;
+}
+
+  .ff_\'SFMono-Regular\'\,_Consolas\,_\'Liberation_Mono\'\,_Menlo\,_monospace {
+    font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+}
+
+  .fs_13px {
+    font-size: 13px;
+}
+
+  .c_\#d6336c {
+    color: #d6336c;
+}
+
+  .c_\#666 {
+    color: #666;
+}
+
+  .lh_1\.6 {
+    line-height: 1.6;
+}
+
+  .resize_vertical {
+    resize: vertical;
+}
+
+  .ov-wrap_break-word {
+    overflow-wrap: break-word;
 }
 
   .inset-e_overview {
@@ -873,14 +1081,6 @@
     line-height: 18px;
 }
 
-  .ai_baseline {
-    align-items: baseline;
-}
-
-  .c_\#9f9b9b {
-    color: #9f9b9b;
-}
-
   .fs_12px {
     font-size: 12px;
 }
@@ -901,20 +1101,8 @@
     background-size: 15px 100px;
 }
 
-  .c_\#595555 {
-    color: #595555;
-}
-
-  .fs_13px {
-    font-size: 13px;
-}
-
   .page_1 {
     page: 1px;
-}
-
-  .flex-wrap_wrap {
-    flex-wrap: wrap;
 }
 
   .cursor_pointer {
@@ -1053,6 +1241,66 @@
     width: calc(100% + 20px) !important;
 }
 
+  .max-w_760px {
+    max-width: 760px;
+}
+
+  .mb_32px {
+    margin-bottom: 32px;
+}
+
+  .pb_16px {
+    padding-bottom: 16px;
+}
+
+  .mb_28px {
+    margin-bottom: 28px;
+}
+
+  .pl_20px {
+    padding-left: 20px;
+}
+
+  .mb_10px {
+    margin-bottom: 10px;
+}
+
+  .max-w_720px {
+    max-width: 720px;
+}
+
+  .mb_12px {
+    margin-bottom: 12px;
+}
+
+  .mt_12px {
+    margin-top: 12px;
+}
+
+  .mb_24px {
+    margin-bottom: 24px;
+}
+
+  .mb_8px {
+    margin-bottom: 8px;
+}
+
+  .pt_8px {
+    padding-top: 8px;
+}
+
+  .min-h_180px {
+    min-height: 180px;
+}
+
+  .mt_16px {
+    margin-top: 16px;
+}
+
+  .min-h_120px {
+    min-height: 120px;
+}
+
   .ml_auto {
     margin-left: auto;
 }
@@ -1119,6 +1367,10 @@
 
   .\[\&_\.bgm-input__wrapper--focus\]\:bd-c_\#f09199\! .bgm-input__wrapper--focus {
     border-color: #f09199 !important;
+}
+
+  .last\:bd-b_none:last-child {
+    border-bottom: var(--borders-none);
 }
 
   .\[\&_h3\]\:ov_hidden h3 {
@@ -1285,12 +1537,24 @@
     width: 100%;
 }
 
+  .last\:mb_0:last-child {
+    margin-bottom: var(--spacing-0);
+}
+
+  .focus\:bd-c_\#888:is(:focus, [data-focus]) {
+    border-color: #888;
+}
+
   .hover\:bg_\#f09199:is(:hover, [data-hover]) {
     background: #f09199;
 }
 
   .hover\:bg_\#e7848e:is(:hover, [data-hover]) {
     background: #e7848e;
+}
+
+  .hover\:td_underline:is(:hover, [data-hover]) {
+    text-decoration: underline;
 }
 
   .hover\:td_none:is(:hover, [data-hover]) {
@@ -1311,6 +1575,10 @@
 
   .\[\&_a\:hover\]\:fw_700 a:hover {
     font-weight: 700;
+}
+
+  .hover\:c_\#54b5df:is(:hover, [data-hover]) {
+    color: #54b5df;
 }
 
   .hover\:c_\#fff:is(:hover, [data-hover]) {
@@ -1364,6 +1632,15 @@
 }
     .\[\@media_\(max-width\:_992px\)\]\:d_none\! {
       display: none !important;
+}
+}
+
+  @media screen and (max-width: 47.9975rem) {
+    .mdDown\:gap_32px {
+      gap: 32px;
+}
+    .mdDown\:flex-d_column {
+      flex-direction: column;
 }
 }
 

--- a/packages/website/src/pages/index/about/copyright.tsx
+++ b/packages/website/src/pages/index/about/copyright.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+import Helmet from '@bangumi/website/components/Helmet';
+import PageContainer from '@bangumi/website/components/PageContainer';
+
+import {
+  aboutContainer,
+  AboutNav,
+  aboutParagraph,
+  aboutSection,
+  aboutSectionTitle,
+  aboutTitle,
+} from './index';
+
+const Copyright: React.FC = () => (
+  <>
+    <Helmet title='版权声明' />
+    <PageContainer className={aboutContainer}>
+      <AboutNav />
+      <h1 className={aboutTitle}>版权声明</h1>
+      <section className={aboutSection}>
+        <h2 className={aboutSectionTitle}>用户发布的内容</h2>
+        <p className={aboutParagraph}>
+          用户在 Bangumi
+          发布的内容（包括但不限于日志、小组话题与回复、条目吐槽、图片等）著作权归发布者本人所有，发布者对其发布内容负相应责任。
+        </p>
+        <p className={aboutParagraph}>
+          Bangumi
+          仅为用户提供内容存储与展示服务，不参与用户内容的创作，也不对用户发布内容的真实性、合法性作出保证。
+        </p>
+      </section>
+      <section className={aboutSection}>
+        <h2 className={aboutSectionTitle}>站方内容</h2>
+        <p className={aboutParagraph}>
+          本站自身的页面、文字与设计等站方内容，未经许可不得擅自复制、转载或用于商业用途。
+        </p>
+      </section>
+      <section className={aboutSection}>
+        <h2 className={aboutSectionTitle}>转载与引用</h2>
+        <p className={aboutParagraph}>
+          转载本站内容时请注明出处与原作者；在符合著作权保护的前提下，欢迎对本站内容进行合理引用。
+        </p>
+      </section>
+      <section className={aboutSection}>
+        <h2 className={aboutSectionTitle}>侵权处理</h2>
+        <p className={aboutParagraph}>
+          如果您认为本站内容侵犯了您的合法权益，请通过站务途径与我们联系，我们会在核实后尽快处理。
+        </p>
+      </section>
+    </PageContainer>
+  </>
+);
+
+export default Copyright;

--- a/packages/website/src/pages/index/about/guideline.tsx
+++ b/packages/website/src/pages/index/about/guideline.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+import Helmet from '@bangumi/website/components/Helmet';
+import PageContainer from '@bangumi/website/components/PageContainer';
+
+import {
+  aboutContainer,
+  aboutList,
+  aboutListItem,
+  AboutNav,
+  aboutParagraph,
+  aboutTitle,
+} from './index';
+
+const Guideline: React.FC = () => (
+  <>
+    <Helmet title='社区指导原则' />
+    <PageContainer className={aboutContainer}>
+      <AboutNav />
+      <h1 className={aboutTitle}>社区指导原则</h1>
+      <p className={aboutParagraph}>
+        Bangumi 是一个开放的社区，为了让大家在这里愉快地交流和分享，请所有用户共同遵守以下原则：
+      </p>
+      <ol className={aboutList}>
+        <li className={aboutListItem}>
+          友善交流：尊重每一位用户，不进行人身攻击、引战或恶意骚扰，理性表达不同观点。
+        </li>
+        <li className={aboutListItem}>
+          尊重版权：不要在站内上传或分享侵犯他人版权的资源，转载他人内容时注明出处。
+        </li>
+        <li className={aboutListItem}>
+          条目编辑规范：编辑条目时应如实填写信息并遵循现有规范，不要恶意修改、删除他人的编辑成果。
+        </li>
+        <li className={aboutListItem}>
+          拒绝广告与刷屏：不要发布商业广告、垃圾信息，也不要重复刷屏影响他人浏览。
+        </li>
+        <li className={aboutListItem}>保护隐私：未经本人同意，不要公开他人的个人隐私信息。</li>
+        <li className={aboutListItem}>遵守法律法规：不发布违反法律法规及公序良俗的内容。</li>
+      </ol>
+    </PageContainer>
+  </>
+);
+
+export default Guideline;

--- a/packages/website/src/pages/index/about/index.tsx
+++ b/packages/website/src/pages/index/about/index.tsx
@@ -1,0 +1,129 @@
+import classNames from 'classnames';
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+
+import { css } from '@bangumi/styled-system/css';
+import Helmet from '@bangumi/website/components/Helmet';
+import PageContainer from '@bangumi/website/components/PageContainer';
+
+interface AboutNavItem {
+  to: string;
+  label: string;
+  end?: boolean;
+}
+
+const ABOUT_NAV_ITEMS: AboutNavItem[] = [
+  { to: '/about', label: '关于本站', end: true },
+  { to: '/about/guideline', label: '社区指导原则' },
+  { to: '/about/copyright', label: '版权声明' },
+  { to: '/about/link2us', label: '链接我们' },
+];
+
+export const aboutContainer = css({ maxWidth: '760px', margin: '0 auto' });
+
+const nav = css({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '24px',
+  marginBottom: '32px',
+  paddingBottom: '16px',
+  borderBottom: '1px solid #e8e3e3',
+});
+
+const navLink = css({
+  color: '#595555',
+  fontSize: '14px',
+  textDecoration: 'none',
+  _hover: { color: '#54b5df' },
+});
+
+const active = css({ color: '#3db3f5', fontWeight: '600' });
+
+export const aboutTitle = css({
+  margin: '0 0 16px',
+  color: '#1f1c1c',
+  fontSize: '26px',
+  fontWeight: '600',
+});
+
+export const aboutSection = css({ marginBottom: '28px' });
+
+export const aboutSectionTitle = css({
+  margin: '0 0 12px',
+  color: '#1f1c1c',
+  fontSize: '18px',
+  fontWeight: '600',
+});
+
+export const aboutParagraph = css({
+  margin: '0 0 12px',
+  color: '#595555',
+  fontSize: '14px',
+  lineHeight: '1.8',
+});
+
+export const aboutList = css({ margin: '0', paddingLeft: '20px' });
+
+export const aboutListItem = css({
+  marginBottom: '10px',
+  color: '#595555',
+  fontSize: '14px',
+  lineHeight: '1.8',
+});
+
+export const inlineLink = css({
+  color: '#3db3f5',
+  textDecoration: 'none',
+  wordBreak: 'break-all',
+  _hover: { textDecoration: 'underline' },
+});
+
+export const AboutNav: React.FC = () => (
+  <nav className={nav}>
+    {ABOUT_NAV_ITEMS.map((item) => (
+      <NavLink
+        key={item.to}
+        to={item.to}
+        end={item.end}
+        className={({ isActive }) => classNames(navLink, isActive && active)}
+      >
+        {item.label}
+      </NavLink>
+    ))}
+  </nav>
+);
+
+const About: React.FC = () => (
+  <>
+    <Helmet title='关于本站' />
+    <PageContainer className={aboutContainer}>
+      <AboutNav />
+      <h1 className={aboutTitle}>关于本站</h1>
+      <p className={aboutParagraph}>
+        Bangumi（番组计划）是一个以 ACG（动画、漫画、游戏）为主题的综合性社区网站，创立于 2008 年。
+        在这里，你可以记录自己看过、读过、玩过的作品，也可以和同好一起交流讨论，分享自己的见闻与感想。
+      </p>
+      <section className={aboutSection}>
+        <h2 className={aboutSectionTitle}>核心功能</h2>
+        <ul className={aboutList}>
+          <li className={aboutListItem}>
+            条目资料库：收录动画、漫画、游戏、音乐等 ACG
+            条目，以及人物、角色与声优信息，并支持社区成员共同编辑补充。
+          </li>
+          <li className={aboutListItem}>
+            收藏管理：通过「想看 / 在看 / 看过」等方式记录追番、阅读与游玩进度，随时回顾自己的 ACG
+            历程。
+          </li>
+          <li className={aboutListItem}>
+            兴趣小组：围绕作品、类型或话题创建和加入小组，和同好分享心得、组织活动。
+          </li>
+          <li className={aboutListItem}>
+            日志与吐槽：撰写日志记录长篇感想，也可以在条目和章节下随手记录吐槽。
+          </li>
+        </ul>
+      </section>
+    </PageContainer>
+  </>
+);
+
+export default About;

--- a/packages/website/src/pages/index/about/link2us.tsx
+++ b/packages/website/src/pages/index/about/link2us.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+import Helmet from '@bangumi/website/components/Helmet';
+import PageContainer from '@bangumi/website/components/PageContainer';
+
+import {
+  aboutContainer,
+  aboutList,
+  aboutListItem,
+  AboutNav,
+  aboutParagraph,
+  aboutSection,
+  aboutSectionTitle,
+  aboutTitle,
+  inlineLink,
+} from './index';
+
+const Link2Us: React.FC = () => (
+  <>
+    <Helmet title='链接我们' />
+    <PageContainer className={aboutContainer}>
+      <AboutNav />
+      <h1 className={aboutTitle}>链接我们</h1>
+      <section className={aboutSection}>
+        <h2 className={aboutSectionTitle}>申请条件</h2>
+        <ul className={aboutList}>
+          <li className={aboutListItem}>网站内容与 ACG（动画、漫画、游戏）相关；</li>
+          <li className={aboutListItem}>内容健康，无恶意程序与违规信息；</li>
+          <li className={aboutListItem}>已添加指向 Bangumi 的链接。</li>
+        </ul>
+      </section>
+      <section className={aboutSection}>
+        <h2 className={aboutSectionTitle}>申请方式</h2>
+        <p className={aboutParagraph}>
+          满足条件的站点，请到站务论坛发布申请帖，附上站点名称、地址与一句简介：
+        </p>
+        <p className={aboutParagraph}>
+          <a className={inlineLink} href='https://bgm.tv/group/issues'>
+            https://bgm.tv/group/issues
+          </a>
+        </p>
+      </section>
+      <section className={aboutSection}>
+        <h2 className={aboutSectionTitle}>审核说明</h2>
+        <p className={aboutParagraph}>
+          我们会在核实站点信息后尽快处理申请。由于精力有限，暂时只接受与 ACG
+          相关的站点申请，敬请谅解。
+        </p>
+      </section>
+    </PageContainer>
+  </>
+);
+
+export default Link2Us;

--- a/packages/website/src/pages/index/dev/app/index.tsx
+++ b/packages/website/src/pages/index/dev/app/index.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+import { css } from '@bangumi/styled-system/css';
+import Helmet from '@bangumi/website/components/Helmet';
+import PageContainer from '@bangumi/website/components/PageContainer';
+
+const page = css({ paddingTop: '8px' });
+
+const header = css({
+  paddingBottom: '16px',
+  marginBottom: '32px',
+  borderBottom: '1px solid #e8e3e3',
+});
+
+const headerTitle = css({ margin: '0 0 8px', fontSize: '26px', lineHeight: '1.4' });
+
+const headerDescription = css({ margin: '0', color: '#9f9b9b' });
+
+const section = css({ marginBottom: '32px' });
+
+const sectionTitle = css({ margin: '0 0 12px', fontSize: '18px', lineHeight: '1.4' });
+
+const paragraph = css({
+  margin: '0 0 12px',
+  fontSize: '14px',
+  lineHeight: '1.8',
+  color: '#1f1c1c',
+});
+
+const link = css({ color: '#54b5df' });
+
+const DevApp: React.FC = () => (
+  <>
+    <Helmet title='开发者平台' />
+    <PageContainer as='main' className={page}>
+      <header className={header}>
+        <h1 className={headerTitle}>开发者平台</h1>
+        <p className={headerDescription}>
+          接入 Bangumi 开放 API，为你的应用带来番组数据与用户授权能力
+        </p>
+      </header>
+
+      <section className={section}>
+        <h2 className={sectionTitle}>关于 Bangumi API 与 OAuth</h2>
+        <p className={paragraph}>
+          Bangumi 为第三方开发者提供开放的 API。通过 OAuth 2.0 授权流程，第三方应用可以在用户
+          同意的前提下获取其收藏、评分、进度、时间线等数据，并执行收藏更新等操作，无需保存用户的
+          账号密码。
+        </p>
+        <p className={paragraph}>
+          完整的接口说明、认证流程与示例请参见官方文档：
+          <a
+            className={link}
+            href='https://bangumi.github.io/api/'
+            target='_blank'
+            rel='noreferrer'
+          >
+            bangumi.github.io/api
+          </a>
+          。
+        </p>
+      </section>
+
+      <section className={section}>
+        <h2 className={sectionTitle}>申请开发者应用</h2>
+        <p className={paragraph}>
+          开发者应用需申请后使用，目前请通过站务协助开通：在
+          <Link className={link} to='/group/dev'>
+            站务论坛
+          </Link>
+          发帖说明应用名称、用途等信息即可。
+        </p>
+      </section>
+    </PageContainer>
+  </>
+);
+
+export default DevApp;

--- a/packages/website/src/pages/index/dollars/index.tsx
+++ b/packages/website/src/pages/index/dollars/index.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+
+import { css } from '@bangumi/styled-system/css';
+import Helmet from '@bangumi/website/components/Helmet';
+import PageContainer from '@bangumi/website/components/PageContainer';
+
+const FEATURES = [
+  {
+    title: '浏览条目',
+    description: '查看动画、书籍、音乐、游戏等条目的详细信息与相关讨论',
+  },
+  {
+    title: '收藏管理',
+    description: '添加收藏、标记观看进度，随时整理自己的收藏列表',
+  },
+  {
+    title: '关注更新',
+    description: '关注动画放送与条目更新动态，不错过任何新内容',
+  },
+  {
+    title: '时间线',
+    description: '浏览好友动态与个人时间线，分享看番、读书、听歌、玩游戏的日常',
+  },
+  {
+    title: '小组讨论',
+    description: '参与小组话题，与同好交流想法',
+  },
+  {
+    title: '离线收藏',
+    description: '没有网络时也能查看已收藏的条目',
+  },
+];
+
+const wrapper = css({ maxWidth: '720px', margin: '0 auto', padding: '40px 0' });
+
+const title = css({
+  marginBottom: '12px',
+  color: '#1f1c1c',
+  fontSize: '28px',
+  fontWeight: '600',
+  lineHeight: '38px',
+});
+
+const intro = css({ marginBottom: '32px', color: '#9f9b9b', fontSize: '15px', lineHeight: '24px' });
+
+const section = css({ marginBottom: '32px' });
+
+const sectionTitle = css({
+  marginBottom: '12px',
+  color: '#1f1c1c',
+  fontSize: '20px',
+  fontWeight: '600',
+  lineHeight: '28px',
+});
+
+const paragraph = css({ margin: '0', color: '#595555', lineHeight: '24px' });
+
+const featureList = css({ margin: '0', padding: '0', listStyle: 'none' });
+
+const featureItem = css({ padding: '8px 0', color: '#595555', lineHeight: '24px' });
+
+const featureName = css({ color: '#1f1c1c', fontWeight: '600' });
+
+const downloadLink = css({
+  display: 'inline-block',
+  marginTop: '12px',
+  color: '#3db3f5',
+  _hover: { color: '#54b5df' },
+});
+
+const Dollars: React.FC = () => {
+  return (
+    <>
+      <Helmet title='Dollars 客户端' />
+      <PageContainer>
+        <div className={wrapper}>
+          <h1 className={title}>Dollars 客户端</h1>
+          <p className={intro}>
+            Dollars 是 Bangumi 番组计划官方客户端，覆盖桌面端与移动端，随时随地记录你的追番日常。
+          </p>
+
+          <section className={section}>
+            <h2 className={sectionTitle}>平台支持</h2>
+            <p className={paragraph}>
+              支持桌面端（Windows、macOS、Linux）与移动端（Android、iOS）等主流平台，
+              跨设备同步你的收藏与进度。
+            </p>
+          </section>
+
+          <section className={section}>
+            <h2 className={sectionTitle}>核心功能</h2>
+            <ul className={featureList}>
+              {FEATURES.map((feature) => (
+                <li className={featureItem} key={feature.title}>
+                  <strong className={featureName}>{feature.title}</strong>：{feature.description}
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section className={section}>
+            <h2 className={sectionTitle}>下载</h2>
+            <p className={paragraph}>
+              Dollars 客户端持续更新中，最新版本与下载地址请前往旧站查看。
+            </p>
+            <a
+              className={downloadLink}
+              href='https://bgm.tv/dollars'
+              target='_blank'
+              rel='noreferrer'
+            >
+              前往旧站查看下载与更新
+            </a>
+          </section>
+        </div>
+      </PageContainer>
+    </>
+  );
+};
+
+export default Dollars;

--- a/packages/website/src/pages/index/goodies/index.tsx
+++ b/packages/website/src/pages/index/goodies/index.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+
+import { css } from '@bangumi/styled-system/css';
+import Helmet from '@bangumi/website/components/Helmet';
+import PageContainer from '@bangumi/website/components/PageContainer';
+
+const title = css({
+  marginBottom: '24px',
+  color: '#1f1c1c',
+  fontSize: '28px',
+  fontWeight: '600',
+  lineHeight: '38px',
+});
+
+const section = css({ marginBottom: '32px', _last: { marginBottom: '0' } });
+
+const sectionTitle = css({
+  marginBottom: '12px',
+  color: '#1f1c1c',
+  fontSize: '20px',
+  fontWeight: '600',
+  lineHeight: '28px',
+});
+
+const description = css({
+  margin: '0 0 12px',
+  color: '#595555',
+  lineHeight: '24px',
+  _last: { marginBottom: '0' },
+});
+
+const linkList = css({ margin: '0', padding: '0', listStyle: 'none' });
+
+const linkListItem = css({ marginBottom: '8px', _last: { marginBottom: '0' } });
+
+const link = css({ color: '#3db3f5', _hover: { color: '#54b5df' } });
+
+const Goodies: React.FC = () => (
+  <>
+    <Helmet title='周边' />
+    <PageContainer>
+      <h1 className={title}>周边与天窗</h1>
+      <section className={section}>
+        <h2 className={sectionTitle}>什么是天窗</h2>
+        <p className={description}>
+          {'「天窗联盟」（通常简称「天窗」）是 Bangumi 旗下的同人创作企划，为同人志、同人周边等'}
+          {'创作提供发布、展示与交流的平台。创作者可以在天窗登记自己的作品，读者也可以按作品、'}
+          {'社团等线索查找感兴趣的同人内容。'}
+        </p>
+        <p className={description}>
+          {'Bangumi 的周边板块则收录与动画、漫画、游戏等作品相关的周边商品与同人创作信息，包括'}
+          {'同人志、徽章、挂画、手办等，方便大家发现和整理自己关注作品的周边情报。'}
+        </p>
+      </section>
+      <section className={section}>
+        <h2 className={sectionTitle}>如何参与</h2>
+        <p className={description}>
+          {'如果你是创作者，可以在'}
+          <a className={link} href='https://bgm.tv/doujin' target='_blank' rel='noreferrer'>
+            天窗联盟
+          </a>
+          {'登记自己的同人志或同人周边，让更多人看到你的作品。'}
+        </p>
+        <p className={description}>
+          {'想和其他同好交流创作心得、获取最新的同人与周边信息，可以加入'}
+          <a className={link} href='https://bgm.tv/group/doujin' target='_blank' rel='noreferrer'>
+            同人小组
+          </a>
+          {'参与讨论。'}
+        </p>
+      </section>
+      <section className={section}>
+        <h2 className={sectionTitle}>相关链接</h2>
+        <ul className={linkList}>
+          <li className={linkListItem}>
+            <a className={link} href='https://bgm.tv/doujin' target='_blank' rel='noreferrer'>
+              天窗联盟（同人企划）
+            </a>
+          </li>
+          <li className={linkListItem}>
+            <a className={link} href='https://bgm.tv/group/doujin' target='_blank' rel='noreferrer'>
+              同人小组
+            </a>
+          </li>
+          <li className={linkListItem}>
+            <a className={link} href='https://bgm.tv/goodies' target='_blank' rel='noreferrer'>
+              旧站周边页
+            </a>
+          </li>
+        </ul>
+      </section>
+    </PageContainer>
+  </>
+);
+
+export default Goodies;

--- a/packages/website/src/pages/index/help/bbcode/index.tsx
+++ b/packages/website/src/pages/index/help/bbcode/index.tsx
@@ -1,0 +1,226 @@
+import React, { useState } from 'react';
+
+import { css } from '@bangumi/styled-system/css';
+import { render } from '@bangumi/utils';
+import Helmet from '@bangumi/website/components/Helmet';
+import PageContainer from '@bangumi/website/components/PageContainer';
+
+interface SyntaxItem {
+  name: string;
+  examples: string[];
+  description: string;
+}
+
+// 仅收录 @bangumi/utils 的 bbcode parser（packages/utils/bbcode/parser.ts）实际支持的语法
+const SYNTAX_ITEMS: SyntaxItem[] = [
+  {
+    name: '粗体',
+    examples: ['[b]粗体[/b]'],
+    description: '将文字加粗显示。',
+  },
+  {
+    name: '斜体',
+    examples: ['[i]斜体[/i]'],
+    description: '将文字显示为斜体。',
+  },
+  {
+    name: '下划线',
+    examples: ['[u]下划线[/u]'],
+    description: '为文字添加下划线。',
+  },
+  {
+    name: '删除线',
+    examples: ['[s]删除线[/s]'],
+    description: '为文字添加删除线。',
+  },
+  {
+    name: '颜色',
+    examples: ['[color=red]红色[/color]', '[color=#ff6600]橙色[/color]'],
+    description: '设置文字颜色，支持 CSS 颜色名和十六进制颜色值。',
+  },
+  {
+    name: '字号',
+    examples: ['[size=18]大号文字[/size]'],
+    description: '设置文字大小，数字表示字体像素大小。',
+  },
+  {
+    name: '链接',
+    examples: ['[url=https://bgm.tv]Bangumi[/url]', '[url]https://bgm.tv[/url]'],
+    description: '为文字添加超链接；不指定地址时以内容本身作为链接地址。',
+  },
+  {
+    name: '图片',
+    examples: ['[img]https://example.com/image.png[/img]'],
+    description: '插入网络图片，需要使用图片的直链地址。',
+  },
+  {
+    name: '引用',
+    examples: ['[quote]引用内容[/quote]'],
+    description: '将内容显示为引用块。',
+  },
+  {
+    name: '代码',
+    examples: ['[code]const a = 1;[/code]'],
+    description: '以代码块显示内容，代码内部的其他 BBCode 不会被解析。',
+  },
+  {
+    name: '剧透',
+    examples: ['[mask]隐藏内容[/mask]'],
+    description: '隐藏文字，鼠标选中文字即可查看内容。',
+  },
+  {
+    name: '对齐',
+    examples: ['[left]左对齐[/left]', '[center]居中[/center]', '[right]右对齐[/right]'],
+    description: '设置内容的对齐方式，也可以使用 [align=center] 等写法。',
+  },
+  {
+    name: '缩进',
+    examples: ['[indent]缩进内容[/indent]'],
+    description: '将内容作为缩进段落显示。',
+  },
+  {
+    name: '提及',
+    examples: ['[user]用户名[/user]'],
+    description: '提及站内用户，会生成指向该用户的链接。',
+  },
+];
+
+const DEFAULT_DEMO = `[center][b]Bangumi 番组计划[/b][/center]
+
+[color=red]红色文字[/color] [size=18]大号文字[/size]
+
+[url=https://bgm.tv]bangumi.tv[/url]
+
+[quote]欢迎使用 BBCode 语法！[/quote]`;
+
+const title = css({ fontSize: '24px', fontWeight: '600', margin: '0 0 24px' });
+
+const wrapper = css({
+  display: 'flex',
+  gap: '40px',
+  alignItems: 'flex-start',
+  mdDown: { flexDirection: 'column', gap: '32px' },
+});
+
+const syntax = css({ flex: '1 1 40%', minWidth: '0' });
+
+const demo = css({ flex: '1 1 60%', minWidth: '0' });
+
+const sectionTitle = css({ fontSize: '18px', fontWeight: '600', margin: '0 0 16px' });
+
+const syntaxList = css({ margin: '0', padding: '0' });
+
+const syntaxItem = css({
+  padding: '12px 0',
+  borderBottom: '1px solid #eee',
+  _last: { borderBottom: 'none' },
+});
+
+const syntaxTerm = css({
+  display: 'flex',
+  alignItems: 'baseline',
+  flexWrap: 'wrap',
+  gap: '12px',
+  fontWeight: 'normal',
+  margin: '0 0 6px',
+});
+
+const tagName = css({ fontSize: '16px', fontWeight: '600' });
+
+const example = css({
+  fontFamily: "'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace",
+  fontSize: '13px',
+  color: '#d6336c',
+  background: '#f4f4f4',
+  border: '1px solid #e6e6e6',
+  borderRadius: '4px',
+  padding: '2px 6px',
+});
+
+const syntaxDesc = css({ margin: '0', fontSize: '13px', lineHeight: '1.8', color: '#666' });
+
+const note = css({ margin: '16px 0 0', fontSize: '13px', color: '#999' });
+
+const demoHint = css({ margin: '0 0 12px', fontSize: '13px', color: '#666' });
+
+const demoTextarea = css({
+  width: '100%',
+  boxSizing: 'border-box',
+  minHeight: '180px',
+  padding: '12px',
+  border: '1px solid #ccc',
+  borderRadius: '4px',
+  fontFamily: "'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace",
+  fontSize: '13px',
+  lineHeight: '1.6',
+  resize: 'vertical',
+  outline: 'none',
+  _focus: { borderColor: '#888' },
+});
+
+const preview = css({
+  marginTop: '16px',
+  minHeight: '120px',
+  padding: '16px',
+  border: '1px solid #e6e6e6',
+  borderRadius: '4px',
+  background: '#fafafa',
+  lineHeight: '1.8',
+  overflowWrap: 'break-word',
+});
+
+const previewEmpty = css({ margin: '0', fontSize: '13px', color: '#999' });
+
+const BBCodeHelp: React.FC = () => {
+  const [value, setValue] = useState(DEFAULT_DEMO);
+
+  return (
+    <>
+      <Helmet title='BBCode 帮助' />
+      <PageContainer>
+        <h1 className={title}>BBCode 帮助</h1>
+        <div className={wrapper}>
+          <section className={syntax}>
+            <h2 className={sectionTitle}>语法说明</h2>
+            <dl className={syntaxList}>
+              {SYNTAX_ITEMS.map((item) => (
+                <div className={syntaxItem} key={item.name}>
+                  <dt className={syntaxTerm}>
+                    <span className={tagName}>{item.name}</span>
+                    {item.examples.map((exampleText) => (
+                      <code className={example} key={exampleText}>
+                        {exampleText}
+                      </code>
+                    ))}
+                  </dt>
+                  <dd className={syntaxDesc}>{item.description}</dd>
+                </div>
+              ))}
+            </dl>
+            <p className={note}>小提示：输入 (bgm38) 等表情代码可以插入 Bangumi 表情。</p>
+          </section>
+          <section className={demo}>
+            <h2 className={sectionTitle}>交互式示例</h2>
+            <p className={demoHint}>在下方输入 BBCode，预览区会实时显示渲染效果。</p>
+            <textarea
+              className={demoTextarea}
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              rows={12}
+              placeholder='输入 BBCode，例如 [b]粗体[/b]'
+            />
+            <div className={preview}>
+              {value.trim() === '' ? (
+                <p className={previewEmpty}>输入内容后，这里会显示渲染效果。</p>
+              ) : (
+                render(value)
+              )}
+            </div>
+          </section>
+        </div>
+      </PageContainer>
+    </>
+  );
+};
+
+export default BBCodeHelp;

--- a/packages/website/src/routes.tsx
+++ b/packages/website/src/routes.tsx
@@ -6,6 +6,14 @@ import LegacyRedirect from './components/PageRoutes/LegacyRedirect';
 const RootIndex = lazy(async () => import('./pages/index'));
 const MatchAll = lazy(async () => import('./pages/index/[...slug]'));
 const HomeIndex = lazy(async () => import('./pages/index/index'));
+const About = lazy(async () => import('./pages/index/about'));
+const AboutGuideline = lazy(async () => import('./pages/index/about/guideline'));
+const AboutCopyright = lazy(async () => import('./pages/index/about/copyright'));
+const AboutLink2Us = lazy(async () => import('./pages/index/about/link2us'));
+const BBCodeHelp = lazy(async () => import('./pages/index/help/bbcode'));
+const DevApp = lazy(async () => import('./pages/index/dev/app'));
+const Dollars = lazy(async () => import('./pages/index/dollars'));
+const Goodies = lazy(async () => import('./pages/index/goodies'));
 const Channel = lazy(async () => import('./pages/index/channel'));
 const Episode = lazy(async () => import('./pages/index/ep/[id]'));
 const EpisodeEdit = lazy(async () => import('./pages/index/ep/[id]/edit'));
@@ -46,28 +54,18 @@ const legacyPagePaths = [
     `${type}/chart`,
     `${type}/tag/*`,
   ]),
-  'about',
-  'about/guideline',
-  'about/copyright',
-  'about/link2us',
-  'award/2021',
   'blog/:id',
   'calendar',
-  'dev/app',
-  'dollars',
-  'goodies',
   'group/all',
   'group/discover',
   'group/mine',
   'group/my_reply',
   'group/my_topic',
-  'help/bbcode',
   'index',
   'index/:id',
   'index/:id/comments',
   'magi',
   'onair',
-  'register',
   'subject/:id/board',
   'subject/:id/characters',
   'subject/:id/collections',
@@ -91,6 +89,19 @@ export const pageRoutes: RouteObject[] = [
       ...legacyPagePaths.map((path) => ({ path, element: <LegacyRedirect /> })),
       { path: '*', element: <MatchAll /> },
       { path: '', element: <HomeIndex /> },
+      {
+        path: 'about',
+        children: [
+          { path: '', element: <About /> },
+          { path: 'guideline', element: <AboutGuideline /> },
+          { path: 'copyright', element: <AboutCopyright /> },
+          { path: 'link2us', element: <AboutLink2Us /> },
+        ],
+      },
+      { path: 'help/bbcode', element: <BBCodeHelp /> },
+      { path: 'dev/app', element: <DevApp /> },
+      { path: 'dollars', element: <Dollars /> },
+      { path: 'goodies', element: <Goodies /> },
       { path: 'ep/:id', element: <Episode /> },
       { path: 'ep/:id/edit', element: <EpisodeEdit /> },
       { path: 'notifications', element: <Notifications /> },


### PR DESCRIPTION
## Summary

Implement the D-class static pages from `docs/features-without-new-api.md` — pages that need no backend API. These paths previously redirected to the legacy site (`bgm.tv`) via `LegacyRedirect`; they now render real pages:

- `/about`, `/about/guideline`, `/about/copyright`, `/about/link2us` — about the site / community guidelines / copyright / link to us, sharing one nav and Panda CSS styles
- `/help/bbcode` — BBCode syntax reference with an interactive live preview, using the existing `@bangumi/utils` BBCode renderer
- `/dev/app` — developer platform intro (Bangumi API / OAuth) with a link to the official API docs
- `/dollars` — official Dollars client intro page
- `/goodies` — doujin / merchandise intro page

All new styles use Panda CSS (`@bangumi/styled-system/css`). The corresponding entries were removed from `legacyPagePaths` and real routes registered in `routes.tsx`; `pnpm panda:codegen && pnpm panda:cssgen` regenerated `styles.css`.

Also fixes the pre-commit hook: `lint-staged` now runs `stylelint --fix --allow-empty-input` so commits that only touch the generated `styles.css` (ignored by `.stylelintignore`) do not fail with `AllFilesIgnoredError`.

## Checks

- `pnpm type-check` ✓
- `pnpm lint` ✓
- `pnpm prettier:check` ✓ (for changed files)
- `pnpm build` ✓
- pre-commit `lint-staged` ✓