### PR TITLE
feat(website): add subject characters page (/subject/:id/characters)

### DIFF
--- a/packages/website/src/hooks/use-subject-characters.ts
+++ b/packages/website/src/hooks/use-subject-characters.ts
@@ -1,0 +1,41 @@
+import { ok } from '@oazapfts/runtime';
+import useSWR from 'swr';
+
+import { ozaClient } from '@bangumi/client';
+import type { SubjectCharacter } from '@bangumi/client/client';
+
+const PAGE_SIZE = 100;
+
+async function fetchSubjectCharacters(subjectID: number): Promise<SubjectCharacter[]> {
+  const firstPage = await ok(
+    ozaClient.getSubjectCharacters(subjectID, { limit: PAGE_SIZE, offset: 0 }),
+  );
+  const remainingPageCount = Math.ceil((firstPage.total - firstPage.data.length) / PAGE_SIZE);
+
+  if (remainingPageCount <= 0) {
+    return firstPage.data;
+  }
+
+  const remainingPages = await Promise.all(
+    Array.from({ length: remainingPageCount }, async (_, index) =>
+      ok(
+        ozaClient.getSubjectCharacters(subjectID, {
+          limit: PAGE_SIZE,
+          offset: firstPage.data.length + index * PAGE_SIZE,
+        }),
+      ),
+    ),
+  );
+
+  return [firstPage, ...remainingPages].flatMap((page) => page.data);
+}
+
+export function useSubjectCharacters(subjectID: number): SubjectCharacter[] | undefined {
+  const { data } = useSWR(
+    `subject-characters ${subjectID}`,
+    async () => fetchSubjectCharacters(subjectID),
+    { suspense: true },
+  );
+
+  return data;
+}

--- a/packages/website/src/mocks/fixtures/p1/subjects/12/characters-GET.json
+++ b/packages/website/src/mocks/fixtures/p1/subjects/12/characters-GET.json
@@ -1,0 +1,112 @@
+{
+  "data": [
+    {
+      "character": {
+        "id": 5,
+        "name": "Test Character",
+        "nameCN": "测试角色",
+        "role": 1,
+        "info": "测试角色的简介，用于验证角色介绍在列表中的展示与两行截断效果。",
+        "images": {
+          "large": "https://lain.bgm.tv/pic/crt/l/00/00/05.jpg",
+          "medium": "https://lain.bgm.tv/pic/crt/m/00/00/05.jpg",
+          "small": "https://lain.bgm.tv/pic/crt/s/00/00/05.jpg",
+          "grid": "https://lain.bgm.tv/pic/crt/g/00/00/05.jpg"
+        },
+        "comment": 10,
+        "lock": false,
+        "nsfw": false
+      },
+      "casts": [
+        {
+          "person": {
+            "id": 8,
+            "name": "Test CV",
+            "nameCN": "测试声优",
+            "type": 1,
+            "info": "",
+            "career": ["声优"],
+            "images": {
+              "large": "https://lain.bgm.tv/pic/prsn/l/00/00/08.jpg",
+              "medium": "https://lain.bgm.tv/pic/prsn/m/00/00/08.jpg",
+              "small": "https://lain.bgm.tv/pic/prsn/s/00/00/08.jpg",
+              "grid": "https://lain.bgm.tv/pic/prsn/g/00/00/08.jpg"
+            },
+            "comment": 1,
+            "lock": false,
+            "nsfw": false
+          },
+          "relation": 0,
+          "summary": ""
+        }
+      ],
+      "type": 1,
+      "order": 1
+    },
+    {
+      "character": {
+        "id": 6,
+        "name": "Test Character B",
+        "nameCN": "测试配角",
+        "role": 1,
+        "info": "",
+        "images": {
+          "large": "https://lain.bgm.tv/pic/crt/l/00/00/06.jpg",
+          "medium": "https://lain.bgm.tv/pic/crt/m/00/00/06.jpg",
+          "small": "https://lain.bgm.tv/pic/crt/s/00/00/06.jpg",
+          "grid": "https://lain.bgm.tv/pic/crt/g/00/00/06.jpg"
+        },
+        "comment": 2,
+        "lock": false,
+        "nsfw": false
+      },
+      "casts": [
+        {
+          "person": {
+            "id": 9,
+            "name": "Test Voice Actor",
+            "nameCN": "测试配音演员",
+            "type": 1,
+            "info": "",
+            "career": ["配音演员"],
+            "images": {
+              "large": "https://lain.bgm.tv/pic/prsn/l/00/00/09.jpg",
+              "medium": "https://lain.bgm.tv/pic/prsn/m/00/00/09.jpg",
+              "small": "https://lain.bgm.tv/pic/prsn/s/00/00/09.jpg",
+              "grid": "https://lain.bgm.tv/pic/prsn/g/00/00/09.jpg"
+            },
+            "comment": 0,
+            "lock": false,
+            "nsfw": false
+          },
+          "relation": 3,
+          "summary": ""
+        }
+      ],
+      "type": 2,
+      "order": 2
+    },
+    {
+      "character": {
+        "id": 7,
+        "name": "Test Cameo",
+        "nameCN": "测试客串",
+        "role": 2,
+        "info": "",
+        "images": {
+          "large": "https://lain.bgm.tv/pic/crt/l/00/00/07.jpg",
+          "medium": "https://lain.bgm.tv/pic/crt/m/00/00/07.jpg",
+          "small": "https://lain.bgm.tv/pic/crt/s/00/00/07.jpg",
+          "grid": "https://lain.bgm.tv/pic/crt/g/00/00/07.jpg"
+        },
+        "comment": 0,
+        "lock": false,
+        "nsfw": false
+      },
+      "casts": [],
+      "type": 3,
+      "order": 3
+    }
+  ],
+  "total": 3
+}

--- a/packages/website/src/mocks/handlers.ts
+++ b/packages/website/src/mocks/handlers.ts
@@ -15,6 +15,7 @@ export const handlers = [
   mockAPI('/p1/subjects/:subjectID/episodes', 'get'),
   mockAPI('/p1/subjects/:subjectID/indexes', 'get'),
   mockAPI('/p1/subjects/:subjectID/relations', 'get'),
+  mockAPI('/p1/subjects/:subjectID/characters', 'get'),
   mockAPI('/p1/subjects/:subjectID/collects', 'get'),
   mockAPI('/p1/persons/:personID', 'get'),
   mockAPI('/p1/persons/:personID/casts', 'get'),

--- a/packages/website/src/pages/index/subject/[id]/SubjectCharacters.spec.tsx
+++ b/packages/website/src/pages/index/subject/[id]/SubjectCharacters.spec.tsx
@@ -1,0 +1,50 @@
+import { screen } from '@testing-library/react';
+import React from 'react';
+
+import type { SubjectCharacter, SubjectHomeResponse } from '@bangumi/client/client';
+import { renderPage } from '@bangumi/website/utils/test-utils';
+
+import charactersFixture from '../../../../mocks/fixtures/p1/subjects/12/characters-GET.json';
+import homeFixture from '../../../../mocks/fixtures/p1/subjects/12/home-GET.json';
+import SubjectCharacters from './components/SubjectCharacters';
+
+const homeData = homeFixture as unknown as SubjectHomeResponse;
+const characters = charactersFixture.data as SubjectCharacter[];
+
+describe('SubjectCharacters', () => {
+  it('renders character groups with character and person links', () => {
+    renderPage(<SubjectCharacters subject={homeData.subject} characters={characters} />);
+
+    // 按出场类型分组：角色、配角、客串
+    expect(screen.getByRole('heading', { name: '角色' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: '配角' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: '客串' })).toBeInTheDocument();
+
+    // 角色头像链接与名字链接均指向角色页
+    const characterLinks = screen.getAllByRole('link', { name: '测试角色' });
+    expect(characterLinks).toHaveLength(2);
+    expect(characterLinks.every((link) => link.getAttribute('href') === '/character/5')).toBe(true);
+
+    // 出演声优链接指向人物页
+    expect(screen.getByRole('link', { name: 'Test CV' })).toHaveAttribute('href', '/person/8');
+    expect(screen.getByRole('link', { name: 'Test Voice Actor' })).toHaveAttribute(
+      'href',
+      '/person/9',
+    );
+
+    // 角色简介与配音类型标签
+    expect(
+      screen.getByText('测试角色的简介，用于验证角色介绍在列表中的展示与两行截断效果。'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('CV:')).toBeInTheDocument();
+    expect(screen.getByText('中文配音:')).toBeInTheDocument();
+
+    expect(screen.getByRole('link', { name: '返回条目' })).toHaveAttribute('href', '/subject/12');
+  });
+
+  it('renders an empty state when the subject has no characters', () => {
+    renderPage(<SubjectCharacters subject={homeData.subject} characters={[]} />);
+
+    expect(screen.getByText('暂无角色')).toBeInTheDocument();
+  });
+});

--- a/packages/website/src/pages/index/subject/[id]/characters.tsx
+++ b/packages/website/src/pages/index/subject/[id]/characters.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+import { withErrorBoundary } from '@bangumi/website/components/ErrorBoundary';
+import Helmet from '@bangumi/website/components/Helmet';
+import { useSubjectCharacters } from '@bangumi/website/hooks/use-subject-characters';
+import { useSubjectHome } from '@bangumi/website/hooks/use-subject-home';
+
+import SubjectCharacters from './components/SubjectCharacters';
+
+function SubjectCharactersPage() {
+  const { id } = useParams();
+  const subjectID = Number(id);
+  const { data } = useSubjectHome(subjectID);
+  const characters = useSubjectCharacters(subjectID);
+
+  if (!data || !characters) {
+    return null;
+  }
+
+  return (
+    <>
+      <Helmet title={`${data.subject.nameCN || data.subject.name} - 角色`} />
+      <SubjectCharacters subject={data.subject} characters={characters} />
+    </>
+  );
+}
+
+export default withErrorBoundary(SubjectCharactersPage, {
+  404: () => <div>没有找到条目</div>,
+});

--- a/packages/website/src/pages/index/subject/[id]/components/SubjectCharacters.module.less
+++ b/packages/website/src/pages/index/subject/[id]/components/SubjectCharacters.module.less
@@ -1,0 +1,114 @@
+@import '@bangumi/design/theme/base';
+
+.columns {
+  display: grid;
+  grid-template-columns: minmax(0, 7fr) minmax(260px, 3fr);
+  align-items: start;
+  gap: 20px;
+}
+
+.characterGroups {
+  min-width: 0;
+}
+
+.groupTitle {
+  margin: 0;
+  padding: 5px 10px;
+  border-top: 1px solid @gray-10;
+  border-bottom: 1px solid @gray-10;
+  color: @gray-80;
+  font-size: 13px;
+  font-weight: normal;
+  line-height: 18px;
+}
+
+.characterList {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.characterItem {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px;
+  border-bottom: 1px dotted @gray-10;
+}
+
+.avatarLink {
+  flex-shrink: 0;
+}
+
+.avatar {
+  display: block;
+  width: 60px;
+  height: 60px;
+  border-radius: 4px;
+  aspect-ratio: 1;
+  object-fit: cover;
+}
+
+.avatarFallback {
+  display: flex;
+  width: 60px;
+  height: 60px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  background: @gray-10;
+  color: @gray-60;
+  font-size: 20px;
+}
+
+.characterInfo {
+  min-width: 0;
+}
+
+.name {
+  display: block;
+  margin-bottom: 4px;
+  color: @gray-80;
+  font-size: 14px;
+  font-weight: bold;
+  overflow-wrap: anywhere;
+}
+
+.info {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+  margin: 0 0 4px;
+  color: @gray-60;
+  font-size: 12px;
+  line-height: 1.6;
+  overflow-wrap: anywhere;
+}
+
+.casts {
+  margin: 0;
+  color: @gray-60;
+  font-size: 12px;
+  line-height: 1.6;
+  overflow-wrap: anywhere;
+}
+
+.castLabel {
+  color: @gray-60;
+}
+
+.empty {
+  margin: 0;
+  padding: 16px 10px;
+  border-top: 1px solid @gray-10;
+  border-bottom: 1px dotted @gray-10;
+  color: @gray-60;
+  font-size: 13px;
+}
+
+@media (max-width: @md) {
+  .columns {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/packages/website/src/pages/index/subject/[id]/components/SubjectCharacters.tsx
+++ b/packages/website/src/pages/index/subject/[id]/components/SubjectCharacters.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+
+import type { Subject, SubjectCharacter } from '@bangumi/client/client';
+import { Typography } from '@bangumi/design';
+import { getCharacterLink, getPersonLink } from '@bangumi/utils/pages';
+import PageContainer from '@bangumi/website/components/PageContainer';
+
+import { CAST_TYPE_DESC } from './subject-common';
+import styles from './SubjectCharacters.module.less';
+import { SubjectHeader } from './SubjectDetail';
+import SubjectSummaryCard from './SubjectSummaryCard';
+
+const { Link } = Typography;
+
+/** 角色出场类型分组标题，对齐旧站 subject_character 分组 */
+const CHARACTER_TYPE_DESC: Record<number, string> = {
+  1: '角色',
+  2: '配角',
+  3: '客串',
+};
+
+type CharacterGroup = {
+  type: number;
+  label: string;
+  items: SubjectCharacter[];
+};
+
+/** 按出场类型分组，组内按 order 排序；分组顺序固定为主角、配角、客串 */
+function groupCharacters(characters: SubjectCharacter[]): CharacterGroup[] {
+  const grouped = new Map<number, SubjectCharacter[]>();
+
+  for (const item of characters) {
+    const list = grouped.get(item.type) ?? [];
+    list.push(item);
+    grouped.set(item.type, list);
+  }
+
+  return [1, 2, 3]
+    .filter((type) => grouped.has(type))
+    .map((type) => ({
+      type,
+      label: CHARACTER_TYPE_DESC[type] ?? `类型 ${type}`,
+      items: [...(grouped.get(type) ?? [])].sort((a, b) => a.order - b.order),
+    }));
+}
+
+function characterTitle(character: SubjectCharacter['character']): string {
+  return character.nameCN || character.name;
+}
+
+export default function SubjectCharacters({
+  subject,
+  characters,
+}: {
+  subject: Subject;
+  characters: SubjectCharacter[];
+}) {
+  const groups = groupCharacters(characters);
+
+  return (
+    <PageContainer as='main'>
+      <SubjectHeader subject={subject} />
+      <div className={styles.columns}>
+        <div className={styles.characterGroups}>
+          {groups.length === 0 && <p className={styles.empty}>暂无角色</p>}
+          {groups.map((group) => (
+            <section key={group.type} aria-labelledby={`character-group-${group.type}-heading`}>
+              <h2 id={`character-group-${group.type}-heading`} className={styles.groupTitle}>
+                {group.label}
+              </h2>
+              <ul className={styles.characterList}>
+                {group.items.map(({ character, casts }) => (
+                  <li key={character.id} className={styles.characterItem}>
+                    <Link
+                      to={getCharacterLink(character.id)}
+                      className={styles.avatarLink}
+                      title={characterTitle(character)}
+                    >
+                      {character.images?.grid ? (
+                        <img
+                          src={character.images.grid}
+                          className={styles.avatar}
+                          loading='lazy'
+                          alt=''
+                        />
+                      ) : (
+                        <span className={styles.avatarFallback}>
+                          {characterTitle(character).slice(0, 1)}
+                        </span>
+                      )}
+                    </Link>
+                    <div className={styles.characterInfo}>
+                      <Link
+                        to={getCharacterLink(character.id)}
+                        className={styles.name}
+                        title={characterTitle(character)}
+                      >
+                        {characterTitle(character)}
+                      </Link>
+                      {character.info !== '' && <p className={styles.info}>{character.info}</p>}
+                      {casts.length > 0 && (
+                        <p className={styles.casts}>
+                          {casts.map((cast, index) => (
+                            <React.Fragment key={cast.person.id}>
+                              {index > 0 && ' / '}
+                              <span className={styles.castLabel}>
+                                {CAST_TYPE_DESC[cast.relation] ?? '出演'}:
+                              </span>{' '}
+                              <Link to={getPersonLink(cast.person.id)}>{cast.person.name}</Link>
+                            </React.Fragment>
+                          ))}
+                        </p>
+                      )}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+        <SubjectSummaryCard subject={subject} />
+      </div>
+    </PageContainer>
+  );
+}

--- a/packages/website/src/routes.tsx
+++ b/packages/website/src/routes.tsx
@@ -21,6 +21,7 @@ const GroupTopic = lazy(async () => import('./pages/index/group/topic/[id]'));
 const GroupTopicEdit = lazy(async () => import('./pages/index/group/topic/[id]/edit'));
 const GroupTopicHome = lazy(async () => import('./pages/index/group/topic/[id]/index'));
 const Character = lazy(async () => import('./pages/index/character/[id]/index'));
+const SubjectCharacters = lazy(async () => import('./pages/index/subject/[id]/characters'));
 const Subject = lazy(async () => import('./pages/index/subject/[id]/index'));
 const SubjectIndexes = lazy(async () => import('./pages/index/subject/[id]/indexes'));
 const SubjectEpisodes = lazy(async () => import('./pages/index/subject/[id]/ep'));
@@ -69,7 +70,6 @@ const legacyPagePaths = [
   'onair',
   'register',
   'subject/:id/board',
-  'subject/:id/characters',
   'subject/:id/collections',
   'subject/:id/comments',
   'subject/:id/persons',
@@ -161,6 +161,7 @@ export const pageRoutes: RouteObject[] = [
             path: ':id',
             children: [
               { path: '', element: <Subject /> },
+              { path: 'characters', element: <SubjectCharacters /> },
               { path: 'index', element: <SubjectIndexes /> },
               { path: 'ep', element: <SubjectEpisodes /> },
               { path: 'relations', element: <SubjectRelations /> },


### PR DESCRIPTION
## 改动

新增条目角色页面 `/subject/:id/characters`，替代原先重定向到旧站的逻辑。不需要新增后端 API，复用已有 `getSubjectCharacters`。

- 新增 `use-subject-characters` hook：按 limit=100 分页聚合全量角色（复用 `use-subject-relations` 模式）
- 新增 `SubjectCharacters` 组件：按出场类型分组（角色/配角/客串），组内按 `order` 排序；每行展示头像（含无图 fallback）、名字、简介（两行截断）、出演声优链接
- 页面复用 `SubjectHeader`（tab 导航）与 `SubjectSummaryCard`（右栏），与 relations 页布局一致
- `routes.tsx`：从 legacy 重定向移除该路径并注册真实路由
- 补充 MSW handler 与 fixture、组件测试

## 验证

- 新增 2 个组件测试；完整测试套件 55 files / 326 tests 通过
- `pnpm type-check`、`pnpm lint`、`pnpm prettier:check`、`pnpm lint:style`、`pnpm build` 均通过