### PR TITLE
feat(website): add subject persons page (/subject/:id/persons)

### DIFF
--- a/packages/styled-system/styles.css
+++ b/packages/styled-system/styles.css
@@ -688,6 +688,18 @@
     margin: 10px 0;
 }
 
+  .p_5px_10px {
+    padding: 5px 10px;
+}
+
+  .p_10px {
+    padding: 10px;
+}
+
+  .bg_\#e8e3e3 {
+    background: #e8e3e3;
+}
+
   .p_2px_8px_2px_5px {
     padding: 2px 8px 2px 5px;
 }
@@ -806,6 +818,10 @@
 
   .bd-b_1px_dotted_\#e8e3e3 {
     border-bottom: 1px dotted #e8e3e3;
+}
+
+  .gap_20px {
+    gap: 20px;
 }
 
   .gap_5px {
@@ -1101,6 +1117,18 @@
     background-size: 15px 100px;
 }
 
+  .asp_1 {
+    aspect-ratio: 1;
+}
+
+  .obj-f_cover {
+    object-fit: cover;
+}
+
+  .ov-wrap_anywhere {
+    overflow-wrap: anywhere;
+}
+
   .page_1 {
     page: 1px;
 }
@@ -1307,6 +1335,14 @@
 
   .h_15px {
     height: 15px;
+}
+
+  .w_60px {
+    width: 60px;
+}
+
+  .mb_4px {
+    margin-bottom: 4px;
 }
 
   .mt_8px {

--- a/packages/website/src/hooks/use-subject-staff-persons.ts
+++ b/packages/website/src/hooks/use-subject-staff-persons.ts
@@ -1,0 +1,41 @@
+import { ok } from '@oazapfts/runtime';
+import useSWR from 'swr';
+
+import { ozaClient } from '@bangumi/client';
+import type { SubjectStaff } from '@bangumi/client/client';
+
+const PAGE_SIZE = 100;
+
+async function fetchSubjectStaffPersons(subjectID: number): Promise<SubjectStaff[]> {
+  const firstPage = await ok(
+    ozaClient.getSubjectStaffPersons(subjectID, { limit: PAGE_SIZE, offset: 0 }),
+  );
+  const remainingPageCount = Math.ceil((firstPage.total - firstPage.data.length) / PAGE_SIZE);
+
+  if (remainingPageCount <= 0) {
+    return firstPage.data;
+  }
+
+  const remainingPages = await Promise.all(
+    Array.from({ length: remainingPageCount }, async (_, index) =>
+      ok(
+        ozaClient.getSubjectStaffPersons(subjectID, {
+          limit: PAGE_SIZE,
+          offset: firstPage.data.length + index * PAGE_SIZE,
+        }),
+      ),
+    ),
+  );
+
+  return [firstPage, ...remainingPages].flatMap((page) => page.data);
+}
+
+export function useSubjectStaffPersons(subjectID: number): SubjectStaff[] | undefined {
+  const { data } = useSWR(
+    `subject-staff-persons ${subjectID}`,
+    async () => fetchSubjectStaffPersons(subjectID),
+    { suspense: true },
+  );
+
+  return data;
+}

--- a/packages/website/src/mocks/fixtures/p1/subjects/12/staffs/persons-GET.json
+++ b/packages/website/src/mocks/fixtures/p1/subjects/12/staffs/persons-GET.json
@@ -1,0 +1,62 @@
+{
+  "data": [
+    {
+      "staff": {
+        "id": 1,
+        "name": "Test Director",
+        "nameCN": "测试监督",
+        "type": 1,
+        "info": "",
+        "career": ["导演", "分镜"],
+        "images": {
+          "large": "https://lain.bgm.tv/pic/prsn/l/00/00/01.jpg",
+          "medium": "https://lain.bgm.tv/pic/prsn/m/00/00/01.jpg",
+          "small": "https://lain.bgm.tv/pic/prsn/s/00/00/01.jpg",
+          "grid": "https://lain.bgm.tv/pic/prsn/g/00/00/01.jpg"
+        },
+        "comment": 5,
+        "lock": false,
+        "nsfw": false
+      },
+      "positions": [
+        {
+          "type": { "id": 1, "en": "director", "cn": "监督", "jp": "監督" },
+          "summary": "",
+          "appearEps": ""
+        },
+        {
+          "type": { "id": 3, "en": "storyboard", "cn": "分镜", "jp": "絵コンテ" },
+          "summary": "第1-3话",
+          "appearEps": ""
+        }
+      ]
+    },
+    {
+      "staff": {
+        "id": 2,
+        "name": "Test Writer",
+        "nameCN": "测试脚本",
+        "type": 1,
+        "info": "",
+        "career": ["脚本"],
+        "images": {
+          "large": "https://lain.bgm.tv/pic/prsn/l/00/00/02.jpg",
+          "medium": "https://lain.bgm.tv/pic/prsn/m/00/00/02.jpg",
+          "small": "https://lain.bgm.tv/pic/prsn/s/00/00/02.jpg",
+          "grid": "https://lain.bgm.tv/pic/prsn/g/00/00/02.jpg"
+        },
+        "comment": 3,
+        "lock": false,
+        "nsfw": false
+      },
+      "positions": [
+        {
+          "type": { "id": 2, "en": "writer", "cn": "脚本", "jp": "脚本" },
+          "summary": "系列构成",
+          "appearEps": "1-12"
+        }
+      ]
+    }
+  ],
+  "total": 2
+}

--- a/packages/website/src/mocks/handlers.ts
+++ b/packages/website/src/mocks/handlers.ts
@@ -16,6 +16,7 @@ export const handlers = [
   mockAPI('/p1/subjects/:subjectID/indexes', 'get'),
   mockAPI('/p1/subjects/:subjectID/relations', 'get'),
   mockAPI('/p1/subjects/:subjectID/characters', 'get'),
+  mockAPI('/p1/subjects/:subjectID/staffs/persons', 'get'),
   mockAPI('/p1/subjects/:subjectID/collects', 'get'),
   mockAPI('/p1/persons/:personID', 'get'),
   mockAPI('/p1/persons/:personID/casts', 'get'),

--- a/packages/website/src/pages/index/subject/[id]/SubjectPersons.spec.tsx
+++ b/packages/website/src/pages/index/subject/[id]/SubjectPersons.spec.tsx
@@ -1,0 +1,50 @@
+import { screen } from '@testing-library/react';
+import React from 'react';
+
+import type { SubjectHomeResponse, SubjectStaff } from '@bangumi/client/client';
+import { renderPage } from '@bangumi/website/utils/test-utils';
+
+import homeFixture from '../../../../mocks/fixtures/p1/subjects/12/home-GET.json';
+import staffFixture from '../../../../mocks/fixtures/p1/subjects/12/staffs/persons-GET.json';
+import SubjectPersons from './components/SubjectPersons';
+
+const homeData = homeFixture as unknown as SubjectHomeResponse;
+const staffs = staffFixture.data as SubjectStaff[];
+
+describe('SubjectPersons', () => {
+  it('groups staff by position with person links', () => {
+    renderPage(<SubjectPersons subject={homeData.subject} staffs={staffs} />);
+
+    // 按职位分组，同一人可以出现在多个职位下
+    expect(screen.getByRole('heading', { name: '监督' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: '脚本' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: '分镜' })).toBeInTheDocument();
+
+    // 名字链接：测试监督同时出现在「监督」和「分镜」两组
+    const directorNameLinks = screen.getAllByRole('link', { name: 'Test Director' });
+    expect(directorNameLinks).toHaveLength(2);
+    expect(directorNameLinks.every((link) => link.getAttribute('href') === '/person/1')).toBe(true);
+
+    // 头像链接（title 显示中文名）同样指向人物页
+    const directorAvatarLinks = screen.getAllByRole('link', { name: '测试监督' });
+    expect(directorAvatarLinks).toHaveLength(2);
+    expect(directorAvatarLinks.every((link) => link.getAttribute('href') === '/person/1')).toBe(
+      true,
+    );
+
+    expect(screen.getByRole('link', { name: 'Test Writer' })).toHaveAttribute('href', '/person/2');
+    expect(screen.getByRole('link', { name: '测试脚本' })).toHaveAttribute('href', '/person/2');
+
+    // 职位摘要与出演话数
+    expect(screen.getByText('第1-3话')).toBeInTheDocument();
+    expect(screen.getByText('系列构成 / 1-12')).toBeInTheDocument();
+
+    expect(screen.getByRole('link', { name: '返回条目' })).toHaveAttribute('href', '/subject/12');
+  });
+
+  it('renders an empty state when the subject has no staff', () => {
+    renderPage(<SubjectPersons subject={homeData.subject} staffs={[]} />);
+
+    expect(screen.getByText('暂无制作人员')).toBeInTheDocument();
+  });
+});

--- a/packages/website/src/pages/index/subject/[id]/components/SubjectPersons.tsx
+++ b/packages/website/src/pages/index/subject/[id]/components/SubjectPersons.tsx
@@ -1,0 +1,182 @@
+import React from 'react';
+
+import type { SlimPerson, Subject, SubjectStaff } from '@bangumi/client/client';
+import { Typography } from '@bangumi/design';
+import { css } from '@bangumi/styled-system/css';
+import { getPersonLink } from '@bangumi/utils/pages';
+import PageContainer from '@bangumi/website/components/PageContainer';
+
+import { SubjectHeader } from './SubjectDetail';
+import SubjectSummaryCard from './SubjectSummaryCard';
+
+const { Link } = Typography;
+
+const columns = css({
+  display: 'grid',
+  gridTemplateColumns: 'minmax(0, 7fr) minmax(260px, 3fr)',
+  alignItems: 'start',
+  gap: '20px',
+  smDown: { gridTemplateColumns: 'minmax(0, 1fr)' },
+});
+
+const personGroups = css({ minWidth: '0' });
+
+const groupTitle = css({
+  margin: '0',
+  padding: '5px 10px',
+  borderTop: '1px solid #e8e3e3',
+  borderBottom: '1px solid #e8e3e3',
+  color: '#595555',
+  fontSize: '13px',
+  fontWeight: 'normal',
+  lineHeight: '18px',
+});
+
+const personList = css({ margin: '0', padding: '0', listStyle: 'none' });
+
+const personItem = css({
+  display: 'flex',
+  alignItems: 'flex-start',
+  gap: '10px',
+  padding: '10px',
+  borderBottom: '1px dotted #e8e3e3',
+});
+
+const avatarLink = css({ flexShrink: '0' });
+
+const avatar = css({
+  display: 'block',
+  width: '60px',
+  height: '60px',
+  borderRadius: '4px',
+  aspectRatio: '1',
+  objectFit: 'cover',
+});
+
+const avatarFallback = css({
+  display: 'flex',
+  width: '60px',
+  height: '60px',
+  alignItems: 'center',
+  justifyContent: 'center',
+  borderRadius: '4px',
+  background: '#e8e3e3',
+  color: '#9f9b9b',
+  fontSize: '20px',
+});
+
+const personInfo = css({ minWidth: '0' });
+
+const name = css({
+  display: 'block',
+  marginBottom: '4px',
+  color: '#595555',
+  fontSize: '14px',
+  fontWeight: 'bold',
+  overflowWrap: 'anywhere',
+});
+
+const info = css({
+  margin: '0',
+  color: '#9f9b9b',
+  fontSize: '12px',
+  lineHeight: '1.6',
+  overflowWrap: 'anywhere',
+});
+
+const empty = css({
+  margin: '0',
+  padding: '16px 10px',
+  borderTop: '1px solid #e8e3e3',
+  borderBottom: '1px dotted #e8e3e3',
+  color: '#9f9b9b',
+  fontSize: '13px',
+});
+
+type PositionGroup = {
+  key: string;
+  label: string;
+  items: { staff: SlimPerson; summary: string; appearEps: string }[];
+};
+
+/** 按职位分组（group=position 视图）：将「人员 -> 职位列表」转置为「职位 -> 人员列表」，职位顺序保持 API 首次出现顺序 */
+function groupByPosition(staffs: SubjectStaff[]): PositionGroup[] {
+  const groups = new Map<string, PositionGroup>();
+
+  for (const { staff, positions } of staffs) {
+    for (const position of positions) {
+      const label =
+        position.type.cn || position.type.jp || position.type.en || `职位 ${position.type.id}`;
+      const key = `position-${position.type.id}`;
+      const group = groups.get(key) ?? { key, label, items: [] };
+      group.items.push({ staff, summary: position.summary, appearEps: position.appearEps });
+      groups.set(key, group);
+    }
+  }
+
+  return [...groups.values()];
+}
+
+function personTitle(staff: SlimPerson): string {
+  return staff.nameCN || staff.name;
+}
+
+export default function SubjectPersons({
+  subject,
+  staffs,
+}: {
+  subject: Subject;
+  staffs: SubjectStaff[];
+}) {
+  const groups = groupByPosition(staffs);
+
+  return (
+    <PageContainer as='main'>
+      <SubjectHeader subject={subject} />
+      <div className={columns}>
+        <div className={personGroups}>
+          {groups.length === 0 && <p className={empty}>暂无制作人员</p>}
+          {groups.map((group) => (
+            <section key={group.key} aria-labelledby={`${group.key}-heading`}>
+              <h2 id={`${group.key}-heading`} className={groupTitle}>
+                {group.label}
+              </h2>
+              <ul className={personList}>
+                {group.items.map(({ staff, summary, appearEps }) => (
+                  <li key={staff.id} className={personItem}>
+                    <Link
+                      to={getPersonLink(staff.id)}
+                      className={avatarLink}
+                      title={personTitle(staff)}
+                    >
+                      {staff.images?.grid ? (
+                        <img src={staff.images.grid} className={avatar} loading='lazy' alt='' />
+                      ) : (
+                        <span className={avatarFallback}>{personTitle(staff).slice(0, 1)}</span>
+                      )}
+                    </Link>
+                    <div className={personInfo}>
+                      <Link
+                        to={getPersonLink(staff.id)}
+                        className={name}
+                        title={personTitle(staff)}
+                      >
+                        {staff.name}
+                      </Link>
+                      {(summary !== '' || appearEps !== '') && (
+                        <p className={info}>
+                          {[summary, appearEps].filter((text) => text !== '').join(' / ')}
+                        </p>
+                      )}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+        <SubjectSummaryCard subject={subject} />
+      </div>
+    </PageContainer>
+  );
+}

--- a/packages/website/src/pages/index/subject/[id]/persons.tsx
+++ b/packages/website/src/pages/index/subject/[id]/persons.tsx
@@ -1,0 +1,7 @@
+
+function SubjectPersonsPage() {
+  // TODO: 实现制作人员列表（/subject/:id/persons）
+  return null;
+}
+
+export default SubjectPersonsPage;

--- a/packages/website/src/pages/index/subject/[id]/persons.tsx
+++ b/packages/website/src/pages/index/subject/[id]/persons.tsx
@@ -1,7 +1,31 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+import { withErrorBoundary } from '@bangumi/website/components/ErrorBoundary';
+import Helmet from '@bangumi/website/components/Helmet';
+import { useSubjectHome } from '@bangumi/website/hooks/use-subject-home';
+import { useSubjectStaffPersons } from '@bangumi/website/hooks/use-subject-staff-persons';
+
+import SubjectPersons from './components/SubjectPersons';
 
 function SubjectPersonsPage() {
-  // TODO: 实现制作人员列表（/subject/:id/persons）
-  return null;
+  const { id } = useParams();
+  const subjectID = Number(id);
+  const { data } = useSubjectHome(subjectID);
+  const staffs = useSubjectStaffPersons(subjectID);
+
+  if (!data || !staffs) {
+    return null;
+  }
+
+  return (
+    <>
+      <Helmet title={`${data.subject.nameCN || data.subject.name} - 制作人员`} />
+      <SubjectPersons subject={data.subject} staffs={staffs} />
+    </>
+  );
 }
 
-export default SubjectPersonsPage;
+export default withErrorBoundary(SubjectPersonsPage, {
+  404: () => <div>没有找到条目</div>,
+});

--- a/packages/website/src/routes.tsx
+++ b/packages/website/src/routes.tsx
@@ -30,6 +30,7 @@ const GroupTopicEdit = lazy(async () => import('./pages/index/group/topic/[id]/e
 const GroupTopicHome = lazy(async () => import('./pages/index/group/topic/[id]/index'));
 const Character = lazy(async () => import('./pages/index/character/[id]/index'));
 const SubjectCharacters = lazy(async () => import('./pages/index/subject/[id]/characters'));
+const SubjectPersons = lazy(async () => import('./pages/index/subject/[id]/persons'));
 const Subject = lazy(async () => import('./pages/index/subject/[id]/index'));
 const SubjectIndexes = lazy(async () => import('./pages/index/subject/[id]/indexes'));
 const SubjectEpisodes = lazy(async () => import('./pages/index/subject/[id]/ep'));
@@ -70,7 +71,6 @@ const legacyPagePaths = [
   'subject/:id/board',
   'subject/:id/collections',
   'subject/:id/comments',
-  'subject/:id/persons',
   'subject/:id/reviews',
   'subject/:id/stats',
   'subject/ep/:id',
@@ -173,6 +173,7 @@ export const pageRoutes: RouteObject[] = [
             children: [
               { path: '', element: <Subject /> },
               { path: 'characters', element: <SubjectCharacters /> },
+              { path: 'persons', element: <SubjectPersons /> },
               { path: 'index', element: <SubjectIndexes /> },
               { path: 'ep', element: <SubjectEpisodes /> },
               { path: 'relations', element: <SubjectRelations /> },


### PR DESCRIPTION
## 改动

新增条目制作人员页面 `/subject/:id/persons`（`?group=position` 按职位分组视图），替代原先重定向到旧站的逻辑。不需要新增后端 API，复用已有 `getSubjectStaffPersons`。

分两个提交：
1. **空页面 + 路由**（`ad2a70f`）：从 legacy 重定向移除该路径并注册路由
2. **实现**（`46f7e25`）：
   - 新增 `use-subject-staff-persons` hook：按 limit=100 分页聚合全量制作人员（复用 `use-subject-characters` 模式）
   - 新增 `SubjectPersons` 组件：将「人员 -> 职位列表」转置为「职位 -> 人员列表」（同一人可出现在多个职位下），职位顺序保持 API 首次出现顺序；每行展示头像（含无图 fallback）、名字、职位摘要/出演话数
   - 页面复用 `SubjectHeader`（tab 导航）与 `SubjectSummaryCard`（右栏），样式使用 Panda CSS
   - 补充 MSW handler 与 fixture、组件测试

## 验证

- 新增 2 个组件测试；完整测试套件 56 files / 328 tests 通过
- `pnpm type-check`、`pnpm lint`、`pnpm prettier:check`、`pnpm lint:style`、`pnpm build` 均通过
- Panda `styles.css` 生成差异已提交