### PR TITLE
fix(website): align subject sub-page headers with overview layout

### DIFF
--- a/packages/website/src/pages/index/subject/[id]/components/SubjectCharacters.tsx
+++ b/packages/website/src/pages/index/subject/[id]/components/SubjectCharacters.tsx
@@ -58,68 +58,70 @@ export default function SubjectCharacters({
   const groups = groupCharacters(characters);
 
   return (
-    <PageContainer as='main'>
+    <>
       <SubjectHeader subject={subject} />
-      <div className={styles.columns}>
-        <div className={styles.characterGroups}>
-          {groups.length === 0 && <p className={styles.empty}>暂无角色</p>}
-          {groups.map((group) => (
-            <section key={group.type} aria-labelledby={`character-group-${group.type}-heading`}>
-              <h2 id={`character-group-${group.type}-heading`} className={styles.groupTitle}>
-                {group.label}
-              </h2>
-              <ul className={styles.characterList}>
-                {group.items.map(({ character, casts }) => (
-                  <li key={character.id} className={styles.characterItem}>
-                    <Link
-                      to={getCharacterLink(character.id)}
-                      className={styles.avatarLink}
-                      title={characterTitle(character)}
-                    >
-                      {character.images?.grid ? (
-                        <img
-                          src={character.images.grid}
-                          className={styles.avatar}
-                          loading='lazy'
-                          alt=''
-                        />
-                      ) : (
-                        <span className={styles.avatarFallback}>
-                          {characterTitle(character).slice(0, 1)}
-                        </span>
-                      )}
-                    </Link>
-                    <div className={styles.characterInfo}>
+      <PageContainer as='main'>
+        <div className={styles.columns}>
+          <div className={styles.characterGroups}>
+            {groups.length === 0 && <p className={styles.empty}>暂无角色</p>}
+            {groups.map((group) => (
+              <section key={group.type} aria-labelledby={`character-group-${group.type}-heading`}>
+                <h2 id={`character-group-${group.type}-heading`} className={styles.groupTitle}>
+                  {group.label}
+                </h2>
+                <ul className={styles.characterList}>
+                  {group.items.map(({ character, casts }) => (
+                    <li key={character.id} className={styles.characterItem}>
                       <Link
                         to={getCharacterLink(character.id)}
-                        className={styles.name}
+                        className={styles.avatarLink}
                         title={characterTitle(character)}
                       >
-                        {characterTitle(character)}
+                        {character.images?.grid ? (
+                          <img
+                            src={character.images.grid}
+                            className={styles.avatar}
+                            loading='lazy'
+                            alt=''
+                          />
+                        ) : (
+                          <span className={styles.avatarFallback}>
+                            {characterTitle(character).slice(0, 1)}
+                          </span>
+                        )}
                       </Link>
-                      {character.info !== '' && <p className={styles.info}>{character.info}</p>}
-                      {casts.length > 0 && (
-                        <p className={styles.casts}>
-                          {casts.map((cast, index) => (
-                            <React.Fragment key={cast.person.id}>
-                              {index > 0 && ' / '}
-                              <span className={styles.castLabel}>
-                                {CAST_TYPE_DESC[cast.relation] ?? '出演'}:
-                              </span>{' '}
-                              <Link to={getPersonLink(cast.person.id)}>{cast.person.name}</Link>
-                            </React.Fragment>
-                          ))}
-                        </p>
-                      )}
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            </section>
-          ))}
+                      <div className={styles.characterInfo}>
+                        <Link
+                          to={getCharacterLink(character.id)}
+                          className={styles.name}
+                          title={characterTitle(character)}
+                        >
+                          {characterTitle(character)}
+                        </Link>
+                        {character.info !== '' && <p className={styles.info}>{character.info}</p>}
+                        {casts.length > 0 && (
+                          <p className={styles.casts}>
+                            {casts.map((cast, index) => (
+                              <React.Fragment key={cast.person.id}>
+                                {index > 0 && ' / '}
+                                <span className={styles.castLabel}>
+                                  {CAST_TYPE_DESC[cast.relation] ?? '出演'}:
+                                </span>{' '}
+                                <Link to={getPersonLink(cast.person.id)}>{cast.person.name}</Link>
+                              </React.Fragment>
+                            ))}
+                          </p>
+                        )}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ))}
+          </div>
+          <SubjectSummaryCard subject={subject} />
         </div>
-        <SubjectSummaryCard subject={subject} />
-      </div>
-    </PageContainer>
+      </PageContainer>
+    </>
   );
 }

--- a/packages/website/src/pages/index/subject/[id]/components/SubjectEpisodes.tsx
+++ b/packages/website/src/pages/index/subject/[id]/components/SubjectEpisodes.tsx
@@ -177,26 +177,28 @@ export default function SubjectEpisodes({
   const showAirStatus = subject.type !== SubjectType.Music;
 
   return (
-    <PageContainer as='main'>
+    <>
       <SubjectHeader subject={subject} />
-      <div className={columns}>
-        <div className={episodeGroups}>
-          {groups.length === 0 && <p className={empty}>暂无章节</p>}
-          {groups.map((group) => (
-            <section key={group.key} aria-labelledby={`${group.key}-heading`}>
-              <h2 id={`${group.key}-heading`} className={groupTitle}>
-                {group.label}
-              </h2>
-              <ol className={episodeList}>
-                {group.episodes.map((episode) => (
-                  <EpisodeRow key={episode.id} episode={episode} showAirStatus={showAirStatus} />
-                ))}
-              </ol>
-            </section>
-          ))}
+      <PageContainer as='main'>
+        <div className={columns}>
+          <div className={episodeGroups}>
+            {groups.length === 0 && <p className={empty}>暂无章节</p>}
+            {groups.map((group) => (
+              <section key={group.key} aria-labelledby={`${group.key}-heading`}>
+                <h2 id={`${group.key}-heading`} className={groupTitle}>
+                  {group.label}
+                </h2>
+                <ol className={episodeList}>
+                  {group.episodes.map((episode) => (
+                    <EpisodeRow key={episode.id} episode={episode} showAirStatus={showAirStatus} />
+                  ))}
+                </ol>
+              </section>
+            ))}
+          </div>
+          <SubjectSummaryCard subject={subject} />
         </div>
-        <SubjectSummaryCard subject={subject} />
-      </div>
-    </PageContainer>
+      </PageContainer>
+    </>
   );
 }

--- a/packages/website/src/pages/index/subject/[id]/components/SubjectIndexes.tsx
+++ b/packages/website/src/pages/index/subject/[id]/components/SubjectIndexes.tsx
@@ -186,65 +186,70 @@ const SubjectIndexes: React.FC<{
   const { user } = useUser();
 
   return (
-    <PageContainer as='main'>
+    <>
       <SubjectHeader subject={subject} />
-      <div className={columns}>
-        <div className={listColumn}>
-          {user && (
-            <a
-              className={collectButton}
-              href={getLegacyPageLink(
-                `/user/${user.username}/index?add_related=${subject.id}&ajax=1&keepThis=false&TB_iframe=true&height=350&width=500`,
-              )}
-              title='收集至我的目录'
-            >
-              收集至我的目录
-            </a>
-          )}
-          <ul className={indexList}>
-            {indexes.map((index) => (
-              <li key={index.id} className={item}>
-                <span className={avatar}>
-                  {index.user && (
-                    <Link to={getUserProfileLink(index.user.username)} title={index.user.nickname}>
-                      <Avatar src={index.user.avatar.medium} alt={index.user.nickname} />
-                    </Link>
-                  )}
-                </span>
-                <span className={info}>
-                  <div className={head}>
-                    <Link to={getIndexLink(index.id)} className={title} title={index.title}>
-                      <h3>{index.title}</h3>
-                    </Link>
-                    <IndexStatsList stats={index.stats} />
-                  </div>
-                  <span className={time}>
+      <PageContainer as='main'>
+        <div className={columns}>
+          <div className={listColumn}>
+            {user && (
+              <a
+                className={collectButton}
+                href={getLegacyPageLink(
+                  `/user/${user.username}/index?add_related=${subject.id}&ajax=1&keepThis=false&TB_iframe=true&height=350&width=500`,
+                )}
+                title='收集至我的目录'
+              >
+                收集至我的目录
+              </a>
+            )}
+            <ul className={indexList}>
+              {indexes.map((index) => (
+                <li key={index.id} className={item}>
+                  <span className={avatar}>
                     {index.user && (
-                      <Link to={getUserProfileLink(index.user.username)}>
-                        {index.user.nickname}
+                      <Link
+                        to={getUserProfileLink(index.user.username)}
+                        title={index.user.nickname}
+                      >
+                        <Avatar src={index.user.avatar.medium} alt={index.user.nickname} />
                       </Link>
                     )}
-                    <span className={dates}>
-                      创建 <span className={date}>{formatDate(index.createdAt)}</span> · 更新{' '}
-                      <span className={date}>{formatDate(index.updatedAt)}</span>
+                  </span>
+                  <span className={info}>
+                    <div className={head}>
+                      <Link to={getIndexLink(index.id)} className={title} title={index.title}>
+                        <h3>{index.title}</h3>
+                      </Link>
+                      <IndexStatsList stats={index.stats} />
+                    </div>
+                    <span className={time}>
+                      {index.user && (
+                        <Link to={getUserProfileLink(index.user.username)}>
+                          {index.user.nickname}
+                        </Link>
+                      )}
+                      <span className={dates}>
+                        创建 <span className={date}>{formatDate(index.createdAt)}</span> · 更新{' '}
+                        <span className={date}>{formatDate(index.updatedAt)}</span>
+                      </span>
                     </span>
                   </span>
-                </span>
-              </li>
-            ))}
-          </ul>
-          {indexes.length === 0 && <p className={empty}>暂无目录</p>}
-          <Pagination
-            total={total}
-            currentPage={currentPage}
-            pageSize={pageSize}
-            onChange={onPageChange}
-            wrapperClass={pagination}
-          />
+                </li>
+              ))}
+            </ul>
+            {indexes.length === 0 && <p className={empty}>暂无目录</p>}
+            <Pagination
+              total={total}
+              currentPage={currentPage}
+              pageSize={pageSize}
+              onChange={onPageChange}
+              wrapperClass={pagination}
+            />
+          </div>
+          <SubjectSummaryCard subject={subject} />
         </div>
-        <SubjectSummaryCard subject={subject} />
-      </div>
-    </PageContainer>
+      </PageContainer>
+    </>
   );
 };
 

--- a/packages/website/src/pages/index/subject/[id]/components/SubjectPersons.tsx
+++ b/packages/website/src/pages/index/subject/[id]/components/SubjectPersons.tsx
@@ -131,52 +131,54 @@ export default function SubjectPersons({
   const groups = groupByPosition(staffs);
 
   return (
-    <PageContainer as='main'>
+    <>
       <SubjectHeader subject={subject} />
-      <div className={columns}>
-        <div className={personGroups}>
-          {groups.length === 0 && <p className={empty}>暂无制作人员</p>}
-          {groups.map((group) => (
-            <section key={group.key} aria-labelledby={`${group.key}-heading`}>
-              <h2 id={`${group.key}-heading`} className={groupTitle}>
-                {group.label}
-              </h2>
-              <ul className={personList}>
-                {group.items.map(({ staff, summary, appearEps }) => (
-                  <li key={staff.id} className={personItem}>
-                    <Link
-                      to={getPersonLink(staff.id)}
-                      className={avatarLink}
-                      title={personTitle(staff)}
-                    >
-                      {staff.images?.grid ? (
-                        <img src={staff.images.grid} className={avatar} loading='lazy' alt='' />
-                      ) : (
-                        <span className={avatarFallback}>{personTitle(staff).slice(0, 1)}</span>
-                      )}
-                    </Link>
-                    <div className={personInfo}>
+      <PageContainer as='main'>
+        <div className={columns}>
+          <div className={personGroups}>
+            {groups.length === 0 && <p className={empty}>暂无制作人员</p>}
+            {groups.map((group) => (
+              <section key={group.key} aria-labelledby={`${group.key}-heading`}>
+                <h2 id={`${group.key}-heading`} className={groupTitle}>
+                  {group.label}
+                </h2>
+                <ul className={personList}>
+                  {group.items.map(({ staff, summary, appearEps }) => (
+                    <li key={staff.id} className={personItem}>
                       <Link
                         to={getPersonLink(staff.id)}
-                        className={name}
+                        className={avatarLink}
                         title={personTitle(staff)}
                       >
-                        {staff.name}
+                        {staff.images?.grid ? (
+                          <img src={staff.images.grid} className={avatar} loading='lazy' alt='' />
+                        ) : (
+                          <span className={avatarFallback}>{personTitle(staff).slice(0, 1)}</span>
+                        )}
                       </Link>
-                      {(summary !== '' || appearEps !== '') && (
-                        <p className={info}>
-                          {[summary, appearEps].filter((text) => text !== '').join(' / ')}
-                        </p>
-                      )}
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            </section>
-          ))}
+                      <div className={personInfo}>
+                        <Link
+                          to={getPersonLink(staff.id)}
+                          className={name}
+                          title={personTitle(staff)}
+                        >
+                          {staff.name}
+                        </Link>
+                        {(summary !== '' || appearEps !== '') && (
+                          <p className={info}>
+                            {[summary, appearEps].filter((text) => text !== '').join(' / ')}
+                          </p>
+                        )}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ))}
+          </div>
+          <SubjectSummaryCard subject={subject} />
         </div>
-        <SubjectSummaryCard subject={subject} />
-      </div>
-    </PageContainer>
+      </PageContainer>
+    </>
   );
 }

--- a/packages/website/src/pages/index/subject/[id]/components/SubjectRelations.tsx
+++ b/packages/website/src/pages/index/subject/[id]/components/SubjectRelations.tsx
@@ -130,43 +130,47 @@ export default function SubjectRelations({
   const groups = groupRelations(relations);
 
   return (
-    <PageContainer as='main'>
+    <>
       <SubjectHeader subject={subject} />
-      <div className={columns}>
-        <div className={relationGroups}>
-          {groups.length === 0 && <p className={empty}>暂无关联条目</p>}
-          {groups.map((group) => (
-            <section key={group.key} aria-labelledby={`${group.key}-heading`}>
-              <h2 id={`${group.key}-heading`} className={groupTitle}>
-                {group.label}
-              </h2>
-              <ul className={relationList}>
-                {group.items.map(({ subject: related }) => (
-                  <li key={related.id} className={relationItem}>
-                    <Link
-                      to={getSubjectLink(related.id)}
-                      className={coverLink}
-                      title={relationTitle(related)}
-                    >
-                      {related.images?.grid ? (
-                        <img src={related.images.grid} className={cover} loading='lazy' alt='' />
-                      ) : (
-                        <span className={coverFallback}>{relationTitle(related).slice(0, 1)}</span>
-                      )}
-                    </Link>
-                    <p className={coverTitle}>
-                      <Link to={getSubjectLink(related.id)} title={relationTitle(related)}>
-                        {relationTitle(related)}
+      <PageContainer as='main'>
+        <div className={columns}>
+          <div className={relationGroups}>
+            {groups.length === 0 && <p className={empty}>暂无关联条目</p>}
+            {groups.map((group) => (
+              <section key={group.key} aria-labelledby={`${group.key}-heading`}>
+                <h2 id={`${group.key}-heading`} className={groupTitle}>
+                  {group.label}
+                </h2>
+                <ul className={relationList}>
+                  {group.items.map(({ subject: related }) => (
+                    <li key={related.id} className={relationItem}>
+                      <Link
+                        to={getSubjectLink(related.id)}
+                        className={coverLink}
+                        title={relationTitle(related)}
+                      >
+                        {related.images?.grid ? (
+                          <img src={related.images.grid} className={cover} loading='lazy' alt='' />
+                        ) : (
+                          <span className={coverFallback}>
+                            {relationTitle(related).slice(0, 1)}
+                          </span>
+                        )}
                       </Link>
-                    </p>
-                  </li>
-                ))}
-              </ul>
-            </section>
-          ))}
+                      <p className={coverTitle}>
+                        <Link to={getSubjectLink(related.id)} title={relationTitle(related)}>
+                          {relationTitle(related)}
+                        </Link>
+                      </p>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ))}
+          </div>
+          <SubjectSummaryCard subject={subject} />
         </div>
-        <SubjectSummaryCard subject={subject} />
-      </div>
-    </PageContainer>
+      </PageContainer>
+    </>
   );
 }


### PR DESCRIPTION
## 改动内容

条目概览页（`/subject/:id`）的 `SubjectHeader`（标题 + tab 导航）位于 `PageContainer as='main'` 之外，而其他 tab 页面（章节、角色、制作人员、关联、目录）把它包在 `PageContainer` 内部，继承了 `padding: 24px 30px`，导致：

- 标题到页面顶部多出 24px 间距
- 标题水平位置比概览页偏右 30px
- tab 条宽度比概览页窄 60px（未横跨整个内容区）

本次将以下页面的 `SubjectHeader` 移到 `PageContainer` 外面，统一为概览页布局：

- `SubjectCharacters.tsx`（角色）
- `SubjectPersons.tsx`（制作人员）
- `SubjectEpisodes.tsx`（章节）
- `SubjectRelations.tsx`（关联）
- `SubjectIndexes.tsx`（目录）

## 验证

- `pnpm type-check` 通过
- 条目相关 Vitest（24 tests）全部通过
- `pnpm lint` 通过
- 截图对比概览/角色/关联三页：标题与 tab 的垂直距离、标题水平位置、tab 条宽度均一致