### PR TITLE
feat(website): add subject board and reviews pages

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,6 @@ pnpm-lock.yaml
 *.snap
 # submodules
 packages/utils/wiki-syntax-spec/
+
+# agent local config
+.kilo

--- a/packages/styled-system/styles.css
+++ b/packages/styled-system/styles.css
@@ -744,6 +744,50 @@
     padding: 0 10px;
 }
 
+  .m_5px_0 {
+    margin: 5px 0;
+}
+
+  .p_5px_25px {
+    padding: 5px 25px;
+}
+
+  .bg_\#f09199 {
+    background: #f09199;
+}
+
+  .m_10px_0 {
+    margin: 10px 0;
+}
+
+  .bd_0 {
+    border: 0;
+}
+
+  .bg_\#e0dcdc {
+    background: #e0dcdc;
+}
+
+  .p_8px_5px_8px_0 {
+    padding: 8px 5px 8px 0;
+}
+
+  .p_0_5px_0_0 {
+    padding: 0 5px 0 0;
+}
+
+  .p_0_0_0_5px {
+    padding: 0 0 0 5px;
+}
+
+  .p_0_5px_0_10px {
+    padding: 0 5px 0 10px;
+}
+
+  .p_16px_10px {
+    padding: 16px 10px;
+}
+
   .p_5px_10px {
     padding: 5px 10px;
 }
@@ -764,22 +808,6 @@
     background: #d9dfe1;
 }
 
-  .p_16px_10px {
-    padding: 16px 10px;
-}
-
-  .m_5px_0 {
-    margin: 5px 0;
-}
-
-  .p_5px_25px {
-    padding: 5px 25px;
-}
-
-  .bg_\#f09199 {
-    background: #f09199;
-}
-
   .p_5px_0 {
     padding: 5px 0;
 }
@@ -794,10 +822,6 @@
 
   .p_0_5px_0_17px {
     padding: 0 5px 0 17px;
-}
-
-  .m_10px_0 {
-    margin: 10px 0;
 }
 
   .p_10px {
@@ -816,12 +840,12 @@
     margin: 5px 0 0;
 }
 
-  .m_0_0_5px {
-    margin: 0 0 5px;
+  .p_15px_10px {
+    padding: 15px 10px;
 }
 
-  .p_0_5px_0_0 {
-    padding: 0 5px 0 0;
+  .m_0_0_5px {
+    margin: 0 0 5px;
 }
 
   .bd_1px_solid_\#e8e3e3 {
@@ -1012,6 +1036,10 @@
     gap: 1rem;
 }
 
+  .bdr_50px {
+    border-radius: 50px;
+}
+
   .bd-t_1px_solid_\#e8e3e3 {
     border-top: 1px solid #e8e3e3;
 }
@@ -1024,16 +1052,16 @@
     border-radius: 50%;
 }
 
-  .bdr_50px {
-    border-radius: 50px;
-}
-
   .flex_0_0_50px {
     flex: 0 0 50px;
 }
 
   .flex_1_1_auto {
     flex: 1 1 auto;
+}
+
+  .gap_5px {
+    gap: 5px;
 }
 
   .flex_0_0_48px {
@@ -1070,10 +1098,6 @@
 
   .gap_4px_14px {
     gap: 4px 14px;
-}
-
-  .gap_5px {
-    gap: 5px;
 }
 
   .bdr_10px {
@@ -1421,24 +1445,12 @@
     flex-basis: 75%;
 }
 
-  .inset-e_overview {
-    inset-inline-end: overview;
-}
-
   .grid-tc_minmax\(0\,_7fr\)_minmax\(260px\,_3fr\) {
     grid-template-columns: minmax(0, 7fr) minmax(260px, 3fr);
 }
 
   .ai_start {
     align-items: start;
-}
-
-  .lh_18px {
-    line-height: 18px;
-}
-
-  .lh_19px {
-    line-height: 19px;
 }
 
   .c_\#fff {
@@ -1451,6 +1463,34 @@
 
   .ta_center {
     text-align: center;
+}
+
+  .bd-cl_collapse {
+    border-collapse: collapse;
+}
+
+  .ta_left {
+    text-align: left;
+}
+
+  .c_\#888 {
+    color: #888;
+}
+
+  .fs_10px {
+    font-size: 10px;
+}
+
+  .inset-e_overview {
+    inset-inline-end: overview;
+}
+
+  .lh_18px {
+    line-height: 18px;
+}
+
+  .lh_19px {
+    line-height: 19px;
 }
 
   .lh_15px {
@@ -1473,12 +1513,16 @@
     object-fit: cover;
 }
 
-  .ta_left {
-    text-align: left;
-}
-
   .fs_11px {
     font-size: 11px;
+}
+
+  .lh_140\% {
+    line-height: 140%;
+}
+
+  .lh_170\% {
+    line-height: 170%;
 }
 
   .fw_300 {
@@ -1925,6 +1969,18 @@
     margin-top: 10px;
 }
 
+  .mb_23px {
+    margin-bottom: 23px;
+}
+
+  .w_40px {
+    width: 40px;
+}
+
+  .w_90px {
+    width: 90px;
+}
+
   .w_8px {
     width: 8px;
 }
@@ -1967,10 +2023,6 @@
 
   .h_44px {
     height: 44px;
-}
-
-  .mb_23px {
-    margin-bottom: 23px;
 }
 
   .mt_21px {
@@ -2063,6 +2115,14 @@
 
   .\[\&_th\,_\&_td\]\:p_11px_4px th,.\[\&_th\,_\&_td\]\:p_11px_4px td {
     padding: 11px 4px;
+}
+
+  .\[\&_tr\.even\]\:bg_\#f9f9f9 tr.even {
+    background: #f9f9f9;
+}
+
+  .\[\&_td\]\:p_8px_4px td {
+    padding: 8px 4px;
 }
 
   .\[\&\:nth-child\(even\)\]\:bg_\#f9f9f9:nth-child(even) {
@@ -2309,6 +2369,14 @@
     text-align: left;
 }
 
+  .\[\&_a\]\:c_\#595555 a {
+    color: #595555;
+}
+
+  .\[\&_a\]\:fw_normal a {
+    font-weight: var(--font-weights-normal);
+}
+
   .\[\&_\.bgm-avatar\]\:d_block .bgm-avatar {
     display: block;
 }
@@ -2333,12 +2401,20 @@
     white-space: nowrap;
 }
 
-  .\[\&_a\]\:c_\#54b5df a {
-    color: #54b5df;
+  .\[\&_a\]\:c_\#1f1c1c a {
+    color: #1f1c1c;
 }
 
-  .\[\&_a\]\:c_\#595555 a {
-    color: #595555;
+  .\[\&_a\]\:d_block a {
+    display: block;
+}
+
+  .\[\&_a\]\:c_\#9f9b9b a {
+    color: #9f9b9b;
+}
+
+  .\[\&_a\]\:c_\#54b5df a {
+    color: #54b5df;
 }
 
   .\[\&_a\]\:d_flex a {
@@ -2395,14 +2471,6 @@
 
   .\[\&_a\]\:fs_13px a {
     font-size: 13px;
-}
-
-  .\[\&_a\]\:c_\#1f1c1c a {
-    color: #1f1c1c;
-}
-
-  .\[\&_a\]\:d_block a {
-    display: block;
 }
 
   .\[\&_img\]\:asp_3_\/_4 img {

--- a/packages/website/src/hooks/use-subject-reviews.ts
+++ b/packages/website/src/hooks/use-subject-reviews.ts
@@ -1,0 +1,20 @@
+import { ok } from '@oazapfts/runtime';
+import useSWR from 'swr';
+
+import { ozaClient } from '@bangumi/client';
+import type { SubjectReview } from '@bangumi/client/client';
+
+/** 获取条目的评论（/subject/:id/reviews） */
+export function useSubjectReviews(
+  subjectID: number,
+  limit: number,
+  offset: number,
+): { data: SubjectReview[] | undefined; total: number | undefined } {
+  const { data } = useSWR(
+    `subject-reviews ${subjectID} ${limit} ${offset}`,
+    async () => ok(ozaClient.getSubjectReviews(subjectID, { limit, offset })),
+    { suspense: true },
+  );
+
+  return data ?? { data: undefined, total: undefined };
+}

--- a/packages/website/src/hooks/use-subject-topics.ts
+++ b/packages/website/src/hooks/use-subject-topics.ts
@@ -1,0 +1,20 @@
+import { ok } from '@oazapfts/runtime';
+import useSWR from 'swr';
+
+import { ozaClient } from '@bangumi/client';
+import type { Topic } from '@bangumi/client/client';
+
+/** 获取条目讨论版主题（/subject/:id/board） */
+export function useSubjectTopics(
+  subjectID: number,
+  limit: number,
+  offset: number,
+): { data: Topic[] | undefined; total: number | undefined } {
+  const { data } = useSWR(
+    `subject-topics ${subjectID} ${limit} ${offset}`,
+    async () => ok(ozaClient.getSubjectTopics(subjectID, { limit, offset })),
+    { suspense: true },
+  );
+
+  return data ?? { data: undefined, total: undefined };
+}

--- a/packages/website/src/mocks/fixtures/p1/subjects/12-GET.json
+++ b/packages/website/src/mocks/fixtures/p1/subjects/12-GET.json
@@ -1,0 +1,85 @@
+{
+  "id": 12,
+  "type": 2,
+  "name": "Test Anime",
+  "nameCN": "测试动画",
+  "images": {
+    "large": "https://lain.bgm.tv/pic/cover/l/00/00/12.jpg",
+    "common": "https://lain.bgm.tv/pic/cover/c/00/00/12.jpg",
+    "medium": "https://lain.bgm.tv/pic/cover/m/00/00/12.jpg",
+    "small": "https://lain.bgm.tv/pic/cover/s/00/00/12.jpg",
+    "grid": "https://lain.bgm.tv/pic/cover/g/00/00/12.jpg"
+  },
+  "info": "",
+  "infobox": [
+    {
+      "key": "中文名",
+      "values": [
+        {
+          "v": "测试动画"
+        }
+      ]
+    },
+    {
+      "key": "话数",
+      "values": [
+        {
+          "v": "12"
+        }
+      ]
+    },
+    {
+      "key": "放送开始",
+      "values": [
+        {
+          "v": "2026年4月1日"
+        }
+      ]
+    }
+  ],
+  "summary": "这是一个用于测试的动画条目。",
+  "locked": false,
+  "metaTags": [],
+  "nsfw": false,
+  "rating": {
+    "rank": 100,
+    "total": 4321,
+    "count": [100, 90, 80, 70, 60, 50, 40, 30, 20, 10],
+    "score": 8.1
+  },
+  "collection": {
+    "1": 100,
+    "2": 2000,
+    "3": 1500,
+    "4": 300,
+    "5": 200
+  },
+  "eps": 12,
+  "volumes": 0,
+  "series": false,
+  "seriesEntry": 0,
+  "redirect": 0,
+  "platform": {
+    "id": 1,
+    "type": "tv",
+    "typeCN": "TV",
+    "alias": "TV"
+  },
+  "airtime": {
+    "year": 2026,
+    "month": 4,
+    "date": "04-01",
+    "weekday": 3
+  },
+  "tags": [
+    {
+      "name": "科幻",
+      "count": 100
+    },
+    {
+      "name": "日常",
+      "count": 80
+    }
+  ],
+  "interest": null
+}

--- a/packages/website/src/mocks/fixtures/p1/subjects/12/reviews-GET.json
+++ b/packages/website/src/mocks/fixtures/p1/subjects/12/reviews-GET.json
@@ -1,0 +1,63 @@
+{
+  "data": [
+    {
+      "id": 201,
+      "user": {
+        "id": 1272395,
+        "username": "1272395",
+        "nickname": "Madeline",
+        "avatar": {
+          "small": "https://lain.bgm.tv/r/100/pic/user/l/001/27/23/1272395_SC9al.jpg?r=1786441385&hd=1",
+          "medium": "https://lain.bgm.tv/r/200/pic/user/l/001/27/23/1272395_SC9al.jpg?r=1786441385&hd=1",
+          "large": "https://lain.bgm.tv/pic/user/l/001/27/23/1272395_SC9al.jpg?r=1786441385&hd=1"
+        },
+        "group": 10,
+        "sign": "",
+        "joinedAt": 1786441140,
+        "isFriend": false
+      },
+      "entry": {
+        "id": 301,
+        "type": 2,
+        "uid": 1272395,
+        "title": "测试动画的观后感：值得一看的宝藏作品",
+        "icon": "",
+        "summary": "这部动画的作画和音乐都非常出色，尤其是第 5 集的演出令人印象深刻，强烈推荐给喜欢日常治愈系作品的朋友。",
+        "replies": 3,
+        "public": true,
+        "createdAt": 1767225600,
+        "updatedAt": 1767229200
+      }
+    },
+    {
+      "id": 202,
+      "user": {
+        "id": 1272395,
+        "username": "1272395",
+        "nickname": "Madeline",
+        "avatar": {
+          "small": "https://lain.bgm.tv/r/100/pic/user/l/001/27/23/1272395_SC9al.jpg?r=1786441385&hd=1",
+          "medium": "https://lain.bgm.tv/r/200/pic/user/l/001/27/23/1272395_SC9al.jpg?r=1786441385&hd=1",
+          "large": "https://lain.bgm.tv/pic/user/l/001/27/23/1272395_SC9al.jpg?r=1786441385&hd=1"
+        },
+        "group": 10,
+        "sign": "",
+        "joinedAt": 1786441140,
+        "isFriend": false
+      },
+      "entry": {
+        "id": 302,
+        "type": 2,
+        "uid": 1272395,
+        "title": "从制作角度分析结局的铺垫",
+        "icon": "",
+        "summary": "最后一话的脚本其实早在第 3 话就埋下了伏笔，本篇从分镜、台词与配乐三个角度逐一对照分析。",
+        "replies": 8,
+        "public": true,
+        "createdAt": 1767398400,
+        "updatedAt": 1767402000
+      }
+    }
+  ],
+  "total": 2
+}

--- a/packages/website/src/mocks/fixtures/p1/subjects/12/topics-GET.json
+++ b/packages/website/src/mocks/fixtures/p1/subjects/12/topics-GET.json
@@ -1,0 +1,80 @@
+{
+  "data": [
+    {
+      "id": 101,
+      "title": "这是一条测试讨论主题，标题可能比较长，用于验证省略号截断效果",
+      "creatorID": 1272395,
+      "creator": {
+        "id": 1272395,
+        "username": "1272395",
+        "nickname": "Madeline",
+        "avatar": {
+          "small": "https://lain.bgm.tv/r/100/pic/user/l/001/27/23/1272395_SC9al.jpg?r=1786441385&hd=1",
+          "medium": "https://lain.bgm.tv/r/200/pic/user/l/001/27/23/1272395_SC9al.jpg?r=1786441385&hd=1",
+          "large": "https://lain.bgm.tv/pic/user/l/001/27/23/1272395_SC9al.jpg?r=1786441385&hd=1"
+        },
+        "group": 10,
+        "sign": "",
+        "joinedAt": 1786441140,
+        "isFriend": false
+      },
+      "parentID": 12,
+      "replyCount": 5,
+      "createdAt": 1767225600,
+      "updatedAt": 1767312000,
+      "state": 0,
+      "display": 0
+    },
+    {
+      "id": 102,
+      "title": "第二集讨论串",
+      "creatorID": 1272395,
+      "creator": {
+        "id": 1272395,
+        "username": "1272395",
+        "nickname": "Madeline",
+        "avatar": {
+          "small": "https://lain.bgm.tv/r/100/pic/user/l/001/27/23/1272395_SC9al.jpg?r=1786441385&hd=1",
+          "medium": "https://lain.bgm.tv/r/200/pic/user/l/001/27/23/1272395_SC9al.jpg?r=1786441385&hd=1",
+          "large": "https://lain.bgm.tv/pic/user/l/001/27/23/1272395_SC9al.jpg?r=1786441385&hd=1"
+        },
+        "group": 10,
+        "sign": "",
+        "joinedAt": 1786441140,
+        "isFriend": false
+      },
+      "parentID": 12,
+      "replyCount": 12,
+      "createdAt": 1767398400,
+      "updatedAt": 1767484800,
+      "state": 0,
+      "display": 0
+    },
+    {
+      "id": 103,
+      "title": "完结纪念帖",
+      "creatorID": 1272395,
+      "creator": {
+        "id": 1272395,
+        "username": "1272395",
+        "nickname": "Madeline",
+        "avatar": {
+          "small": "https://lain.bgm.tv/r/100/pic/user/l/001/27/23/1272395_SC9al.jpg?r=1786441385&hd=1",
+          "medium": "https://lain.bgm.tv/r/200/pic/user/l/001/27/23/1272395_SC9al.jpg?r=1786441385&hd=1",
+          "large": "https://lain.bgm.tv/pic/user/l/001/27/23/1272395_SC9al.jpg?r=1786441385&hd=1"
+        },
+        "group": 10,
+        "sign": "",
+        "joinedAt": 1786441140,
+        "isFriend": false
+      },
+      "parentID": 12,
+      "replyCount": 20,
+      "createdAt": 1768003200,
+      "updatedAt": 1768089600,
+      "state": 0,
+      "display": 0
+    }
+  ],
+  "total": 3
+}

--- a/packages/website/src/mocks/handlers.ts
+++ b/packages/website/src/mocks/handlers.ts
@@ -17,6 +17,8 @@ export const handlers = [
   mockAPI('/p1/subjects/:subjectID/relations', 'get'),
   mockAPI('/p1/subjects/:subjectID/characters', 'get'),
   mockAPI('/p1/subjects/:subjectID/staffs/persons', 'get'),
+  mockAPI('/p1/subjects/:subjectID/topics', 'get'),
+  mockAPI('/p1/subjects/:subjectID/reviews', 'get'),
   mockAPI('/p1/subjects/:subjectID/collects', 'get'),
   mockAPI('/p1/persons/:personID', 'get'),
   mockAPI('/p1/persons/:personID/casts', 'get'),

--- a/packages/website/src/pages/index/subject/[id]/SubjectBoard.spec.tsx
+++ b/packages/website/src/pages/index/subject/[id]/SubjectBoard.spec.tsx
@@ -1,0 +1,70 @@
+import { screen } from '@testing-library/react';
+import React from 'react';
+
+import type { SubjectHomeResponse } from '@bangumi/client/client';
+import { renderPage } from '@bangumi/website/utils/test-utils';
+
+import homeFixture from '../../../../mocks/fixtures/p1/subjects/12/home-GET.json';
+import topicsFixture from '../../../../mocks/fixtures/p1/subjects/12/topics-GET.json';
+import SubjectBoard from './components/SubjectBoard';
+
+const homeData = homeFixture as unknown as SubjectHomeResponse;
+const { data: topics, total } = topicsFixture;
+
+describe('SubjectBoard', () => {
+  const renderBoard = (props: Partial<React.ComponentProps<typeof SubjectBoard>> = {}) =>
+    renderPage(
+      <SubjectBoard
+        subject={homeData.subject}
+        topics={topics}
+        total={total}
+        currentPage={1}
+        pageSize={10}
+        onPageChange={() => undefined}
+        {...props}
+      />,
+    );
+
+  it('should render the topic list with links', () => {
+    renderBoard();
+
+    // 主题标题链接指向主题页
+    const title = screen.getByRole('link', {
+      name: '这是一条测试讨论主题，标题可能比较长，用于验证省略号截断效果',
+    });
+    expect(title).toHaveAttribute('href', '/subject/topic/101');
+    expect(screen.getByRole('link', { name: '第二集讨论串' })).toHaveAttribute(
+      'href',
+      '/subject/topic/102',
+    );
+    expect(screen.getByRole('link', { name: '完结纪念帖' })).toHaveAttribute(
+      'href',
+      '/subject/topic/103',
+    );
+
+    // 作者链接与回复数（fixture 时间戳为 UTC，测试环境固定为 Etc/GMT）
+    const authorLinks = screen.getAllByRole('link', { name: 'Madeline' });
+    expect(authorLinks).toHaveLength(3);
+    expect(authorLinks[0]).toHaveAttribute('href', '/user/1272395');
+    expect(screen.getByText('5 replies')).toBeInTheDocument();
+    expect(screen.getByText('2026-1-1')).toBeInTheDocument();
+
+    // 右栏条目卡
+    expect(screen.getByRole('link', { name: '返回条目' })).toHaveAttribute('href', '/subject/12');
+  });
+
+  it('should show the new topic button when logged in', async () => {
+    renderBoard();
+
+    const button = await screen.findByRole('link', { name: '添加新讨论' });
+    // 新前端未实现发帖页，跳转旧站
+    expect(button).toHaveAttribute('href', 'https://bgm.tv/subject/12/topic/new');
+  });
+
+  it('should render an empty state when there are no topics', () => {
+    renderBoard({ topics: [], total: 0 });
+
+    expect(screen.getByText('暂无讨论')).toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  });
+});

--- a/packages/website/src/pages/index/subject/[id]/SubjectReviews.spec.tsx
+++ b/packages/website/src/pages/index/subject/[id]/SubjectReviews.spec.tsx
@@ -1,0 +1,64 @@
+import { screen } from '@testing-library/react';
+import React from 'react';
+
+import type { SubjectHomeResponse } from '@bangumi/client/client';
+import { renderPage } from '@bangumi/website/utils/test-utils';
+
+import homeFixture from '../../../../mocks/fixtures/p1/subjects/12/home-GET.json';
+import reviewsFixture from '../../../../mocks/fixtures/p1/subjects/12/reviews-GET.json';
+import SubjectReviews from './components/SubjectReviews';
+
+const homeData = homeFixture as unknown as SubjectHomeResponse;
+const { data: reviews, total } = reviewsFixture;
+
+describe('SubjectReviews', () => {
+  const renderReviews = (props: Partial<React.ComponentProps<typeof SubjectReviews>> = {}) =>
+    renderPage(
+      <SubjectReviews
+        subject={homeData.subject}
+        reviews={reviews}
+        total={total}
+        currentPage={1}
+        pageSize={10}
+        onPageChange={() => undefined}
+        {...props}
+      />,
+    );
+
+  it('should render the review list with links', () => {
+    renderReviews();
+
+    // 评论标题与摘要均链接到日志页
+    const title = screen.getByRole('link', { name: '测试动画的观后感：值得一看的宝藏作品' });
+    expect(title).toHaveAttribute('href', '/blog/301');
+    expect(screen.getByRole('link', { name: '从制作角度分析结局的铺垫' })).toHaveAttribute(
+      'href',
+      '/blog/302',
+    );
+
+    // 作者、时间与回复数（fixture 时间戳为 UTC，测试环境固定为 Etc/GMT）
+    const authorLinks = screen.getAllByRole('link', { name: 'Madeline' });
+    expect(authorLinks).toHaveLength(2);
+    expect(authorLinks[0]).toHaveAttribute('href', '/user/1272395');
+    expect(screen.getByText('2026-1-1')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '3 回复' })).toHaveAttribute('href', '/blog/301');
+
+    // 右栏条目卡
+    expect(screen.getByRole('link', { name: '返回条目' })).toHaveAttribute('href', '/subject/12');
+  });
+
+  it('should show the new review button when logged in', async () => {
+    renderReviews();
+
+    const button = await screen.findByRole('link', { name: '我来评论' });
+    // 新前端未实现写日志页，跳转旧站
+    expect(button).toHaveAttribute('href', 'https://bgm.tv/blog/create?review=12');
+  });
+
+  it('should render an empty state when there are no reviews', () => {
+    renderReviews({ reviews: [], total: 0 });
+
+    expect(screen.getByText('暂无评论')).toBeInTheDocument();
+    expect(screen.queryAllByRole('link', { name: '返回条目' })).toHaveLength(1);
+  });
+});

--- a/packages/website/src/pages/index/subject/[id]/board.tsx
+++ b/packages/website/src/pages/index/subject/[id]/board.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+import { withErrorBoundary } from '@bangumi/website/components/ErrorBoundary';
+import Helmet from '@bangumi/website/components/Helmet';
+import { useTransitionNavigate } from '@bangumi/website/hooks/use-navigate';
+import { usePaginationParams } from '@bangumi/website/hooks/use-pagination';
+import { useSubject } from '@bangumi/website/hooks/use-subject';
+import { useSubjectTopics } from '@bangumi/website/hooks/use-subject-topics';
+
+import SubjectBoard from './components/SubjectBoard';
+
+const PAGE_SIZE = 10;
+
+function SubjectBoardPage() {
+  const { id } = useParams();
+  const subjectID = Number(id);
+  const { curPage, pageSize, offset } = usePaginationParams(PAGE_SIZE);
+  const subject = useSubject(subjectID);
+  const { data: topics, total } = useSubjectTopics(subjectID, pageSize, offset);
+  const [, navigate] = useTransitionNavigate();
+
+  if (!subject || !topics) {
+    return null;
+  }
+
+  const handlePageChange = (page: number): void => {
+    navigate({ search: `page=${page}` });
+  };
+
+  return (
+    <>
+      <Helmet title={`${subject.nameCN || subject.name} - 讨论版`} />
+      <SubjectBoard
+        subject={subject}
+        topics={topics}
+        total={total ?? 0}
+        currentPage={curPage}
+        pageSize={pageSize}
+        onPageChange={handlePageChange}
+      />
+    </>
+  );
+}
+
+export default withErrorBoundary(SubjectBoardPage, {
+  404: () => <div>没有找到条目</div>,
+});

--- a/packages/website/src/pages/index/subject/[id]/components/SubjectBoard.tsx
+++ b/packages/website/src/pages/index/subject/[id]/components/SubjectBoard.tsx
@@ -1,0 +1,173 @@
+import dayjs from 'dayjs';
+import React from 'react';
+
+import type { Subject, Topic } from '@bangumi/client/client';
+import { Pagination, Typography } from '@bangumi/design';
+import { css } from '@bangumi/styled-system/css';
+import { getLegacyPageLink, getSubjectTopicLink, getUserProfileLink } from '@bangumi/utils/pages';
+import PageContainer from '@bangumi/website/components/PageContainer';
+import { useUser } from '@bangumi/website/hooks/use-user';
+
+import { SubjectHeader } from './SubjectDetail';
+import SubjectSummaryCard from './SubjectSummaryCard';
+
+const { Link } = Typography;
+
+const columns = css({
+  display: 'grid',
+  gridTemplateColumns: 'minmax(0, 7fr) minmax(260px, 3fr)',
+  alignItems: 'start',
+  gap: '20px',
+  '@media (max-width: 768px)': { gridTemplateColumns: 'minmax(0, 1fr)' },
+});
+
+const boardMain = css({ minWidth: '0' });
+
+/** 添加新讨论，对齐 PHP btnPink */
+const newTopicButton = css({
+  boxSizing: 'border-box',
+  display: 'inline-block',
+  margin: '5px 0',
+  padding: '5px 25px',
+  borderRadius: '50px',
+  background: '#f09199',
+  color: '#fff',
+  fontSize: '14px',
+  lineHeight: '150%',
+  textAlign: 'center',
+  _hover: { background: '#e7848e', color: '#fff', textDecoration: 'none' },
+});
+
+/** 分隔线，对齐 PHP hr.board */
+const boardHr = css({
+  height: '1px',
+  margin: '10px 0',
+  border: '0',
+  background: '#e0dcdc',
+});
+
+/** 主题列表，对齐 PHP table.topic_list */
+const topicTable = css({
+  width: '100%',
+  marginBottom: '23px',
+  borderCollapse: 'collapse',
+  fontSize: '13px',
+  '& tr': { borderBottom: '1px dotted #e8e3e3' },
+  '& tr.even': { background: '#f9f9f9' },
+  '& td': { padding: '8px 4px' },
+});
+
+const topicSubject = css({
+  padding: '8px 5px 8px 0',
+  textAlign: 'left',
+  '& a': {
+    color: '#595555',
+    fontWeight: 'normal',
+  },
+});
+
+const topicAuthor = css({
+  width: '120px',
+  padding: '0 5px 0 0',
+  color: '#595555',
+});
+
+const topicReplies = css({
+  width: '40px',
+  padding: '0 0 0 5px',
+  color: '#888',
+  fontSize: '10px',
+  textAlign: 'right',
+  whiteSpace: 'nowrap',
+});
+
+const topicTime = css({
+  width: '90px',
+  padding: '0 5px 0 10px',
+  color: '#9f9b9b',
+  fontSize: '12px',
+  textAlign: 'right',
+  whiteSpace: 'nowrap',
+});
+
+const empty = css({
+  margin: '0',
+  padding: '16px 10px',
+  borderTop: '1px solid #e8e3e3',
+  borderBottom: '1px dotted #e8e3e3',
+  color: '#9f9b9b',
+  fontSize: '13px',
+});
+
+const pagination = css({ margin: '10px 0' });
+
+const SubjectBoard: React.FC<{
+  subject: Subject;
+  topics: Topic[];
+  total: number;
+  currentPage: number;
+  pageSize: number;
+  onPageChange: (page: number) => void;
+}> = ({ subject, topics, total, currentPage, pageSize, onPageChange }) => {
+  const { user } = useUser();
+
+  return (
+    <>
+      <SubjectHeader subject={subject} />
+      <PageContainer as='main'>
+        <div className={columns}>
+          <div className={boardMain}>
+            {user != null && (
+              <a
+                className={newTopicButton}
+                href={getLegacyPageLink(`/subject/${subject.id}/topic/new`)}
+                title='添加新讨论'
+              >
+                添加新讨论
+              </a>
+            )}
+            <hr className={boardHr} />
+            {topics.length === 0 && <p className={empty}>暂无讨论</p>}
+            {topics.length > 0 && (
+              <table className={topicTable}>
+                <tbody>
+                  {topics.map((topic, index) => (
+                    <tr key={topic.id} className={index % 2 === 0 ? 'odd' : 'even'}>
+                      <td className={topicSubject}>
+                        <Link to={getSubjectTopicLink(topic.id)} title={topic.title}>
+                          {topic.title}
+                        </Link>
+                      </td>
+                      <td className={topicAuthor}>
+                        <Link
+                          to={getUserProfileLink(topic.creator?.username ?? '')}
+                          title={topic.creator?.nickname}
+                        >
+                          {topic.creator?.nickname}
+                        </Link>
+                      </td>
+                      <td className={topicReplies}>{topic.replyCount} replies</td>
+                      <td className={topicTime}>
+                        {dayjs.unix(topic.createdAt).format('YYYY-M-D')}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+            <Pagination
+              total={total}
+              currentPage={currentPage}
+              pageSize={pageSize}
+              onChange={onPageChange}
+              wrapperClass={pagination}
+            />
+          </div>
+          <SubjectSummaryCard subject={subject} />
+        </div>
+      </PageContainer>
+    </>
+  );
+};
+
+export default SubjectBoard;

--- a/packages/website/src/pages/index/subject/[id]/components/SubjectReviews.tsx
+++ b/packages/website/src/pages/index/subject/[id]/components/SubjectReviews.tsx
@@ -1,0 +1,181 @@
+import dayjs from 'dayjs';
+import React from 'react';
+
+import type { Subject, SubjectReview } from '@bangumi/client/client';
+import { Pagination, Typography } from '@bangumi/design';
+import { css } from '@bangumi/styled-system/css';
+import { getBlogLink, getLegacyPageLink, getUserProfileLink } from '@bangumi/utils/pages';
+import PageContainer from '@bangumi/website/components/PageContainer';
+import { useUser } from '@bangumi/website/hooks/use-user';
+
+import { SubjectHeader } from './SubjectDetail';
+import SubjectSummaryCard from './SubjectSummaryCard';
+
+const { Link } = Typography;
+
+const columns = css({
+  display: 'grid',
+  gridTemplateColumns: 'minmax(0, 7fr) minmax(260px, 3fr)',
+  alignItems: 'start',
+  gap: '20px',
+  '@media (max-width: 768px)': { gridTemplateColumns: 'minmax(0, 1fr)' },
+});
+
+const reviewsMain = css({ minWidth: '0' });
+
+/** 我来评论，对齐 PHP btnPink */
+const newReviewButton = css({
+  boxSizing: 'border-box',
+  display: 'inline-block',
+  margin: '5px 0',
+  padding: '5px 25px',
+  borderRadius: '50px',
+  background: '#f09199',
+  color: '#fff',
+  fontSize: '14px',
+  lineHeight: '150%',
+  textAlign: 'center',
+  _hover: { background: '#e7848e', color: '#fff', textDecoration: 'none' },
+});
+
+/** 分隔线，对齐 PHP hr.board */
+const boardHr = css({
+  height: '1px',
+  margin: '10px 0',
+  border: '0',
+  background: '#e0dcdc',
+});
+
+/** 评论（日志）列表，对齐 PHP block_entry_list */
+const entryList = css({
+  margin: '0',
+  padding: '0',
+  listStyle: 'none',
+});
+
+const entryItem = css({
+  display: 'flex',
+  alignItems: 'flex-start',
+  gap: '12px',
+  padding: '15px 10px',
+  borderBottom: '1px solid #e8e3e3',
+  boxSizing: 'border-box',
+});
+
+const entryBody = css({ flex: '1 1 auto', minWidth: '0' });
+
+const entryTitle = css({
+  margin: '0 0 5px',
+  fontSize: '16px',
+  fontWeight: '400',
+  lineHeight: '140%',
+  '& a': {
+    color: '#1f1c1c',
+  },
+});
+
+const entrySummary = css({
+  margin: '0 0 5px',
+  fontSize: '14px',
+  lineHeight: '170%',
+  color: '#9f9b9b',
+  overflowWrap: 'anywhere',
+  '& a': {
+    display: 'block',
+    color: '#9f9b9b',
+  },
+});
+
+const entryMeta = css({
+  display: 'flex',
+  flexWrap: 'wrap',
+  alignItems: 'center',
+  gap: '5px',
+  margin: '5px 0 0',
+  fontSize: '13px',
+  color: '#9f9b9b',
+});
+
+const empty = css({
+  margin: '0',
+  padding: '16px 10px',
+  borderTop: '1px solid #e8e3e3',
+  borderBottom: '1px dotted #e8e3e3',
+  color: '#9f9b9b',
+  fontSize: '13px',
+});
+
+const pagination = css({ margin: '10px 0' });
+
+const SubjectReviews: React.FC<{
+  subject: Subject;
+  reviews: SubjectReview[];
+  total: number;
+  currentPage: number;
+  pageSize: number;
+  onPageChange: (page: number) => void;
+}> = ({ subject, reviews, total, currentPage, pageSize, onPageChange }) => {
+  const { user } = useUser();
+
+  return (
+    <>
+      <SubjectHeader subject={subject} />
+      <PageContainer as='main'>
+        <div className={columns}>
+          <div className={reviewsMain}>
+            {user != null && (
+              <a
+                className={newReviewButton}
+                href={getLegacyPageLink(`/blog/create?review=${subject.id}`)}
+                title='我来评论'
+              >
+                我来评论
+              </a>
+            )}
+            <hr className={boardHr} />
+            {reviews.length === 0 && <p className={empty}>暂无评论</p>}
+            {reviews.length > 0 && (
+              <ul className={entryList}>
+                {reviews.map((review) => (
+                  <li key={review.id} className={entryItem}>
+                    <div className={entryBody}>
+                      <h2 className={entryTitle}>
+                        <Link to={getBlogLink(review.entry.id)} title={review.entry.title}>
+                          {review.entry.title}
+                        </Link>
+                      </h2>
+                      <p className={entrySummary}>
+                        <Link to={getBlogLink(review.entry.id)}>{review.entry.summary}</Link>
+                      </p>
+                      <div className={entryMeta}>
+                        <Link to={getUserProfileLink(review.user.username)}>
+                          {review.user.nickname}
+                        </Link>
+                        <span>·</span>
+                        <span>评论 {subject.name}</span>
+                        <span>·</span>
+                        <span>{dayjs.unix(review.entry.createdAt).format('YYYY-M-D')}</span>
+                        <span>·</span>
+                        <Link to={getBlogLink(review.entry.id)}>{review.entry.replies} 回复</Link>
+                      </div>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+            <Pagination
+              total={total}
+              currentPage={currentPage}
+              pageSize={pageSize}
+              onChange={onPageChange}
+              wrapperClass={pagination}
+            />
+          </div>
+          <SubjectSummaryCard subject={subject} />
+        </div>
+      </PageContainer>
+    </>
+  );
+};
+
+export default SubjectReviews;

--- a/packages/website/src/pages/index/subject/[id]/reviews.tsx
+++ b/packages/website/src/pages/index/subject/[id]/reviews.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+import { withErrorBoundary } from '@bangumi/website/components/ErrorBoundary';
+import Helmet from '@bangumi/website/components/Helmet';
+import { useTransitionNavigate } from '@bangumi/website/hooks/use-navigate';
+import { usePaginationParams } from '@bangumi/website/hooks/use-pagination';
+import { useSubject } from '@bangumi/website/hooks/use-subject';
+import { useSubjectReviews } from '@bangumi/website/hooks/use-subject-reviews';
+
+import SubjectReviews from './components/SubjectReviews';
+
+const PAGE_SIZE = 10;
+
+function SubjectReviewsPage() {
+  const { id } = useParams();
+  const subjectID = Number(id);
+  const { curPage, pageSize, offset } = usePaginationParams(PAGE_SIZE);
+  const subject = useSubject(subjectID);
+  const { data: reviews, total } = useSubjectReviews(subjectID, pageSize, offset);
+  const [, navigate] = useTransitionNavigate();
+
+  if (!subject || !reviews) {
+    return null;
+  }
+
+  const handlePageChange = (page: number): void => {
+    navigate({ search: `page=${page}` });
+  };
+
+  return (
+    <>
+      <Helmet title={`${subject.nameCN || subject.name} - 评论`} />
+      <SubjectReviews
+        subject={subject}
+        reviews={reviews}
+        total={total ?? 0}
+        currentPage={curPage}
+        pageSize={pageSize}
+        onPageChange={handlePageChange}
+      />
+    </>
+  );
+}
+
+export default withErrorBoundary(SubjectReviewsPage, {
+  404: () => <div>没有找到条目</div>,
+});

--- a/packages/website/src/routes.tsx
+++ b/packages/website/src/routes.tsx
@@ -35,6 +35,8 @@ const Subject = lazy(async () => import('./pages/index/subject/[id]/index'));
 const SubjectIndexes = lazy(async () => import('./pages/index/subject/[id]/indexes'));
 const SubjectEpisodes = lazy(async () => import('./pages/index/subject/[id]/ep'));
 const SubjectRelations = lazy(async () => import('./pages/index/subject/[id]/relations'));
+const SubjectBoard = lazy(async () => import('./pages/index/subject/[id]/board'));
+const SubjectReviews = lazy(async () => import('./pages/index/subject/[id]/reviews'));
 const SubjectSearch = lazy(async () => import('./pages/index/subject_search/[keyword]'));
 const Person = lazy(async () => import('./pages/index/person/[id]'));
 const Wiki = lazy(async () => import('./pages/index/subject/[id]/wiki'));
@@ -68,10 +70,8 @@ const legacyPagePaths = [
   'index/:id/comments',
   'magi',
   'onair',
-  'subject/:id/board',
   'subject/:id/collections',
   'subject/:id/comments',
-  'subject/:id/reviews',
   'subject/:id/stats',
   'subject/ep/:id',
   'subject/tag/:tag',
@@ -177,6 +177,8 @@ export const pageRoutes: RouteObject[] = [
               { path: 'index', element: <SubjectIndexes /> },
               { path: 'ep', element: <SubjectEpisodes /> },
               { path: 'relations', element: <SubjectRelations /> },
+              { path: 'board', element: <SubjectBoard /> },
+              { path: 'reviews', element: <SubjectReviews /> },
               {
                 path: 'wiki',
                 element: <Wiki />,


### PR DESCRIPTION
## 改动内容

实现条目页面的「讨论版」（`/subject/:id/board`）和「评论」（`/subject/:id/reviews`）两个 tab，替换原来的旧站跳转。

### 讨论版 `/subject/:id/board`
- 主题列表（标题 / 作者 / 回复数 / 时间），对齐旧站 `subject_topiclist` 表格与斑马纹
- 登录后显示「添加新讨论」按钮（发帖页未实现，暂跳转旧站）
- 分页（每页 10 条）

### 评论 `/subject/:id/reviews`
- 评论（日志）列表：标题 / 摘要 / 作者 / 时间 / 回复数，对齐旧站 `block_entry_list`
- 登录后显示「我来评论」按钮（写日志页未实现，暂跳转旧站）
- 分页（每页 10 条，对齐旧站）

### 其他
- 两个页面沿用「概览页布局」：`SubjectHeader` 在 `PageContainer` 外（与 #1006 一致），右侧复用 `SubjectSummaryCard`
- 新增 hooks：`use-subject-topics`、`use-subject-reviews`（使用 `/p1/subjects/:id/topics`、`/p1/subjects/:id/reviews` API）
- 注册 MSW handler 与 fixtures（`subjects/12` 的 topics/reviews 数据）
- `.prettierignore` 添加 `.kilo`（agent 本地配置目录）
- 重新生成 `packages/styled-system/styles.css`（新增原子类；顺带移除了无源码引用的 `.inset-e_overview` 残留）

## 验证

- Vitest：条目相关 40 个测试全部通过（含新增 `SubjectBoard.spec.tsx`、`SubjectReviews.spec.tsx`）
- `pnpm type-check`、`pnpm lint`、`pnpm lint:style`、`pnpm prettier:check` 通过
- `pnpm run build` 通过
- 截图对比概览 / 讨论版 / 评论 / 角色四页：标题与 tab 距离、标题水平位置、tab 宽度完全一致，两页内容渲染正常