### PR TITLE
fix(website): only show mobile header search panel when toggled

### DIFF
--- a/packages/website/e2e/specs/main.spec.ts
+++ b/packages/website/e2e/specs/main.spec.ts
@@ -13,8 +13,8 @@ test.describe('main page', () => {
     await page.goto('/');
 
     const headerContent = page.locator('header > div').first();
-    await expect(headerContent).toHaveCSS('padding-left', '16px');
-    await expect(headerContent).toHaveCSS('padding-right', '16px');
+    await expect(headerContent).toHaveCSS('padding-left', '5px');
+    await expect(headerContent).toHaveCSS('padding-right', '5px');
     await expect
       .poll(async () => page.evaluate(() => document.documentElement.scrollWidth))
       .toBe(375);
@@ -33,8 +33,19 @@ test.describe('main page', () => {
     await expect(toggle).toHaveAccessibleName('关闭菜单');
     await expect(toggle).toHaveAttribute('aria-expanded', 'true');
     await expect(navigation).toBeVisible();
-    await expect(navigation.getByRole('textbox', { name: '搜索' })).toBeVisible();
+    await expect(
+      page.locator('#mobile-search-panel').getByRole('textbox', { name: '搜索' }),
+    ).toBeVisible();
     await expect(navigation.getByRole('link', { name: '动画' })).toBeVisible();
+  });
+
+  test('移动端初始状态搜索面板不可见', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto('/');
+
+    // 回归测试：header 迁移 Panda CSS 后，smDown 内无条件 display:block 曾覆盖 hidden 属性，
+    // 导致搜索面板在移动端无条件显示（#995）
+    await expect(page.locator('#mobile-search-panel')).toBeHidden();
   });
 
   test('移动端已登录操作区保持水平对齐', async ({ page }) => {

--- a/packages/website/src/components/Header/index.tsx
+++ b/packages/website/src/components/Header/index.tsx
@@ -289,7 +289,6 @@ const icon = css({ width: '18px', height: '18px' });
 
 const notificationIcon = css({
   position: 'relative',
-  smDown: { display: 'none' },
 });
 
 const notificationNotice = css({
@@ -357,7 +356,6 @@ const mobilePanelStyle = css({
     top: '100%',
     left: '0',
     zIndex: '1',
-    display: 'block',
     width: '100%',
     padding: '4px 10px 0',
     boxSizing: 'border-box',
@@ -365,6 +363,10 @@ const mobilePanelStyle = css({
     borderBottom: '1px solid rgba(249, 188, 193, 0.95)',
     boxShadow: '0 0 0 2px rgba(0, 0, 0, 0.04)',
   },
+});
+
+const mobilePanelOpen = css({
+  smDown: { display: 'block' },
 });
 
 const mobileSearch = css({
@@ -443,13 +445,13 @@ const Header: FC = () => {
   const [searchCategory, setSearchCategory] = useState('all');
   const searchInputRef = useRef<HTMLInputElement>(null);
   const showMobileMenu = mobilePanel === 'menu';
-  const showMobileSearch = mobilePanel !== 'closed';
+  const showMobilePanel = mobilePanel !== 'closed';
 
   useEffect(() => {
-    if (showMobileSearch) {
+    if (mobilePanel === 'search') {
       searchInputRef.current?.focus();
     }
-  }, [showMobileSearch]);
+  }, [mobilePanel]);
 
   const toggleMobileMenu = (): void => {
     setMobilePanel((panel) => (panel === 'menu' ? 'closed' : 'menu'));
@@ -500,7 +502,7 @@ const Header: FC = () => {
             className={mobileSearchButton}
             type='button'
             aria-controls='mobile-search-panel'
-            aria-expanded={showMobileSearch}
+            aria-expanded={showMobilePanel}
             aria-label='搜索'
             onClick={() => {
               setMobilePanel((panel) => (panel === 'search' ? 'closed' : 'search'));
@@ -553,7 +555,10 @@ const Header: FC = () => {
           )}
         </div>
       </div>
-      <div id='mobile-search-panel' hidden={!showMobileSearch} className={mobilePanelStyle}>
+      <div
+        id='mobile-search-panel'
+        className={cx(mobilePanelStyle, showMobilePanel && mobilePanelOpen)}
+      >
         <form className={mobileSearchForm} onSubmit={handleMobileSearch}>
           <Input
             ref={searchInputRef}


### PR DESCRIPTION
## 变更

修复移动端 header 搜索面板无条件显示的问题（#995 Panda CSS 迁移引入的回归）：

- **核心修复**：`mobilePanelStyle` 在 `smDown` 内无条件 `display: block`，覆盖了 `hidden` 属性的 UA 样式，导致移动端每个页面加载时搜索面板（搜索框 + 导航菜单容器）都渲染。改为条件类 `mobilePanelOpen` 控制显隐，删除失效的 `hidden` 属性。
- 搜索框仅在打开搜索面板（`mobilePanel === 'search'`）时聚焦，打开菜单不再误聚焦。
- `showMobileSearch` 改名 `showMobilePanel`（语义为面板打开，含 menu/search 两种模式）。
- 移除 `notificationIcon` 上迁移时错误添加的 `smDown: { display: 'none' }`（迁移前不存在该规则，导致已登录移动端通知图标被隐藏）。

## 测试修复

- 新增 e2e 回归测试：移动端初始状态 `#mobile-search-panel` 不可见。
- 横向溢出测试的 padding 期望从 16px 对齐为 5px（`#991` 有意将移动端 gutter 改为 5px，测试未同步，此测试自 `#991` 起一直失败）。
- 导航菜单测试的搜索框定位器移到 `#mobile-search-panel` 内（`#995` 把搜索框从 `#mobile-navigation` 移出到面板 form 中）。

## 验证

- `pnpm build` ✓
- `pnpm test`（334 通过）✓
- `pnpm lint` / `pnpm type-check` / `pnpm lint:style` / `pnpm prettier:check` ✓
- Playwright `main.spec.ts`：5 passed；「收藏菜单」测试依赖登录 setup 的 storage state（Cloudflare Turnstile），本地无法完成登录，未运行
- Playwright 实测（390px/1440px）：初始隐藏、点搜索展开并聚焦、点菜单展开含导航、桌面端始终隐藏，均符合预期