### PR TITLE
feat(website): add subject comments (吐槽) page

### DIFF
--- a/packages/styled-system/styles.css
+++ b/packages/styled-system/styles.css
@@ -788,6 +788,18 @@
     padding: 16px 10px;
 }
 
+  .m_0_0_10px {
+    margin: 0 0 10px;
+}
+
+  .p_10px_0 {
+    padding: 10px 0;
+}
+
+  .m_0_0_4px {
+    margin: 0 0 4px;
+}
+
   .p_5px_10px {
     padding: 5px 10px;
 }
@@ -890,18 +902,6 @@
 
   .bg_\#f88f9b {
     background: #f88f9b;
-}
-
-  .m_0_0_10px {
-    margin: 0 0 10px;
-}
-
-  .p_10px_0 {
-    padding: 10px 0;
-}
-
-  .m_0_0_4px {
-    margin: 0 0 4px;
 }
 
   .p_2px_8px_2px_5px {
@@ -1048,6 +1048,22 @@
     border-top: 1px solid #e8e3e3;
 }
 
+  .gap_4px_0 {
+    gap: 4px 0;
+}
+
+  .bd-t_1px_dotted_\#e8e3e3 {
+    border-top: 1px dotted #e8e3e3;
+}
+
+  .flex_0_0_40px {
+    flex: 0 0 40px;
+}
+
+  .gap_5px {
+    gap: 5px;
+}
+
   .bd-b_1px_dotted_\#e0e0e0 {
     border-bottom: 1px dotted #e0e0e0;
 }
@@ -1058,10 +1074,6 @@
 
   .flex_0_0_50px {
     flex: 0 0 50px;
-}
-
-  .gap_5px {
-    gap: 5px;
 }
 
   .flex_0_0_48px {
@@ -1985,6 +1997,10 @@
     width: 90px;
 }
 
+  .h_40px {
+    height: 40px;
+}
+
   .w_8px {
     width: 8px;
 }
@@ -2195,6 +2211,10 @@
 
   .\[\&_tr\]\:bd-b_1px_dotted_\#e8e3e3 tr {
     border-bottom: 1px dotted #e8e3e3;
+}
+
+  .\[\&\:first-child\]\:bd-t_none:first-child {
+    border-top: var(--borders-none);
 }
 
   .\[\&_h3\]\:ov_hidden h3 {

--- a/packages/website/src/hooks/use-subject-comments.ts
+++ b/packages/website/src/hooks/use-subject-comments.ts
@@ -1,0 +1,21 @@
+import { ok } from '@oazapfts/runtime';
+import useSWR from 'swr';
+
+import { ozaClient } from '@bangumi/client';
+import type { CollectionType, SubjectInterestComment } from '@bangumi/client/client';
+
+/** 获取条目的吐槽（/subject/:id/comments） */
+export function useSubjectComments(
+  subjectID: number,
+  limit: number,
+  offset: number,
+  type?: CollectionType,
+): { data: SubjectInterestComment[] | undefined; total: number | undefined } {
+  const { data } = useSWR(
+    `subject-comments ${subjectID} ${type ?? 'all'} ${limit} ${offset}`,
+    async () => ok(ozaClient.getSubjectComments(subjectID, { $type: type, limit, offset })),
+    { suspense: true },
+  );
+
+  return data ?? { data: undefined, total: undefined };
+}

--- a/packages/website/src/mocks/fixtures/p1/subjects/12/comments-GET.json
+++ b/packages/website/src/mocks/fixtures/p1/subjects/12/comments-GET.json
@@ -1,0 +1,59 @@
+{
+  "data": [
+    {
+      "id": 1001,
+      "user": {
+        "id": 1272395,
+        "username": "Madeline",
+        "nickname": "Madeline",
+        "avatar": {
+          "small": "https://lain.bgm.tv/pic/user/s/000/12/72/1272395.jpg",
+          "medium": "https://lain.bgm.tv/pic/user/m/000/12/72/1272395.jpg",
+          "large": "https://lain.bgm.tv/pic/user/l/000/12/72/1272395.jpg"
+        }
+      },
+      "type": 2,
+      "rate": 8,
+      "comment": "剧情节奏紧凑，作画稳定，值得一看的宝藏作品。",
+      "updatedAt": 1735689600,
+      "reactions": []
+    },
+    {
+      "id": 1002,
+      "user": {
+        "id": 382951,
+        "username": "382951",
+        "nickname": "树洞酱",
+        "avatar": {
+          "small": "https://lain.bgm.tv/pic/user/s/000/38/29/382951.jpg",
+          "medium": "https://lain.bgm.tv/pic/user/m/000/38/29/382951.jpg",
+          "large": "https://lain.bgm.tv/pic/user/l/000/38/29/382951.jpg"
+        }
+      },
+      "type": 2,
+      "rate": 7,
+      "comment": "中规中矩，但结尾的处理不太满意。",
+      "updatedAt": 1735689600,
+      "reactions": []
+    },
+    {
+      "id": 1003,
+      "user": {
+        "id": 1,
+        "username": "sai",
+        "nickname": "Sai",
+        "avatar": {
+          "small": "https://lain.bgm.tv/pic/user/s/000/00/00/1.jpg",
+          "medium": "https://lain.bgm.tv/pic/user/m/000/00/00/1.jpg",
+          "large": "https://lain.bgm.tv/pic/user/l/000/00/00/1.jpg"
+        }
+      },
+      "type": 1,
+      "rate": 0,
+      "comment": "先码住，等完结再看。",
+      "updatedAt": 1735689600,
+      "reactions": []
+    }
+  ],
+  "total": 3
+}

--- a/packages/website/src/mocks/handlers.ts
+++ b/packages/website/src/mocks/handlers.ts
@@ -21,6 +21,7 @@ export const handlers = [
   mockAPI('/p1/subjects/:subjectID/staffs/persons', 'get'),
   mockAPI('/p1/subjects/:subjectID/topics', 'get'),
   mockAPI('/p1/subjects/:subjectID/reviews', 'get'),
+  mockAPI('/p1/subjects/:subjectID/comments', 'get'),
   mockAPI('/p1/subjects/:subjectID/collects', 'get'),
   mockAPI('/p1/persons/:personID', 'get'),
   mockAPI('/p1/persons/:personID/casts', 'get'),

--- a/packages/website/src/pages/index/subject/[id]/SubjectComments.spec.tsx
+++ b/packages/website/src/pages/index/subject/[id]/SubjectComments.spec.tsx
@@ -1,0 +1,79 @@
+import { screen } from '@testing-library/react';
+import React from 'react';
+
+import type { SubjectHomeResponse, SubjectInterestComment } from '@bangumi/client/client';
+import { renderPage } from '@bangumi/website/utils/test-utils';
+
+import commentsFixture from '../../../../mocks/fixtures/p1/subjects/12/comments-GET.json';
+import homeFixture from '../../../../mocks/fixtures/p1/subjects/12/home-GET.json';
+import SubjectComments from './components/SubjectComments';
+
+const homeData = homeFixture as unknown as SubjectHomeResponse;
+const { data: comments, total } = commentsFixture as unknown as {
+  data: SubjectInterestComment[];
+  total: number;
+};
+
+describe('SubjectComments', () => {
+  const renderComments = (props: Partial<React.ComponentProps<typeof SubjectComments>> = {}) =>
+    renderPage(
+      <SubjectComments
+        subject={homeData.subject}
+        comments={comments}
+        total={total}
+        currentPage={1}
+        pageSize={20}
+        type={undefined}
+        onPageChange={() => undefined}
+        {...props}
+      />,
+    );
+
+  it('should render the comment list with rates and collect types', () => {
+    renderComments();
+
+    // 作者链接到个人主页
+    const authorLinks = screen.getAllByRole('link', { name: 'Madeline' });
+    expect(authorLinks[0]).toHaveAttribute('href', '/user/Madeline');
+
+    // 评分星星：rate=8 → 4 颗实星，rate=7 → 3 颗实星，共 7 颗
+    const rate = screen.getAllByTestId('filled');
+    expect(rate).toHaveLength(7);
+
+    // 收藏类型与吐槽内容（"看过" 出现 3 次：筛选 tab 1 次 + 两条吐槽各 1 次）
+    expect(screen.getAllByText('看过')).toHaveLength(3);
+    expect(screen.getByText('剧情节奏紧凑，作画稳定，值得一看的宝藏作品。')).toBeInTheDocument();
+    expect(screen.getByText('先码住，等完结再看。')).toBeInTheDocument();
+  });
+
+  it('should not render a rate for comments without a score', () => {
+    renderComments();
+
+    // type=1 的吐槽 rate=0，不显示星星
+    const text = screen.getByText('先码住，等完结再看。');
+    expect(text.closest('li')?.querySelector('.bgm-rate')).toBeNull();
+  });
+
+  it('should render the filter tabs with collect type links', () => {
+    renderComments();
+
+    expect(screen.getByRole('link', { name: '全部' })).toHaveAttribute(
+      'href',
+      '/subject/12/comments',
+    );
+    expect(screen.getByRole('link', { name: '看过' })).toHaveAttribute(
+      'href',
+      '/subject/12/comments?type=2',
+    );
+    expect(screen.getByRole('link', { name: '想看' })).toHaveAttribute(
+      'href',
+      '/subject/12/comments?type=1',
+    );
+  });
+
+  it('should render an empty state when there are no comments', () => {
+    renderComments({ comments: [], total: 0 });
+
+    expect(screen.getByText('还没有吐槽')).toBeInTheDocument();
+  });
+});

--- a/packages/website/src/pages/index/subject/[id]/comments.tsx
+++ b/packages/website/src/pages/index/subject/[id]/comments.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { useParams, useSearchParams } from 'react-router-dom';
+
+import type { CollectionType } from '@bangumi/client/client';
+import { withErrorBoundary } from '@bangumi/website/components/ErrorBoundary';
+import Helmet from '@bangumi/website/components/Helmet';
+import { useTransitionNavigate } from '@bangumi/website/hooks/use-navigate';
+import { usePaginationParams } from '@bangumi/website/hooks/use-pagination';
+import { useSubject } from '@bangumi/website/hooks/use-subject';
+import { useSubjectComments } from '@bangumi/website/hooks/use-subject-comments';
+
+import SubjectComments from './components/SubjectComments';
+
+const PAGE_SIZE = 20;
+
+function SubjectCommentsPage() {
+  const { id } = useParams();
+  const subjectID = Number(id);
+  const [searchParams] = useSearchParams();
+  const rawType = searchParams.get('type');
+  const type = rawType ? (Number(rawType) as CollectionType) : undefined;
+  const { curPage, pageSize, offset } = usePaginationParams(PAGE_SIZE);
+  const subject = useSubject(subjectID);
+  const { data: comments, total } = useSubjectComments(subjectID, pageSize, offset, type);
+  const [, navigate] = useTransitionNavigate();
+
+  if (!subject || !comments) {
+    return null;
+  }
+
+  const handlePageChange = (page: number): void => {
+    navigate({ search: type === undefined ? `page=${page}` : `type=${type}&page=${page}` });
+  };
+
+  return (
+    <>
+      <Helmet title={`${subject.nameCN || subject.name} - 吐槽`} />
+      <SubjectComments
+        subject={subject}
+        comments={comments}
+        total={total ?? 0}
+        currentPage={curPage}
+        pageSize={pageSize}
+        type={type}
+        onPageChange={handlePageChange}
+      />
+    </>
+  );
+}
+
+export default withErrorBoundary(SubjectCommentsPage, {
+  404: () => <div>没有找到条目</div>,
+});

--- a/packages/website/src/pages/index/subject/[id]/components/SubjectComments.tsx
+++ b/packages/website/src/pages/index/subject/[id]/components/SubjectComments.tsx
@@ -1,0 +1,171 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+
+import type { CollectionType, Subject, SubjectInterestComment } from '@bangumi/client/client';
+import { Pagination, Rate, Tab, Typography } from '@bangumi/design';
+import { css } from '@bangumi/styled-system/css';
+import { getSubjectCommentsLink, getUserProfileLink } from '@bangumi/utils/pages';
+import PageContainer from '@bangumi/website/components/PageContainer';
+
+import { COLLECT_DESC, makeDescriptiveTime } from './subject-common';
+import { SubjectHeader } from './SubjectDetail';
+import SubjectSummaryCard from './SubjectSummaryCard';
+
+const { Link } = Typography;
+
+const columns = css({
+  display: 'grid',
+  gridTemplateColumns: 'minmax(0, 7fr) minmax(260px, 3fr)',
+  alignItems: 'start',
+  gap: '20px',
+  '@media (max-width: 768px)': { gridTemplateColumns: 'minmax(0, 1fr)' },
+});
+
+const commentsMain = css({ minWidth: '0' });
+
+const commentTabs = css({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '4px 0',
+  margin: '0 0 10px',
+});
+
+const commentList = css({
+  margin: '0',
+  padding: '0',
+  listStyle: 'none',
+});
+
+const commentItem = css({
+  display: 'flex',
+  alignItems: 'flex-start',
+  gap: '10px',
+  padding: '10px 0',
+  borderTop: '1px dotted #e8e3e3',
+  boxSizing: 'border-box',
+  '&:first-child': { borderTop: 'none' },
+});
+
+const commentAvatar = css({
+  flex: '0 0 40px',
+  width: '40px',
+  height: '40px',
+  borderRadius: '6px',
+});
+
+const commentBody = css({
+  flex: '1 1 auto',
+  minWidth: '0',
+  fontSize: '13px',
+  lineHeight: '150%',
+});
+
+const commentMeta = css({
+  display: 'flex',
+  flexWrap: 'wrap',
+  alignItems: 'center',
+  gap: '5px',
+  margin: '0 0 4px',
+  fontSize: '13px',
+  color: '#9f9b9b',
+});
+
+const commentText = css({
+  margin: '0',
+  color: '#595555',
+  overflowWrap: 'anywhere',
+});
+
+const empty = css({
+  margin: '0',
+  padding: '16px 10px',
+  borderTop: '1px solid #e8e3e3',
+  borderBottom: '1px dotted #e8e3e3',
+  color: '#9f9b9b',
+  fontSize: '13px',
+});
+
+const pagination = css({ margin: '10px 0' });
+
+const commentsTabsItems = [
+  { key: 'all', label: '全部', type: undefined as CollectionType | undefined },
+  ...(Object.entries(COLLECT_DESC) as [string, string][]).map(([key, label]) => ({
+    key,
+    label,
+    type: Number(key) as CollectionType,
+  })),
+];
+
+const SubjectComments: React.FC<{
+  subject: Subject;
+  comments: SubjectInterestComment[];
+  total: number;
+  currentPage: number;
+  pageSize: number;
+  type: CollectionType | undefined;
+  onPageChange: (page: number) => void;
+}> = ({ subject, comments, total, currentPage, pageSize, type, onPageChange }) => {
+  return (
+    <>
+      <SubjectHeader subject={subject} />
+      <PageContainer as='main'>
+        <div className={columns}>
+          <div className={commentsMain}>
+            <Tab.Group type='borderless'>
+              {commentsTabsItems.map((item) => (
+                <NavLink
+                  key={item.key}
+                  to={
+                    item.type === undefined
+                      ? getSubjectCommentsLink(subject.id)
+                      : `${getSubjectCommentsLink(subject.id)}?type=${item.type}`
+                  }
+                  className={commentTabs}
+                >
+                  {({ isActive }) => <Tab.Item isActive={isActive}>{item.label}</Tab.Item>}
+                </NavLink>
+              ))}
+            </Tab.Group>
+            {comments.length === 0 && <p className={empty}>还没有吐槽</p>}
+            {comments.length > 0 && (
+              <ul className={commentList}>
+                {comments.map((comment) => (
+                  <li key={comment.id} className={commentItem}>
+                    <Link to={getUserProfileLink(comment.user.username)}>
+                      <img
+                        src={comment.user.avatar.small}
+                        alt={comment.user.nickname}
+                        className={commentAvatar}
+                      />
+                    </Link>
+                    <div className={commentBody}>
+                      <div className={commentMeta}>
+                        <Link to={getUserProfileLink(comment.user.username)}>
+                          {comment.user.nickname}
+                        </Link>
+                        {comment.rate > 0 && <Rate value={comment.rate} />}
+                        <span>{COLLECT_DESC[comment.type]}</span>
+                        <span>@{makeDescriptiveTime(comment.updatedAt)}</span>
+                      </div>
+                      <p className={commentText}>{comment.comment}</p>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+            <Pagination
+              total={total}
+              currentPage={currentPage}
+              pageSize={pageSize}
+              onChange={onPageChange}
+              wrapperClass={pagination}
+            />
+          </div>
+          <SubjectSummaryCard subject={subject} />
+        </div>
+      </PageContainer>
+    </>
+  );
+};
+
+export default SubjectComments;

--- a/packages/website/src/pages/index/subject/[id]/components/SubjectDetail.tsx
+++ b/packages/website/src/pages/index/subject/[id]/components/SubjectDetail.tsx
@@ -23,7 +23,6 @@ import {
   getSubjectPersonsLink,
   getSubjectRelationsLink,
   getSubjectReviewsLink,
-  getSubjectStatsLink,
   getSubjectWikiEditLink,
   getUserProfileLink,
 } from '@bangumi/utils/pages';
@@ -32,64 +31,11 @@ import { useSubjectCollects } from '@bangumi/website/hooks/use-subject-collects'
 import { useUser } from '@bangumi/website/hooks/use-user';
 
 import CollectionPanel from './CollectionPanel';
-import { COLLECT_DESC, collectVerb } from './subject-common';
+import { COLLECT_DESC, collectVerb, makeDescriptiveTime } from './subject-common';
 import styles from './SubjectDetail.module.less';
 import { SubjectPrimaryBlocks, SubjectSecondaryBlocks } from './SubjectDetailBlocks';
 
 const { Link } = Typography;
-
-/** 相对时间，对齐 PHP GlobalCore::make_descriptive_time（如「1小时25分钟前」） */
-function makeDescriptiveTime(timestamp: number): string {
-  const YEAR = 86400 * 365;
-  const MONTH = 86400 * 30;
-  const DAY = 86400;
-  const HOUR = 3600;
-  const MINUTE = 60;
-
-  const diff = Math.floor(Date.now() / 1000) - timestamp;
-
-  if (diff > YEAR) {
-    const years = Math.floor(diff / YEAR);
-    const rest = diff - years * YEAR;
-    if (rest > MONTH) {
-      return `${years}年${Math.floor(rest / MONTH)}月前`;
-    }
-    return `${years}年前`;
-  }
-  if (diff > MONTH) {
-    const months = Math.floor(diff / MONTH);
-    const rest = diff - months * MONTH;
-    if (rest > DAY) {
-      return `${months}月${Math.floor(rest / DAY)}天前`;
-    }
-    return `${months}月前`;
-  }
-  if (diff > DAY) {
-    const days = Math.floor(diff / DAY);
-    const rest = diff - days * DAY;
-    if (rest > HOUR) {
-      return `${days}天${Math.floor(rest / HOUR)}小时前`;
-    }
-    return `${days}天前`;
-  }
-  if (diff > HOUR) {
-    const hours = Math.floor(diff / HOUR);
-    const rest = diff - hours * HOUR;
-    if (rest > MINUTE) {
-      return `${hours}小时${Math.floor(rest / MINUTE)}分钟前`;
-    }
-    return `${hours}小时前`;
-  }
-  if (diff > MINUTE) {
-    const minutes = Math.floor(diff / MINUTE);
-    const rest = diff - minutes * MINUTE;
-    if (rest > 0) {
-      return `${minutes}分${rest}秒前`;
-    }
-    return `${minutes}分钟前`;
-  }
-  return `${diff}秒前`;
-}
 
 /** 条目标题与导航 tabs，对齐 PHP subject_header */
 export function SubjectHeader({ subject }: { subject: Subject }) {
@@ -132,11 +78,6 @@ export function SubjectHeader({ subject }: { subject: Subject }) {
       key: 'board',
       label: '讨论版',
       to: getSubjectBoardLink(subject.id),
-    },
-    {
-      key: 'stats',
-      label: '透视',
-      to: getSubjectStatsLink(subject.id),
     },
     {
       key: 'wiki',

--- a/packages/website/src/pages/index/subject/[id]/components/subject-common.ts
+++ b/packages/website/src/pages/index/subject/[id]/components/subject-common.ts
@@ -31,3 +31,56 @@ export function collectVerb(subjectType: number): string {
       return '看';
   }
 }
+
+/** 相对时间，对齐 PHP GlobalCore::make_descriptive_time（如「1小时25分钟前」） */
+export function makeDescriptiveTime(timestamp: number): string {
+  const YEAR = 86400 * 365;
+  const MONTH = 86400 * 30;
+  const DAY = 86400;
+  const HOUR = 3600;
+  const MINUTE = 60;
+
+  const diff = Math.floor(Date.now() / 1000) - timestamp;
+
+  if (diff > YEAR) {
+    const years = Math.floor(diff / YEAR);
+    const rest = diff - years * YEAR;
+    if (rest > MONTH) {
+      return `${years}年${Math.floor(rest / MONTH)}月前`;
+    }
+    return `${years}年前`;
+  }
+  if (diff > MONTH) {
+    const months = Math.floor(diff / MONTH);
+    const rest = diff - months * MONTH;
+    if (rest > DAY) {
+      return `${months}月${Math.floor(rest / DAY)}天前`;
+    }
+    return `${months}月前`;
+  }
+  if (diff > DAY) {
+    const days = Math.floor(diff / DAY);
+    const rest = diff - days * DAY;
+    if (rest > HOUR) {
+      return `${days}天${Math.floor(rest / HOUR)}小时前`;
+    }
+    return `${days}天前`;
+  }
+  if (diff > HOUR) {
+    const hours = Math.floor(diff / HOUR);
+    const rest = diff - hours * HOUR;
+    if (rest > MINUTE) {
+      return `${hours}小时${Math.floor(rest / MINUTE)}分钟前`;
+    }
+    return `${hours}小时前`;
+  }
+  if (diff > MINUTE) {
+    const minutes = Math.floor(diff / MINUTE);
+    const rest = diff - minutes * MINUTE;
+    if (rest > 0) {
+      return `${minutes}分${rest}秒前`;
+    }
+    return `${minutes}分钟前`;
+  }
+  return `${diff}秒前`;
+}

--- a/packages/website/src/routes.tsx
+++ b/packages/website/src/routes.tsx
@@ -36,6 +36,7 @@ const SubjectIndexes = lazy(async () => import('./pages/index/subject/[id]/index
 const SubjectEpisodes = lazy(async () => import('./pages/index/subject/[id]/ep'));
 const SubjectRelations = lazy(async () => import('./pages/index/subject/[id]/relations'));
 const SubjectBoard = lazy(async () => import('./pages/index/subject/[id]/board'));
+const SubjectComments = lazy(async () => import('./pages/index/subject/[id]/comments'));
 const SubjectReviews = lazy(async () => import('./pages/index/subject/[id]/reviews'));
 const SubjectSearch = lazy(async () => import('./pages/index/subject_search/[keyword]'));
 const Person = lazy(async () => import('./pages/index/person/[id]'));
@@ -71,7 +72,6 @@ const legacyPagePaths = [
   'magi',
   'onair',
   'subject/:id/collections',
-  'subject/:id/comments',
   'subject/:id/stats',
   'subject/ep/:id',
   'subject/tag/:tag',
@@ -178,6 +178,7 @@ export const pageRoutes: RouteObject[] = [
               { path: 'ep', element: <SubjectEpisodes /> },
               { path: 'relations', element: <SubjectRelations /> },
               { path: 'board', element: <SubjectBoard /> },
+              { path: 'comments', element: <SubjectComments /> },
               { path: 'reviews', element: <SubjectReviews /> },
               {
                 path: 'wiki',


### PR DESCRIPTION
## 变更

实现条目吐槽页面 `/subject/:id/comments`，替换原来的旧站跳转（legacy redirect），基于现有 `GET /p1/subjects/:subjectID/comments` 接口：

- **吐槽列表**：头像、昵称、`Rate` 星星评分、收藏类型（想看/看过…）、相对时间、吐槽文字，布局对齐旧版 `block_comment_box`
- **筛选 tabs**：全部 + 5 个收藏类型，通过 `type` URL 参数筛选，翻页时保留筛选条件
- `makeDescriptiveTime` 从 `SubjectDetail.tsx` 移到共享的 `subject-common.ts`，吐槽与详情页共用
- 顺带按你的要求**删除了 subject header 里的「透视」tab**
- 注册路由、从 legacy 路径移除 `subject/:id/comments`、新增 MSW handler/fixture 与单元测试（4 条）

## 验证

- `pnpm build` ✓
- `pnpm test`（341 通过）✓
- `pnpm lint` / `pnpm type-check` / `pnpm prettier:check` ✓
- Playwright 截图：桌面与 375px 移动端渲染正常（筛选 tab、评分星星、相对时间、右侧条目卡片）

## 说明

修复了无 `type` 参数时误传 `type=0` 的问题（`Number(null)` 为 0，后端校验失败返回 400）。