### PR TITLE
feat(website): add person works (作品) and voice (角色) tabs

### DIFF
--- a/packages/website/src/hooks/use-person-casts.ts
+++ b/packages/website/src/hooks/use-person-casts.ts
@@ -1,0 +1,20 @@
+import { ok } from '@oazapfts/runtime';
+import useSWR from 'swr';
+
+import { ozaClient } from '@bangumi/client';
+import type { PersonCharacter } from '@bangumi/client/client';
+
+/** 获取人物的演出角色列表（/person/:id/works/voice） */
+export function usePersonCasts(
+  personID: number,
+  limit: number,
+  offset: number,
+): { data: PersonCharacter[] | undefined; total: number | undefined } {
+  const { data } = useSWR(
+    `person-casts ${personID} ${limit} ${offset}`,
+    async () => ok(ozaClient.getPersonCasts(personID, { limit, offset })),
+    { suspense: true },
+  );
+
+  return data ?? { data: undefined, total: undefined };
+}

--- a/packages/website/src/hooks/use-person-works.ts
+++ b/packages/website/src/hooks/use-person-works.ts
@@ -1,0 +1,20 @@
+import { ok } from '@oazapfts/runtime';
+import useSWR from 'swr';
+
+import { ozaClient } from '@bangumi/client';
+import type { PersonWork } from '@bangumi/client/client';
+
+/** 获取人物的作品列表（/person/:id/works） */
+export function usePersonWorks(
+  personID: number,
+  limit: number,
+  offset: number,
+): { data: PersonWork[] | undefined; total: number | undefined } {
+  const { data } = useSWR(
+    `person-works ${personID} ${limit} ${offset}`,
+    async () => ok(ozaClient.getPersonWorks(personID, { limit, offset })),
+    { suspense: true },
+  );
+
+  return data ?? { data: undefined, total: undefined };
+}

--- a/packages/website/src/mocks/fixtures/p1/persons/21884/works-GET.json
+++ b/packages/website/src/mocks/fixtures/p1/persons/21884/works-GET.json
@@ -1,1 +1,101 @@
-{ "data": [], "total": 0 }
+{
+  "data": [
+    {
+      "subject": {
+        "id": 622206,
+        "name": "ヤニねこ",
+        "nameCN": "尼古喵喵",
+        "type": 2,
+        "info": "2026年7月2日 / 木村拓 / にゃんにゃんファクトリー（講談社「ヤングマガジン」連載） / 松浦力",
+        "metaTags": ["TV", "喜剧", "日常", "日本", "漫画改", "青年向"],
+        "rating": {
+          "rank": 1862,
+          "count": [36, 12, 21, 37, 116, 402, 1255, 981, 177, 119],
+          "score": 7.19,
+          "total": 3156
+        },
+        "locked": false,
+        "nsfw": false,
+        "images": {
+          "large": "https://lain.bgm.tv/pic/cover/l/6a/b3/622206_dpWcC.jpg",
+          "common": "https://lain.bgm.tv/r/400/pic/cover/l/6a/b3/622206_dpWcC.jpg",
+          "medium": "https://lain.bgm.tv/r/200/pic/cover/l/6a/b3/622206_dpWcC.jpg",
+          "small": "https://lain.bgm.tv/r/100/pic/cover/l/6a/b3/622206_dpWcC.jpg",
+          "grid": "https://lain.bgm.tv/r/100x100/pic/cover/l/6a/b3/622206_dpWcC.jpg"
+        }
+      },
+      "positions": [
+        {
+          "type": { "id": 1, "en": "Director", "cn": "导演", "jp": "監督" },
+          "summary": "",
+          "appearEps": ""
+        }
+      ]
+    },
+    {
+      "subject": {
+        "id": 622207,
+        "name": "テストアニメ",
+        "nameCN": "测试动画",
+        "type": 2,
+        "info": "2026年4月1日 / 测试工作室",
+        "metaTags": ["TV", "日本"],
+        "rating": {
+          "rank": 100,
+          "count": [100, 90, 80, 70, 60, 50, 40, 30, 20, 10],
+          "score": 8.1,
+          "total": 4321
+        },
+        "locked": false,
+        "nsfw": false,
+        "images": {
+          "large": "https://lain.bgm.tv/pic/cover/l/00/00/622207.jpg",
+          "common": "https://lain.bgm.tv/r/400/pic/cover/l/00/00/622207.jpg",
+          "medium": "https://lain.bgm.tv/r/200/pic/cover/l/00/00/622207.jpg",
+          "small": "https://lain.bgm.tv/r/100/pic/cover/l/00/00/622207.jpg",
+          "grid": "https://lain.bgm.tv/r/100x100/pic/cover/l/00/00/622207.jpg"
+        }
+      },
+      "positions": [
+        {
+          "type": { "id": 5, "en": "Screenplay", "cn": "脚本", "jp": "脚本" },
+          "summary": "",
+          "appearEps": ""
+        }
+      ]
+    },
+    {
+      "subject": {
+        "id": 622208,
+        "name": "声優ラジオ",
+        "nameCN": "声优电台",
+        "type": 6,
+        "info": "2026年1月1日",
+        "metaTags": ["日本"],
+        "rating": {
+          "rank": 500,
+          "count": [10, 8, 6, 5, 4, 3, 2, 1, 1, 1],
+          "score": 7.5,
+          "total": 41
+        },
+        "locked": false,
+        "nsfw": false,
+        "images": {
+          "large": "https://lain.bgm.tv/pic/cover/l/00/00/622208.jpg",
+          "common": "https://lain.bgm.tv/r/400/pic/cover/l/00/00/622208.jpg",
+          "medium": "https://lain.bgm.tv/r/200/pic/cover/l/00/00/622208.jpg",
+          "small": "https://lain.bgm.tv/r/100/pic/cover/l/00/00/622208.jpg",
+          "grid": "https://lain.bgm.tv/r/100x100/pic/cover/l/00/00/622208.jpg"
+        }
+      },
+      "positions": [
+        {
+          "type": { "id": 12, "en": "Performer", "cn": "主演", "jp": "出演" },
+          "summary": "",
+          "appearEps": ""
+        }
+      ]
+    }
+  ],
+  "total": 3
+}

--- a/packages/website/src/pages/index/character/[id]/CharacterDetail.tsx
+++ b/packages/website/src/pages/index/character/[id]/CharacterDetail.tsx
@@ -56,11 +56,7 @@ function CharacterHeader({ character }: { character: Character }) {
   };
 
   const baseLink = getCharacterLink(character.id);
-  const tabs = [
-    { label: '概览', to: baseLink, end: true },
-    { label: '相册', to: `${baseLink}/album`, end: false },
-    { label: '收藏', to: `${baseLink}/collections`, end: false },
-  ];
+  const tabs = [{ label: '概览', to: baseLink, end: true }];
 
   return (
     <header className={styles.header}>

--- a/packages/website/src/pages/index/person/[id]/PersonDetail.spec.tsx
+++ b/packages/website/src/pages/index/person/[id]/PersonDetail.spec.tsx
@@ -112,7 +112,7 @@ describe('PersonDetail', () => {
     // 最近演出角色
     expect(screen.getByRole('heading', { name: '最近演出角色' })).toBeInTheDocument();
     expect(screen.getAllByText('柴田').length).toBeGreaterThan(0);
-    expect(screen.getByRole('link', { name: 'ヤニねこ' })).toHaveAttribute(
+    expect(screen.getAllByRole('link', { name: 'ヤニねこ' })[0]).toHaveAttribute(
       'href',
       '/subject/622206',
     );

--- a/packages/website/src/pages/index/person/[id]/PersonDetail.tsx
+++ b/packages/website/src/pages/index/person/[id]/PersonDetail.tsx
@@ -46,11 +46,8 @@ export function PersonHeader({ person }: { person: PersonHomeData['person'] }) {
   const basePath = getPersonLink(person.id);
   const tabs = [
     { label: '概览', to: basePath, end: true },
-    { label: '相册', to: `${basePath}/album` },
     { label: '角色', to: `${basePath}/works/voice` },
     { label: '作品', to: `${basePath}/works` },
-    { label: '合作', to: `${basePath}/collabs` },
-    { label: '收藏', to: `${basePath}/collections` },
   ];
 
   return (

--- a/packages/website/src/pages/index/person/[id]/PersonDetail.tsx
+++ b/packages/website/src/pages/index/person/[id]/PersonDetail.tsx
@@ -17,11 +17,11 @@ import {
   getUserProfileLink,
 } from '@bangumi/utils/pages';
 import CollectSidePanel from '@bangumi/website/components/CollectSidePanel';
-import Helmet from '@bangumi/website/components/Helmet';
 import IndexSidePanel from '@bangumi/website/components/IndexSidePanel';
 import PageContainer from '@bangumi/website/components/PageContainer';
 import type { PersonHomeData } from '@bangumi/website/hooks/use-person-home';
 
+import PersonLayout from './components/PersonLayout';
 import styles from './PersonDetail.module.less';
 
 const { Link } = Typography;
@@ -42,7 +42,7 @@ const CHARACTER_ROLE_LABELS: Record<number, string> = {
   3: '客串',
 };
 
-function PersonHeader({ person }: { person: PersonHomeData['person'] }) {
+export function PersonHeader({ person }: { person: PersonHomeData['person'] }) {
   const basePath = getPersonLink(person.id);
   const tabs = [
     { label: '概览', to: basePath, end: true },
@@ -126,7 +126,7 @@ function InfoItem({ item }: { item: Infobox[number] }) {
   );
 }
 
-function PersonInfobox({ data }: { data: PersonHomeData }) {
+export function PersonInfobox({ data }: { data: PersonHomeData }) {
   const { person } = data;
   return (
     <aside className={styles.columnLeft}>
@@ -179,7 +179,7 @@ function SectionHeader({ title, more }: { title: string; more?: React.ReactNode 
   );
 }
 
-function CastList({ casts }: { casts: PersonCharacter[] }) {
+export function CastList({ casts }: { casts: PersonCharacter[] }) {
   return (
     <ul className={styles.castList}>
       {casts.map(({ character, relations }) => (
@@ -220,7 +220,7 @@ function CastList({ casts }: { casts: PersonCharacter[] }) {
   );
 }
 
-function WorkList({ works }: { works: PersonWork[] }) {
+export function WorkList({ works }: { works: PersonWork[] }) {
   return (
     <ul className={styles.workList}>
       {works.map(({ subject, positions }) => (
@@ -297,54 +297,45 @@ export default function PersonDetail({ data }: { data: PersonHomeData }) {
   const basePath = getPersonLink(data.person.id);
 
   return (
-    <>
-      <Helmet title={`${data.person.nameCN} ${data.person.name}`} />
-      <PersonHeader person={data.person} />
-      <PageContainer as='main' className={styles.page}>
-        <div className={styles.columns}>
-          <PersonInfobox data={data} />
-          <div className={styles.columnMain}>
-            {career && <h2 className={styles.career}>职业: {career}</h2>}
-            {data.person.summary && <p className={styles.summary}>{data.person.summary}</p>}
+    <PersonLayout data={data} title={`${data.person.nameCN} ${data.person.name}`}>
+      {career && <h2 className={styles.career}>职业: {career}</h2>}
+      {data.person.summary && <p className={styles.summary}>{data.person.summary}</p>}
 
-            <section className={styles.section}>
-              <SectionHeader
-                title='最近演出角色'
-                more={
-                  data.castsTotal > data.casts.length ? (
-                    <Link to={`${basePath}/works/voice`}>更多角色 »</Link>
-                  ) : undefined
-                }
-              />
-              <CastList casts={data.casts} />
-            </section>
+      <section className={styles.section}>
+        <SectionHeader
+          title='最近演出角色'
+          more={
+            data.castsTotal > data.casts.length ? (
+              <Link to={`${basePath}/works/voice`}>更多角色 »</Link>
+            ) : undefined
+          }
+        />
+        <CastList casts={data.casts} />
+      </section>
 
-            <section className={styles.section}>
-              <SectionHeader
-                title='最近参与'
-                more={
-                  data.worksTotal > data.works.length ? (
-                    <Link to={`${basePath}/works`}>更多作品 »</Link>
-                  ) : undefined
-                }
-              />
-              <WorkList works={data.works} />
-            </section>
+      <section className={styles.section}>
+        <SectionHeader
+          title='最近参与'
+          more={
+            data.worksTotal > data.works.length ? (
+              <Link to={`${basePath}/works`}>更多作品 »</Link>
+            ) : undefined
+          }
+        />
+        <WorkList works={data.works} />
+      </section>
 
-            {data.relations.length > 0 && (
-              <section className={styles.section}>
-                <SectionHeader title='关联人物' />
-                <RelationGrid relations={data.relations} />
-              </section>
-            )}
+      {data.relations.length > 0 && (
+        <section className={styles.section}>
+          <SectionHeader title='关联人物' />
+          <RelationGrid relations={data.relations} />
+        </section>
+      )}
 
-            <section className={styles.section}>
-              <SectionHeader title='吐槽箱' />
-              <CommentList comments={data.comments} />
-            </section>
-          </div>
-        </div>
-      </PageContainer>
-    </>
+      <section className={styles.section}>
+        <SectionHeader title='吐槽箱' />
+        <CommentList comments={data.comments} />
+      </section>
+    </PersonLayout>
   );
 }

--- a/packages/website/src/pages/index/person/[id]/components/PersonLayout.tsx
+++ b/packages/website/src/pages/index/person/[id]/components/PersonLayout.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from 'react';
+import React from 'react';
+
+import Helmet from '@bangumi/website/components/Helmet';
+import PageContainer from '@bangumi/website/components/PageContainer';
+import type { PersonHomeData } from '@bangumi/website/hooks/use-person-home';
+
+import { PersonHeader, PersonInfobox } from '../PersonDetail';
+import styles from '../PersonDetail.module.less';
+
+/** 人物页面共享布局：Header + 左栏 Infobox + 主栏内容，各 tab 复用 */
+const PersonLayout: React.FC<{
+  data: PersonHomeData;
+  title?: string;
+  children: ReactNode;
+}> = ({ data, title, children }) => (
+  <>
+    {title != null && <Helmet title={title} />}
+    <PersonHeader person={data.person} />
+    <PageContainer as='main' className={styles.page}>
+      <div className={styles.columns}>
+        <PersonInfobox data={data} />
+        <div className={styles.columnMain}>{children}</div>
+      </div>
+    </PageContainer>
+  </>
+);
+
+export default PersonLayout;

--- a/packages/website/src/pages/index/person/[id]/voice.spec.tsx
+++ b/packages/website/src/pages/index/person/[id]/voice.spec.tsx
@@ -1,0 +1,99 @@
+import { act, screen } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import React, { Suspense } from 'react';
+import { useParams } from 'react-router-dom';
+
+import {
+  personCastsFixture,
+  personCollectsFixture,
+  personCommentsFixture,
+  personFixture,
+  personIndexesFixture,
+  personRelationsFixture,
+  personWorksFixture,
+} from '@bangumi/website/mocks/fixtures/p1/persons/21884';
+import { server as mockServer } from '@bangumi/website/mocks/server';
+import { renderPage } from '@bangumi/website/utils/test-utils';
+
+import PersonVoicePage from './voice';
+
+vi.mock('react-router-dom', async () => {
+  return {
+    __esModule: true,
+    ...(await vi.importActual<typeof import('react-router-dom')>('react-router-dom')),
+    useParams: vi.fn(),
+  } as unknown;
+});
+
+const mockedUseParams = vi.mocked(useParams);
+
+function mockPersonAPI() {
+  mockServer.use(
+    http.get('http://localhost:3000/p1/persons/21884', () => HttpResponse.json(personFixture)),
+    http.get('http://localhost:3000/p1/persons/21884/casts', () =>
+      HttpResponse.json(personCastsFixture),
+    ),
+    http.get('http://localhost:3000/p1/persons/21884/works', () =>
+      HttpResponse.json(personWorksFixture),
+    ),
+    http.get('http://localhost:3000/p1/persons/21884/relations', () =>
+      HttpResponse.json(personRelationsFixture),
+    ),
+    http.get('http://localhost:3000/p1/persons/21884/collects', () =>
+      HttpResponse.json(personCollectsFixture),
+    ),
+    http.get('http://localhost:3000/p1/persons/21884/comments', () =>
+      HttpResponse.json(personCommentsFixture),
+    ),
+    http.get('http://localhost:3000/p1/persons/21884/indexes', () =>
+      HttpResponse.json(personIndexesFixture),
+    ),
+  );
+}
+
+beforeEach(() => {
+  mockedUseParams.mockReturnValue({ id: '21884' });
+  mockPersonAPI();
+});
+
+describe('PersonVoice', () => {
+  it('should render the cast list with characters and subjects', async () => {
+    await act(async () => {
+      renderPage(
+        <Suspense fallback={null}>
+          <PersonVoicePage />
+        </Suspense>,
+      );
+    });
+
+    expect(await screen.findByText('「中村章吾」的角色')).toBeInTheDocument();
+
+    // 角色链接
+    const characterLink = screen.getByRole('link', { name: '柴田' });
+    expect(characterLink).toHaveAttribute('href', '/character/217861');
+
+    // 出演条目与角色类型（fixture relations type=2 → 配角）
+    expect(screen.getByRole('link', { name: 'ヤニねこ' })).toHaveAttribute(
+      'href',
+      '/subject/622206',
+    );
+    expect(screen.getAllByText('配角').length).toBeGreaterThan(0);
+  });
+
+  it('should render the shared layout with person infobox', async () => {
+    await act(async () => {
+      renderPage(
+        <Suspense fallback={null}>
+          <PersonVoicePage />
+        </Suspense>,
+      );
+    });
+
+    // 左栏 infobox 与导航 tabs 复用同一布局
+    expect(await screen.findByRole('heading', { name: '谁收藏了中村章吾?' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '角色' })).toHaveAttribute(
+      'href',
+      '/person/21884/works/voice',
+    );
+  });
+});

--- a/packages/website/src/pages/index/person/[id]/voice.tsx
+++ b/packages/website/src/pages/index/person/[id]/voice.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+import { Pagination } from '@bangumi/design';
+import { withErrorBoundary } from '@bangumi/website/components/ErrorBoundary';
+import { useTransitionNavigate } from '@bangumi/website/hooks/use-navigate';
+import { usePaginationParams } from '@bangumi/website/hooks/use-pagination';
+import { usePersonCasts } from '@bangumi/website/hooks/use-person-casts';
+import { usePersonHome } from '@bangumi/website/hooks/use-person-home';
+
+import PersonLayout from './components/PersonLayout';
+import { CastList } from './PersonDetail';
+import styles from './PersonDetail.module.less';
+
+const PAGE_SIZE = 20;
+
+function PersonVoicePage() {
+  const { id } = useParams();
+  const personID = Number(id);
+  const { curPage, pageSize, offset } = usePaginationParams(PAGE_SIZE);
+  const { data } = usePersonHome(personID);
+  const { data: casts, total } = usePersonCasts(personID, pageSize, offset);
+  const [, navigate] = useTransitionNavigate();
+
+  if (!data || !casts) {
+    return null;
+  }
+
+  const handlePageChange = (page: number): void => {
+    navigate({ search: `page=${page}` });
+  };
+
+  return (
+    <PersonLayout data={data} title={`${data.person.name} - 角色`}>
+      <div className={styles.sectionHeader}>
+        <h2>「{data.person.name}」的角色</h2>
+      </div>
+      <CastList casts={casts} />
+      <Pagination
+        total={total ?? 0}
+        currentPage={curPage}
+        pageSize={pageSize}
+        onChange={handlePageChange}
+      />
+    </PersonLayout>
+  );
+}
+
+export default withErrorBoundary(PersonVoicePage, {
+  404: () => <div>没有找到人物</div>,
+});

--- a/packages/website/src/pages/index/person/[id]/works.spec.tsx
+++ b/packages/website/src/pages/index/person/[id]/works.spec.tsx
@@ -1,0 +1,105 @@
+import { act, screen } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import React, { Suspense } from 'react';
+import { useParams } from 'react-router-dom';
+
+import {
+  personCastsFixture,
+  personCollectsFixture,
+  personCommentsFixture,
+  personFixture,
+  personIndexesFixture,
+  personRelationsFixture,
+  personWorksFixture,
+} from '@bangumi/website/mocks/fixtures/p1/persons/21884';
+import { server as mockServer } from '@bangumi/website/mocks/server';
+import { renderPage } from '@bangumi/website/utils/test-utils';
+
+import PersonWorksPage from './works';
+
+vi.mock('react-router-dom', async () => {
+  return {
+    __esModule: true,
+    ...(await vi.importActual<typeof import('react-router-dom')>('react-router-dom')),
+    useParams: vi.fn(),
+  } as unknown;
+});
+
+const mockedUseParams = vi.mocked(useParams);
+
+function mockPersonAPI() {
+  mockServer.use(
+    http.get('http://localhost:3000/p1/persons/21884', () => HttpResponse.json(personFixture)),
+    http.get('http://localhost:3000/p1/persons/21884/casts', () =>
+      HttpResponse.json(personCastsFixture),
+    ),
+    http.get('http://localhost:3000/p1/persons/21884/works', () =>
+      HttpResponse.json(personWorksFixture),
+    ),
+    http.get('http://localhost:3000/p1/persons/21884/relations', () =>
+      HttpResponse.json(personRelationsFixture),
+    ),
+    http.get('http://localhost:3000/p1/persons/21884/collects', () =>
+      HttpResponse.json(personCollectsFixture),
+    ),
+    http.get('http://localhost:3000/p1/persons/21884/comments', () =>
+      HttpResponse.json(personCommentsFixture),
+    ),
+    http.get('http://localhost:3000/p1/persons/21884/indexes', () =>
+      HttpResponse.json(personIndexesFixture),
+    ),
+  );
+}
+
+beforeEach(() => {
+  mockedUseParams.mockReturnValue({ id: '21884' });
+  mockPersonAPI();
+});
+
+describe('PersonWorks', () => {
+  it('should render the work list with positions', async () => {
+    await act(async () => {
+      renderPage(
+        <Suspense fallback={null}>
+          <PersonWorksPage />
+        </Suspense>,
+      );
+    });
+
+    expect(await screen.findByText('「中村章吾」的作品')).toBeInTheDocument();
+
+    // 作品标题链接到条目
+    const workLink = screen.getByRole('link', { name: 'ヤニねこ' });
+    expect(workLink).toHaveAttribute('href', '/subject/622206');
+    expect(screen.getByRole('link', { name: 'テストアニメ' })).toHaveAttribute(
+      'href',
+      '/subject/622207',
+    );
+
+    // 职位标签
+    expect(screen.getByText('导演')).toBeInTheDocument();
+    expect(screen.getByText('脚本')).toBeInTheDocument();
+    expect(screen.getByText('主演')).toBeInTheDocument();
+  });
+
+  it('should render the shared layout with person infobox', async () => {
+    await act(async () => {
+      renderPage(
+        <Suspense fallback={null}>
+          <PersonWorksPage />
+        </Suspense>,
+      );
+    });
+
+    // 左栏 infobox 与导航 tabs 复用同一布局
+    expect(await screen.findByRole('heading', { name: '推荐本条目的目录' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '角色' })).toHaveAttribute(
+      'href',
+      '/person/21884/works/voice',
+    );
+    expect(screen.getByRole('link', { name: '作品' })).toHaveAttribute(
+      'href',
+      '/person/21884/works',
+    );
+  });
+});

--- a/packages/website/src/pages/index/person/[id]/works.tsx
+++ b/packages/website/src/pages/index/person/[id]/works.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+import { Pagination } from '@bangumi/design';
+import { withErrorBoundary } from '@bangumi/website/components/ErrorBoundary';
+import { useTransitionNavigate } from '@bangumi/website/hooks/use-navigate';
+import { usePaginationParams } from '@bangumi/website/hooks/use-pagination';
+import { usePersonHome } from '@bangumi/website/hooks/use-person-home';
+import { usePersonWorks } from '@bangumi/website/hooks/use-person-works';
+
+import PersonLayout from './components/PersonLayout';
+import { WorkList } from './PersonDetail';
+import styles from './PersonDetail.module.less';
+
+const PAGE_SIZE = 20;
+
+function PersonWorksPage() {
+  const { id } = useParams();
+  const personID = Number(id);
+  const { curPage, pageSize, offset } = usePaginationParams(PAGE_SIZE);
+  const { data } = usePersonHome(personID);
+  const { data: works, total } = usePersonWorks(personID, pageSize, offset);
+  const [, navigate] = useTransitionNavigate();
+
+  if (!data || !works) {
+    return null;
+  }
+
+  const handlePageChange = (page: number): void => {
+    navigate({ search: `page=${page}` });
+  };
+
+  return (
+    <PersonLayout data={data} title={`${data.person.name} - 作品`}>
+      <div className={styles.sectionHeader}>
+        <h2>「{data.person.name}」的作品</h2>
+      </div>
+      <WorkList works={works} />
+      <Pagination
+        total={total ?? 0}
+        currentPage={curPage}
+        pageSize={pageSize}
+        onChange={handlePageChange}
+      />
+    </PersonLayout>
+  );
+}
+
+export default withErrorBoundary(PersonWorksPage, {
+  404: () => <div>没有找到人物</div>,
+});

--- a/packages/website/src/routes.tsx
+++ b/packages/website/src/routes.tsx
@@ -40,6 +40,8 @@ const SubjectComments = lazy(async () => import('./pages/index/subject/[id]/comm
 const SubjectReviews = lazy(async () => import('./pages/index/subject/[id]/reviews'));
 const SubjectSearch = lazy(async () => import('./pages/index/subject_search/[keyword]'));
 const Person = lazy(async () => import('./pages/index/person/[id]'));
+const PersonVoice = lazy(async () => import('./pages/index/person/[id]/voice'));
+const PersonWorks = lazy(async () => import('./pages/index/person/[id]/works'));
 const Wiki = lazy(async () => import('./pages/index/subject/[id]/wiki'));
 const WikiEdit = lazy(async () => import('./pages/index/subject/[id]/wiki/edit'));
 const WikiEditDetail = lazy(async () => import('./pages/index/subject/[id]/wiki/edit_detail'));
@@ -197,7 +199,11 @@ export const pageRoutes: RouteObject[] = [
       },
       {
         path: 'person/:id',
-        element: <Person />,
+        children: [
+          { path: '', element: <Person /> },
+          { path: 'works', element: <PersonWorks /> },
+          { path: 'works/voice', element: <PersonVoice /> },
+        ],
       },
       {
         path: 'subject_search/:keyword',


### PR DESCRIPTION
## 变更

实现人物页面的「角色」「作品」两个 tab（`/person/:id/works` 与 `/person/:id/works/voice`），基于现有 `getPersonWorks` / `getPersonCasts` 接口。

按你的要求，**避免每个 tab 单独重新实现布局**：

- 新增共享布局 `PersonLayout`（`PersonHeader` + `PageContainer` + 左栏 `PersonInfobox` + 主栏 children），从概览页提取
- 概览页（`PersonDetail`）、角色页、作品页**三个 tab 共用同一布局**：header/tab 高亮、左栏 infobox（推荐目录/谁收藏了）保持一致
- `PersonHeader` / `PersonInfobox` / `CastList` / `WorkList` 从 `PersonDetail` 导出复用
- 新增 `use-person-works` / `use-person-casts` 分页 hooks
- 作品页：封面 + 标题 + 职位标签；角色页：角色头像 + 出演条目 + 角色类型标签，均带分页
- 嵌套路由注册；补充 works fixture 与两个页面测试（各 2 条）

## 验证

- `pnpm build` ✓
- `pnpm test`（345 通过）✓
- `pnpm lint` / `pnpm type-check` / `pnpm prettier:check` ✓
- Playwright 截图：两个 tab 的 header/tab 高亮、左栏 infobox、列表与职位/角色标签渲染正常；375px 移动端 `scrollWidth = 375` 无溢出