### PR TITLE
fix(website): show CI release version in footer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # 拉取全部历史与 tag，让构建能通过 git describe 拿到最近发布版本
+          fetch-depth: 0
+          fetch-tags: true
       - uses: ./.github/actions/setup-js-env
 
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
           echo "version=${today}.$((count + 1))" >> "$GITHUB_OUTPUT"
 
       - run: pnpm build
+        env:
+          # 先构建后打 tag，git describe 拿不到本次版本号，必须显式注入
+          VERSION: ${{ steps.version.outputs.version }}
       - run: zip -r bangumi-website.zip ./packages/website/dist
       - run: openssl dgst -sha256 bangumi-website.zip > bangumi-website.zip.sha256
 

--- a/packages/website/vite.config.ts
+++ b/packages/website/vite.config.ts
@@ -13,11 +13,21 @@ import { version } from '../../package.json';
 import { pandaDevHmr } from './panda-dev-hmr';
 
 let COMMIT_HASH = '';
+let VERSION = '';
 
 try {
-  COMMIT_HASH = execSync('git rev-parse --short HEAD').toString();
+  COMMIT_HASH = execSync('git rev-parse --short HEAD').toString().trim();
 } catch {
   console.log('failed to get git info');
+}
+
+// 版本号优先使用 CI 注入的 VERSION（release 流程先构建后打 tag，git describe 拿不到本次版本），
+// 其次使用最近的 git tag（本地 / preview 构建），最后 fallback 到 package.json version。
+try {
+  VERSION =
+    process.env.VERSION?.trim() || execSync('git describe --tags --abbrev=0').toString().trim();
+} catch {
+  console.log('failed to get version from git, fallback to package.json version');
 }
 
 dayjs.extend(utc);
@@ -144,7 +154,7 @@ export default defineConfig(({ mode }) => {
     },
     define: {
       'import.meta.env.VITE_TURNSTILE_SITE_KEY': JSON.stringify(turnstileSiteKey),
-      'import.meta.env.__APP_VERSION__': JSON.stringify(version),
+      'import.meta.env.__APP_VERSION__': JSON.stringify(VERSION || version),
       'import.meta.env.__COMMIT_HASH__': JSON.stringify(COMMIT_HASH),
       'import.meta.env.__BUILT_TIME__': JSON.stringify(BUILD_TIME),
     },


### PR DESCRIPTION
## Problem

The footer displays the stale `package.json` version (`0.0.0-alpha.9`), which never gets updated. The actual releases are published by CI with `YYYY.MM.DD.N` tags (e.g. `2026.08.12.1`), so the shown version is wrong on every release build.

## Changes

Resolve the footer version in order of:

1. `VERSION` env var injected by the release workflow — the release workflow builds *before* creating the tag, so git cannot see the current version yet
2. nearest git tag via `git describe --tags --abbrev=0` — used by local and preview builds
3. `package.json` version as a fallback for environments without git

Workflow updates:

- `release.yml`: pass `VERSION: ${{ steps.version.outputs.version }}` to the build step
- `build.yml`: checkout with `fetch-depth: 0` + `fetch-tags: true` so builds can resolve the latest release tag

Also trims the `COMMIT_HASH` output (previously included a trailing newline from `execSync`).

## Verification

Built locally and confirmed the injected values in the dist output:

| Scenario | Rendered version |
|---|---|
| normal build (git describe) | `2026.08.12.1` |
| `VERSION=2026.08.13.1` (release) | `2026.08.13.1` |
| no git env (`GIT_DIR=/nonexistent`) | falls back to `0.0.0-alpha.9` |

Passed `pnpm website build` (incl. `tsc --noEmit`), eslint, and prettier checks.