### PR TITLE
feat(website): add group channel pages (小组频道/所有小组/随便看看等)

### DIFF
--- a/packages/design/components/Layout/style/index.less
+++ b/packages/design/components/Layout/style/index.less
@@ -20,5 +20,11 @@
         display: none;
       }
     }
+
+    // 窄屏隐藏右侧栏后，固定 246px 的侧栏列与 gap 仍占空间导致 grid 溢出，
+    // 收窄为单列让主栏占满容器
+    @media (max-width: @lg) {
+      grid-template-columns: minmax(0, 1fr);
+    }
   }
 }

--- a/packages/styled-system/styles.css
+++ b/packages/styled-system/styles.css
@@ -1016,6 +1016,14 @@
     border-radius: 4px;
 }
 
+  .gap_20px_30px {
+    gap: 20px 30px;
+}
+
+  .bdr_10px {
+    border-radius: 10px;
+}
+
   .grid-c_1 {
     grid-column: 1;
 }
@@ -1134,10 +1142,6 @@
 
   .gap_4px_14px {
     gap: 4px 14px;
-}
-
-  .bdr_10px {
-    border-radius: 10px;
 }
 
   .bd-c_\#369cf8 {
@@ -1421,6 +1425,18 @@
     inset-inline-end: true;
 }
 
+  .grid-tc_repeat\(3\,_1fr\) {
+    grid-template-columns: repeat(3, 1fr);
+}
+
+  .tbl_fixed {
+    table-layout: fixed;
+}
+
+  .ta_right {
+    text-align: right;
+}
+
   .ai_flex-start {
     align-items: flex-start;
 }
@@ -1457,16 +1473,8 @@
     overflow-wrap: break-word;
 }
 
-  .ta_right {
-    text-align: right;
-}
-
   .lh_1\.35 {
     line-height: 1.35;
-}
-
-  .tbl_fixed {
-    table-layout: fixed;
 }
 
   .grid-tc_repeat\(3\,_290px\) {
@@ -1861,16 +1869,20 @@
     margin-bottom: 8px;
 }
 
+  .mt_0 {
+    margin-top: var(--spacing-0);
+}
+
+  .mb_20px {
+    margin-bottom: 20px;
+}
+
   .h_22px {
     height: 22px;
 }
 
   .mt_24px {
     margin-top: 24px;
-}
-
-  .mb_20px {
-    margin-bottom: 20px;
 }
 
   .min-h_40px {
@@ -1941,8 +1953,28 @@
     margin-left: 10px;
 }
 
+  .w_60px {
+    width: 60px;
+}
+
+  .mt_2px {
+    margin-top: 2px;
+}
+
   .mb_40px {
     margin-bottom: 40px;
+}
+
+  .w_130px {
+    width: 130px;
+}
+
+  .w_110px {
+    width: 110px;
+}
+
+  .w_100px {
+    width: 100px;
 }
 
   .w_75\% {
@@ -1951,10 +1983,6 @@
 
   .mt_40px {
     margin-top: 40px;
-}
-
-  .w_60px {
-    width: 60px;
 }
 
   .w_290px {
@@ -2007,10 +2035,6 @@
 
   .w_120px {
     width: 120px;
-}
-
-  .w_100px {
-    width: 100px;
 }
 
   .mt_20px {
@@ -2233,6 +2257,10 @@
     border-color: #f09199 !important;
 }
 
+  .\[\&_tr\]\:bd-b_1px_dotted_\#e8e3e3 tr {
+    border-bottom: 1px dotted #e8e3e3;
+}
+
   .\[\&_\.bgm-input__wrapper\]\:flex_1 .bgm-input__wrapper {
     flex: 1 1 0%;
 }
@@ -2247,10 +2275,6 @@
 
   .\[\&\:last-child\]\:bd-b_none:last-child {
     border-bottom: var(--borders-none);
-}
-
-  .\[\&_tr\]\:bd-b_1px_dotted_\#e8e3e3 tr {
-    border-bottom: 1px dotted #e8e3e3;
 }
 
   .\[\&\:first-child\]\:bd-t_none:first-child {
@@ -2417,18 +2441,6 @@
     color: #9f9b9b;
 }
 
-  .\[\&_\.bgm-input\]\:fs_1\.125rem .bgm-input {
-    font-size: 1.125rem;
-}
-
-  .\[\&_img\]\:d_block img {
-    display: block;
-}
-
-  .\[\&_\.bgm-link\]\:c_\#0084b4 .bgm-link {
-    color: #0084b4;
-}
-
   .\[\&_thead\]\:fs_18px thead {
     font-size: 18px;
 }
@@ -2439,6 +2451,18 @@
 
   .\[\&_thead\]\:ta_left thead {
     text-align: left;
+}
+
+  .\[\&_\.bgm-input\]\:fs_1\.125rem .bgm-input {
+    font-size: 1.125rem;
+}
+
+  .\[\&_img\]\:d_block img {
+    display: block;
+}
+
+  .\[\&_\.bgm-link\]\:c_\#0084b4 .bgm-link {
+    color: #0084b4;
 }
 
   .\[\&_a\]\:c_\#595555 a {
@@ -2645,16 +2669,16 @@
     margin-bottom: var(--spacing-0);
 }
 
+  .\[\&_\>_\*\]\:mb_10px > * {
+    margin-bottom: 10px;
+}
+
   .\[\&_\>_\*\]\:mr_20px > * {
     margin-right: 20px;
 }
 
   .\[\&_\>_a\]\:mb_6px > a {
     margin-bottom: 6px;
-}
-
-  .\[\&_\>_\*\]\:mb_10px > * {
-    margin-bottom: 10px;
 }
 
   .\[\&\[class\]\]\:w_20px[class] {
@@ -2769,12 +2793,12 @@
     text-decoration: none;
 }
 
-  .\[\&_\.bgm-input\]\:\[\&\:\:placeholder\]\:c_\#9f9b9b .bgm-input::placeholder {
-    color: #9f9b9b;
-}
-
   .\[\&_thead\]\:\[\&_th\]\:fw_normal thead th {
     font-weight: var(--font-weights-normal);
+}
+
+  .\[\&_\.bgm-input\]\:\[\&\:\:placeholder\]\:c_\#9f9b9b .bgm-input::placeholder {
+    color: #9f9b9b;
 }
 
   .\[\&_a\]\:hover\:c_\#54b5df a:is(:hover, [data-hover]) {
@@ -2991,6 +3015,9 @@
 }
     .smDown\:bx-sh_0_0_0_2px_rgba\(0\,_0\,_0\,_0\.04\) {
       box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.04);
+}
+    .smDown\:grid-tc_repeat\(2\,_1fr\) {
+      grid-template-columns: repeat(2, 1fr);
 }
     .smDown\:grid-tc_minmax\(0\,_1fr\) {
       grid-template-columns: minmax(0, 1fr);

--- a/packages/website/src/components/Header/index.tsx
+++ b/packages/website/src/components/Header/index.tsx
@@ -73,6 +73,7 @@ const navRight = [
   {
     key: 'group',
     label: '小组',
+    href: '/group',
     subMenu: groupSubMenu,
   },
 ];

--- a/packages/website/src/hooks/use-groups.ts
+++ b/packages/website/src/hooks/use-groups.ts
@@ -1,0 +1,21 @@
+import { ok } from '@oazapfts/runtime';
+import useSWR from 'swr';
+
+import { ozaClient } from '@bangumi/client';
+import type { GroupFilterMode, GroupSort, SlimGroup } from '@bangumi/client/client';
+
+/** 获取小组列表（/group/all 等） */
+export function useGroups(
+  sort: GroupSort,
+  mode: GroupFilterMode | undefined,
+  limit: number,
+  offset: number,
+): { data: SlimGroup[] | undefined; total: number | undefined } {
+  const { data } = useSWR(
+    `groups ${sort} ${mode ?? ''} ${limit} ${offset}`,
+    async () => ok(ozaClient.getGroups(sort, { mode, limit, offset })),
+    { suspense: true },
+  );
+
+  return data ?? { data: undefined, total: undefined };
+}

--- a/packages/website/src/hooks/use-recent-group-topics.ts
+++ b/packages/website/src/hooks/use-recent-group-topics.ts
@@ -1,0 +1,26 @@
+import { ok } from '@oazapfts/runtime';
+import useSWR from 'swr';
+
+import { ozaClient } from '@bangumi/client';
+import type { GroupTopic } from '@bangumi/client/client';
+import { GroupTopicFilterMode } from '@bangumi/client/client';
+
+/**
+ * 获取小组话题流。
+ * 不传 mode 时固定传服务端默认模式 Joined，由服务端按登录态分发：
+ * 登录返回已加入小组的话题，未登录强制返回全部话题。
+ */
+export function useRecentGroupTopics(
+  limit: number,
+  offset: number,
+  mode?: GroupTopicFilterMode,
+): { data: GroupTopic[] | undefined; total: number | undefined } {
+  const { data } = useSWR(
+    `recent-group-topics ${mode ?? ''} ${limit} ${offset}`,
+    async () =>
+      ok(ozaClient.getRecentGroupTopics(mode ?? GroupTopicFilterMode.Joined, { limit, offset })),
+    { suspense: true },
+  );
+
+  return data ?? { data: undefined, total: undefined };
+}

--- a/packages/website/src/mocks/fixtures/p1/groups-GET.json
+++ b/packages/website/src/mocks/fixtures/p1/groups-GET.json
@@ -1,0 +1,50 @@
+{
+  "data": [
+    {
+      "id": 128,
+      "name": "wiki",
+      "nsfw": false,
+      "title": "番組WIKI計画",
+      "icon": {
+        "small": "https://lain.bgm.tv/r/100/pic/icon/l/000/00/01/128.jpg",
+        "medium": "https://lain.bgm.tv/r/200/pic/icon/l/000/00/01/128.jpg",
+        "large": "https://lain.bgm.tv/pic/icon/l/000/00/01/128.jpg"
+      },
+      "creatorID": 271,
+      "members": 8099,
+      "accessible": true,
+      "createdAt": 1233321099
+    },
+    {
+      "id": 129,
+      "name": "sandbox",
+      "nsfw": false,
+      "title": "新番组",
+      "icon": {
+        "small": "https://lain.bgm.tv/r/100/pic/icon/l/000/00/01/129.jpg",
+        "medium": "https://lain.bgm.tv/r/200/pic/icon/l/000/00/01/129.jpg",
+        "large": "https://lain.bgm.tv/pic/icon/l/000/00/01/129.jpg"
+      },
+      "creatorID": 271,
+      "members": 1234,
+      "accessible": true,
+      "createdAt": 1233321100
+    },
+    {
+      "id": 130,
+      "name": "magi",
+      "nsfw": false,
+      "title": "MAGI 小组",
+      "icon": {
+        "small": "https://lain.bgm.tv/r/100/pic/icon/l/000/00/01/130.jpg",
+        "medium": "https://lain.bgm.tv/r/200/pic/icon/l/000/00/01/130.jpg",
+        "large": "https://lain.bgm.tv/pic/icon/l/000/00/01/130.jpg"
+      },
+      "creatorID": 1,
+      "members": 567,
+      "accessible": true,
+      "createdAt": 1233321200
+    }
+  ],
+  "total": 3
+}

--- a/packages/website/src/mocks/fixtures/p1/groups/-/topics-GET.json
+++ b/packages/website/src/mocks/fixtures/p1/groups/-/topics-GET.json
@@ -1,0 +1,83 @@
+{
+  "data": [
+    {
+      "id": 430381,
+      "title": "[投票结果] 关于连载书籍平台子分类的关联问题",
+      "creatorID": 21804,
+      "parentID": 128,
+      "replyCount": 107,
+      "createdAt": 1753694225,
+      "updatedAt": 1786465803,
+      "state": 0,
+      "display": 1,
+      "group": {
+        "id": 128,
+        "name": "wiki",
+        "nsfw": false,
+        "title": "番組WIKI計画",
+        "icon": {
+          "small": "https://lain.bgm.tv/r/100/pic/icon/l/000/00/01/128.jpg",
+          "medium": "https://lain.bgm.tv/r/200/pic/icon/l/000/00/01/128.jpg",
+          "large": "https://lain.bgm.tv/pic/icon/l/000/00/01/128.jpg"
+        },
+        "creatorID": 271,
+        "members": 8099,
+        "accessible": true,
+        "createdAt": 1233321099
+      },
+      "replies": [],
+      "creator": {
+        "avatar": {
+          "large": "https://lain.bgm.tv/pic/user/l/000/00/00/00000.jpg",
+          "medium": "https://lain.bgm.tv/r/200/pic/user/l/000/00/00/00000.jpg",
+          "small": "https://lain.bgm.tv/r/100/pic/user/l/000/00/00/00000.jpg"
+        },
+        "sign": "测试",
+        "username": "test_user",
+        "nickname": "测试用户",
+        "user_group": 0,
+        "id": 21804
+      }
+    },
+    {
+      "id": 430382,
+      "title": "新番组 2026 年春季动画讨论帖",
+      "creatorID": 21805,
+      "parentID": 129,
+      "replyCount": 32,
+      "createdAt": 1753694300,
+      "updatedAt": 1786465900,
+      "state": 0,
+      "display": 1,
+      "group": {
+        "id": 129,
+        "name": "sandbox",
+        "nsfw": false,
+        "title": "新番组",
+        "icon": {
+          "small": "https://lain.bgm.tv/r/100/pic/icon/l/000/00/01/129.jpg",
+          "medium": "https://lain.bgm.tv/r/200/pic/icon/l/000/00/01/129.jpg",
+          "large": "https://lain.bgm.tv/pic/icon/l/000/00/01/129.jpg"
+        },
+        "creatorID": 271,
+        "members": 1234,
+        "accessible": true,
+        "createdAt": 1233321100
+      },
+      "replies": [],
+      "creator": {
+        "avatar": {
+          "large": "https://lain.bgm.tv/pic/user/l/000/00/00/00000.jpg",
+          "medium": "https://lain.bgm.tv/r/200/pic/user/l/000/00/00/00000.jpg",
+          "small": "https://lain.bgm.tv/r/100/pic/user/l/000/00/00/00000.jpg"
+        },
+        "sign": "",
+        "username": "test_user2",
+        "nickname": "测试用户2",
+        "user_group": 0,
+        "id": 21805
+      }
+    }
+  ],
+  "total": 2
+}

--- a/packages/website/src/mocks/handlers.ts
+++ b/packages/website/src/mocks/handlers.ts
@@ -36,6 +36,8 @@ export const handlers = [
   mockAPI('/p1/users/:username', 'get'),
   mockAPI('/p1/users/:username/friends', 'get'),
   mockAPI('/p1/users/:username/groups', 'get'),
+  mockAPI('/p1/groups', 'get'),
+  mockAPI('/p1/groups/-/topics', 'get'),
   mockAPI('/p1/groups/-/topics/:topicID', 'get'),
   mockAPI('/p1/groups/-/posts/:postID/like', 'put'),
   mockAPI('/p1/groups/-/posts/:postID/like', 'delete'),

--- a/packages/website/src/pages/index/group/all.tsx
+++ b/packages/website/src/pages/index/group/all.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+
+import { GroupSort } from '@bangumi/client/client';
+import { Layout, Pagination, Section, Tab } from '@bangumi/design';
+import { css } from '@bangumi/styled-system/css';
+import Helmet from '@bangumi/website/components/Helmet';
+import PageContainer from '@bangumi/website/components/PageContainer';
+import { useGroups } from '@bangumi/website/hooks/use-groups';
+import { useTransitionNavigate } from '@bangumi/website/hooks/use-navigate';
+import { usePaginationParams } from '@bangumi/website/hooks/use-pagination';
+
+import GroupChannelSidebar from './components/GroupChannelSidebar';
+import GroupList from './components/GroupList';
+
+const PAGE_SIZE = 24;
+
+const sortItems = [
+  { key: GroupSort.Members, label: '成员数' },
+  { key: GroupSort.Topics, label: '主题数' },
+  { key: GroupSort.Posts, label: '帖子数' },
+  { key: GroupSort.Created, label: '创建时间' },
+  { key: GroupSort.Updated, label: '最近活跃' },
+];
+
+const pageContainer = css({
+  '& > *': {
+    marginBottom: '10px',
+  },
+});
+
+const mainSection = css({
+  marginTop: '0',
+});
+
+const sortTabs = css({
+  marginBottom: '20px',
+});
+
+const GroupAll: React.FC = () => {
+  const [searchParams] = useSearchParams();
+  const { curPage, pageSize, offset } = usePaginationParams(PAGE_SIZE);
+  const [, navigate] = useTransitionNavigate();
+  const sortParam = searchParams.get('sort');
+  const sort = (Object.values(GroupSort) as string[]).includes(sortParam ?? '')
+    ? (sortParam as GroupSort)
+    : GroupSort.Members;
+  const { data: groups, total } = useGroups(sort, undefined, pageSize, offset);
+
+  const handlePageChange = (page: number): void => {
+    navigate({ search: `sort=${sort}&page=${page}` });
+  };
+
+  return (
+    <>
+      <Helmet title='所有小组' />
+      <PageContainer className={pageContainer}>
+        <Layout
+          type='alpha'
+          leftChildren={
+            <Section title='所有小组' wrapperClass={mainSection}>
+              <div className={sortTabs}>
+                <Tab.Group type='borderless'>
+                  {sortItems.map((item) => (
+                    <Link to={{ search: `sort=${item.key}` }} key={item.key}>
+                      <Tab.Item isActive={sort === item.key}>{item.label}</Tab.Item>
+                    </Link>
+                  ))}
+                </Tab.Group>
+              </div>
+              <GroupList groups={groups ?? []} />
+              <Pagination
+                total={total ?? 0}
+                currentPage={curPage}
+                pageSize={pageSize}
+                onChange={handlePageChange}
+              />
+            </Section>
+          }
+          rightChildren={<GroupChannelSidebar />}
+        />
+      </PageContainer>
+    </>
+  );
+};
+
+export default GroupAll;

--- a/packages/website/src/pages/index/group/components/GroupChannelSidebar.tsx
+++ b/packages/website/src/pages/index/group/components/GroupChannelSidebar.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import { Section, Typography } from '@bangumi/design';
+import { css } from '@bangumi/styled-system/css';
+
+const { Link } = Typography;
+
+const wrapper = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '12px',
+});
+
+const navLinks = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '12px',
+  fontSize: '14px',
+  fontWeight: '600',
+  color: '#9f9b9b',
+});
+
+/** 小组频道侧栏：导航 */
+const GroupChannelSidebar: React.FC = () => {
+  return (
+    <Section title='小组频道'>
+      <div className={wrapper}>
+        <div className={navLinks}>
+          <Link to='/group'>小组频道</Link>
+          <Link to='/group/all'>所有小组</Link>
+          <Link to='/group/discover'>随便看看</Link>
+          <Link to='/group/my_topic'>我发表的话题</Link>
+          <Link to='/group/my_reply'>我回复的话题</Link>
+          <Link to='/group/mine'>我参加的小组</Link>
+        </div>
+      </div>
+    </Section>
+  );
+};
+
+export default GroupChannelSidebar;

--- a/packages/website/src/pages/index/group/components/GroupList.tsx
+++ b/packages/website/src/pages/index/group/components/GroupList.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+
+import type { SlimGroup } from '@bangumi/client/client';
+import { Image, Typography } from '@bangumi/design';
+import { css } from '@bangumi/styled-system/css';
+
+const { Link } = Typography;
+
+const groupList = css({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(3, 1fr)',
+  gap: '20px 30px',
+  smDown: {
+    gridTemplateColumns: 'repeat(2, 1fr)',
+  },
+});
+
+const groupCard = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '10px',
+  minWidth: '0',
+  fontSize: '14px',
+});
+
+const groupIcon = css({
+  flexShrink: '0',
+  width: '60px',
+  height: '60px',
+  display: 'block',
+  borderRadius: '10px',
+});
+
+const groupTitle = css({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+});
+
+const groupMembers = css({
+  display: 'block',
+  marginTop: '2px',
+  color: '#9f9b9b',
+  fontSize: '12px',
+});
+
+/** 小组卡片网格（头像 + 标题 + 成员数） */
+const GroupList: React.FC<{ groups: SlimGroup[] }> = ({ groups }) => {
+  return (
+    <ul className={groupList}>
+      {groups.map((group) => (
+        <li key={group.id}>
+          <Link className={groupCard} to={`/group/${group.name}`} fontWeight='bold'>
+            <Image className={groupIcon} src={group.icon.large} alt={`${group.title} 小组图标`} />
+            <span>
+              <span className={groupTitle}>{group.title}</span>
+              <small className={groupMembers}>{group.members} 位成员</small>
+            </span>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default GroupList;

--- a/packages/website/src/pages/index/group/components/GroupNavigation.tsx
+++ b/packages/website/src/pages/index/group/components/GroupNavigation.tsx
@@ -44,7 +44,8 @@ const GroupNavigation = ({ group }: { group: Group }) => {
             <br />
           </div>
           <div>
-            小组：<Link to='#'>我管理的</Link> | <Link to='/group/mine'>我参加的</Link>
+            小组：<Link to='/group/mine?mode=managed'>我管理的</Link> |{' '}
+            <Link to='/group/mine'>我参加的</Link>
           </div>
         </div>
       </div>

--- a/packages/website/src/pages/index/group/components/GroupTopicListPage.tsx
+++ b/packages/website/src/pages/index/group/components/GroupTopicListPage.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+import type { GroupTopicFilterMode } from '@bangumi/client/client';
+import { Layout, Pagination, Section } from '@bangumi/design';
+import { css } from '@bangumi/styled-system/css';
+import Helmet from '@bangumi/website/components/Helmet';
+import PageContainer from '@bangumi/website/components/PageContainer';
+import { useTransitionNavigate } from '@bangumi/website/hooks/use-navigate';
+import { usePaginationParams } from '@bangumi/website/hooks/use-pagination';
+import { useRecentGroupTopics } from '@bangumi/website/hooks/use-recent-group-topics';
+
+import GroupChannelSidebar from './GroupChannelSidebar';
+import GroupTopicTable from './GroupTopicTable';
+
+const PAGE_SIZE = 20;
+
+const pageContainer = css({
+  '& > *': {
+    marginBottom: '10px',
+  },
+});
+
+const mainSection = css({
+  marginTop: '0',
+});
+
+/** 跨小组话题列表页（随便看看/我发表/我回复共用） */
+const GroupTopicListPage: React.FC<{ mode: GroupTopicFilterMode; title: string }> = ({
+  mode,
+  title,
+}) => {
+  const { curPage, pageSize, offset } = usePaginationParams(PAGE_SIZE);
+  const [, navigate] = useTransitionNavigate();
+  const { data: topics, total } = useRecentGroupTopics(pageSize, offset, mode);
+
+  const handlePageChange = (page: number): void => {
+    navigate({ search: `page=${page}` });
+  };
+
+  return (
+    <>
+      <Helmet title={title} />
+      <PageContainer className={pageContainer}>
+        <Layout
+          type='alpha'
+          leftChildren={
+            <Section title={title} wrapperClass={mainSection}>
+              <GroupTopicTable topics={topics ?? []} />
+              <Pagination
+                total={total ?? 0}
+                currentPage={curPage}
+                pageSize={pageSize}
+                onChange={handlePageChange}
+              />
+            </Section>
+          }
+          rightChildren={<GroupChannelSidebar />}
+        />
+      </PageContainer>
+    </>
+  );
+};
+
+export default GroupTopicListPage;

--- a/packages/website/src/pages/index/group/components/GroupTopicTable.tsx
+++ b/packages/website/src/pages/index/group/components/GroupTopicTable.tsx
@@ -1,0 +1,105 @@
+import dayjs from 'dayjs';
+import React from 'react';
+
+import type { GroupTopic } from '@bangumi/client/client';
+import { Typography } from '@bangumi/design';
+import { css } from '@bangumi/styled-system/css';
+import { getUserProfileLink } from '@bangumi/utils/pages';
+
+const topicTable = css({
+  width: '100%',
+  color: '#9f9b9b',
+  tableLayout: 'fixed',
+  '& th, & td': {
+    padding: '11px 4px',
+  },
+  '& tr': {
+    borderBottom: '1px dotted #e8e3e3',
+  },
+  '& thead': {
+    fontSize: '18px',
+    lineHeight: '18px',
+    textAlign: 'left',
+    '& th': {
+      fontWeight: 'normal',
+    },
+  },
+});
+
+const title = css({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+});
+
+const group = css({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  width: '130px',
+});
+
+const author = css({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  width: '110px',
+  smDown: { display: 'none' },
+});
+
+const replies = css({
+  width: '60px',
+});
+
+const updateTime = css({
+  width: '100px',
+  textAlign: 'right',
+  smDown: { display: 'none' },
+});
+
+/** 跨小组的话题表（频道首页/随便看看/我的话题），比组内 TopicsTable 多一列小组 */
+const GroupTopicTable: React.FC<{ topics: GroupTopic[] }> = ({ topics }) => {
+  return (
+    <table className={topicTable}>
+      <thead>
+        <tr>
+          <th className={title}>标题</th>
+          <th className={group}>小组</th>
+          <th className={author}>作者</th>
+          <th className={replies}>回复数</th>
+          <th className={updateTime}>最后回复于</th>
+        </tr>
+      </thead>
+      <tbody>
+        {topics.map((topic) => {
+          return (
+            <tr key={topic.id}>
+              <td className={title} title={topic.title}>
+                <Typography.Link to={`/group/topic/${topic.id}`} fontWeight='bold'>
+                  {topic.title}
+                </Typography.Link>
+              </td>
+              <td className={group} title={topic.group.title}>
+                <Typography.Link to={`/group/${topic.group.name}`} fontWeight='bold'>
+                  {topic.group.title}
+                </Typography.Link>
+              </td>
+              <td className={author} title={topic.creator?.nickname}>
+                <Typography.Link
+                  to={getUserProfileLink(topic.creator?.username ?? '')}
+                  fontWeight='bold'
+                >
+                  {topic.creator?.nickname}
+                </Typography.Link>
+              </td>
+              <td className={replies}>{topic.replyCount}</td>
+              <td className={updateTime}>{dayjs(topic.updatedAt * 1000).format('YYYY-M-D')}</td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+};
+
+export default GroupTopicTable;

--- a/packages/website/src/pages/index/group/discover.tsx
+++ b/packages/website/src/pages/index/group/discover.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import { GroupTopicFilterMode } from '@bangumi/client/client';
+
+import GroupTopicListPage from './components/GroupTopicListPage';
+
+const GroupDiscover: React.FC = () => (
+  <GroupTopicListPage mode={GroupTopicFilterMode.All} title='随便看看' />
+);
+
+export default GroupDiscover;

--- a/packages/website/src/pages/index/group/index.spec.tsx
+++ b/packages/website/src/pages/index/group/index.spec.tsx
@@ -1,0 +1,85 @@
+import { act, screen } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import React, { Suspense } from 'react';
+
+import topicsFixture from '@bangumi/website/mocks/fixtures/p1/groups/-/topics-GET.json';
+import groupsFixture from '@bangumi/website/mocks/fixtures/p1/groups-GET.json';
+import { server as mockServer } from '@bangumi/website/mocks/server';
+import { renderPage } from '@bangumi/website/utils/test-utils';
+
+import GroupChannel from '.';
+
+beforeEach(() => {
+  mockServer.use(
+    http.get('http://localhost:3000/p1/groups', () => HttpResponse.json(groupsFixture)),
+    http.get('http://localhost:3000/p1/groups/-/topics', () => HttpResponse.json(topicsFixture)),
+  );
+});
+
+describe('GroupChannel', () => {
+  it('话题请求不携带登录相关的 mode 区分，由服务端分发', async () => {
+    let topicsRequestMode: string | null = null;
+    mockServer.use(
+      http.get('http://localhost:3000/p1/groups/-/topics', ({ request }) => {
+        topicsRequestMode = new URL(request.url).searchParams.get('mode');
+        return HttpResponse.json(topicsFixture);
+      }),
+    );
+
+    await act(async () => {
+      renderPage(
+        <Suspense fallback={null}>
+          <GroupChannel />
+        </Suspense>,
+      );
+    });
+
+    // 固定传服务端默认模式 Joined，不做登录态判断
+    expect(topicsRequestMode).toBe('joined');
+  });
+
+  it('渲染热门小组与最新话题', async () => {
+    await act(async () => {
+      renderPage(
+        <Suspense fallback={null}>
+          <GroupChannel />
+        </Suspense>,
+      );
+    });
+
+    // 热门小组
+    expect(await screen.findByText('热门小组')).toBeInTheDocument();
+    expect(screen.getAllByText('番組WIKI計画').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('8099 位成员').length).toBeGreaterThan(0);
+
+    // 小组最新话题
+    expect(screen.getByText('小组最新话题')).toBeInTheDocument();
+    expect(screen.getByText('[投票结果] 关于连载书籍平台子分类的关联问题')).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', {
+        name: '[投票结果] 关于连载书籍平台子分类的关联问题',
+      }),
+    ).toHaveAttribute('href', '/group/topic/430381');
+  });
+
+  it('侧栏包含小组频道导航', async () => {
+    await act(async () => {
+      renderPage(
+        <Suspense fallback={null}>
+          <GroupChannel />
+        </Suspense>,
+      );
+    });
+
+    expect((await screen.findAllByText('小组频道')).length).toBeGreaterThan(0);
+    expect(screen.getByRole('link', { name: '所有小组' })).toHaveAttribute('href', '/group/all');
+    expect(screen.getByRole('link', { name: '随便看看' })).toHaveAttribute(
+      'href',
+      '/group/discover',
+    );
+    expect(screen.getByRole('link', { name: '我参加的小组' })).toHaveAttribute(
+      'href',
+      '/group/mine',
+    );
+  });
+});

--- a/packages/website/src/pages/index/group/index.tsx
+++ b/packages/website/src/pages/index/group/index.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+import { GroupSort } from '@bangumi/client/client';
+import { Button, Layout, Section } from '@bangumi/design';
+import { ArrowRightCircle } from '@bangumi/icons';
+import { css } from '@bangumi/styled-system/css';
+import Helmet from '@bangumi/website/components/Helmet';
+import PageContainer from '@bangumi/website/components/PageContainer';
+import { useGroups } from '@bangumi/website/hooks/use-groups';
+import { useRecentGroupTopics } from '@bangumi/website/hooks/use-recent-group-topics';
+
+import GroupChannelSidebar from './components/GroupChannelSidebar';
+import GroupList from './components/GroupList';
+import GroupTopicTable from './components/GroupTopicTable';
+
+const pageContainer = css({
+  '& > *': {
+    marginBottom: '10px',
+  },
+});
+
+const mainSection = css({
+  marginTop: '0',
+});
+
+const GroupChannel: React.FC = () => {
+  // 话题流由服务端按登录态分发（登录=已加入小组，未登录=全部）
+  const { data: topics } = useRecentGroupTopics(20, 0);
+  const { data: hotGroups } = useGroups(GroupSort.Members, undefined, 6, 0);
+
+  return (
+    <>
+      <Helmet title='小组' />
+      <PageContainer className={pageContainer}>
+        <Layout
+          type='alpha'
+          leftChildren={
+            <>
+              <Section title='热门小组' wrapperClass={mainSection}>
+                <GroupList groups={hotGroups ?? []} />
+              </Section>
+              <Section
+                title='小组最新话题'
+                wrapperClass={mainSection}
+                renderFooter={() => (
+                  <Button.Link type='plain' to='/group/discover'>
+                    更多话题
+                    <ArrowRightCircle />
+                  </Button.Link>
+                )}
+              >
+                <GroupTopicTable topics={topics ?? []} />
+              </Section>
+            </>
+          }
+          rightChildren={<GroupChannelSidebar />}
+        />
+      </PageContainer>
+    </>
+  );
+};
+
+export default GroupChannel;

--- a/packages/website/src/pages/index/group/list-pages.spec.tsx
+++ b/packages/website/src/pages/index/group/list-pages.spec.tsx
@@ -1,0 +1,89 @@
+import { act, screen } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import React, { Suspense } from 'react';
+
+import topicsFixture from '@bangumi/website/mocks/fixtures/p1/groups/-/topics-GET.json';
+import groupsFixture from '@bangumi/website/mocks/fixtures/p1/groups-GET.json';
+import { server as mockServer } from '@bangumi/website/mocks/server';
+import { renderPage } from '@bangumi/website/utils/test-utils';
+
+import GroupAll from './all';
+import GroupDiscover from './discover';
+import GroupMine from './mine';
+import GroupMyReply from './my-reply';
+import GroupMyTopic from './my-topic';
+
+function mockGroupAPI() {
+  mockServer.use(
+    http.get('http://localhost:3000/p1/groups', () => HttpResponse.json(groupsFixture)),
+    http.get('http://localhost:3000/p1/groups/-/topics', () => HttpResponse.json(topicsFixture)),
+  );
+}
+
+beforeEach(() => {
+  mockGroupAPI();
+});
+
+describe('GroupAll', () => {
+  it('渲染小组列表与排序 tab', async () => {
+    await act(async () => {
+      renderPage(
+        <Suspense fallback={null}>
+          <GroupAll />
+        </Suspense>,
+      );
+    });
+
+    expect((await screen.findAllByText('所有小组')).length).toBeGreaterThan(0);
+    expect(screen.getAllByText('番組WIKI計画').length).toBeGreaterThan(0);
+    expect(screen.getByText('MAGI 小组')).toBeInTheDocument();
+    expect(screen.getByText('8099 位成员')).toBeInTheDocument();
+    // 排序 tab
+    expect(screen.getByText('成员数')).toBeInTheDocument();
+    expect(screen.getByText('最近活跃')).toBeInTheDocument();
+    // 小组链接
+    expect(screen.getByRole('link', { name: /番組WIKI計画/ })).toHaveAttribute(
+      'href',
+      '/group/wiki',
+    );
+  });
+});
+
+describe('GroupMine', () => {
+  it('渲染我参加的小组列表', async () => {
+    await act(async () => {
+      renderPage(
+        <Suspense fallback={null}>
+          <GroupMine />
+        </Suspense>,
+      );
+    });
+
+    expect(await screen.findAllByText('我参加的小组')).not.toHaveLength(0);
+    expect(screen.getByText('番組WIKI計画')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /番組WIKI計画/ })).toHaveAttribute(
+      'href',
+      '/group/wiki',
+    );
+  });
+});
+
+describe('GroupTopicListPages', () => {
+  it.each([
+    [GroupMyTopic, '我发表的话题'],
+    [GroupMyReply, '我回复的话题'],
+    [GroupDiscover, '随便看看'],
+  ])('渲染 %s 标题与话题', async (Page, title) => {
+    await act(async () => {
+      renderPage(
+        <Suspense fallback={null}>
+          <Page />
+        </Suspense>,
+      );
+    });
+
+    expect(await screen.findAllByText(title)).not.toHaveLength(0);
+    expect(screen.getByText('[投票结果] 关于连载书籍平台子分类的关联问题')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '新番组' })).toHaveAttribute('href', '/group/sandbox');
+  });
+});

--- a/packages/website/src/pages/index/group/mine.tsx
+++ b/packages/website/src/pages/index/group/mine.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+import { GroupFilterMode, GroupSort } from '@bangumi/client/client';
+import { Layout, Pagination, Section } from '@bangumi/design';
+import { css } from '@bangumi/styled-system/css';
+import Helmet from '@bangumi/website/components/Helmet';
+import PageContainer from '@bangumi/website/components/PageContainer';
+import { useGroups } from '@bangumi/website/hooks/use-groups';
+import { useTransitionNavigate } from '@bangumi/website/hooks/use-navigate';
+import { usePaginationParams } from '@bangumi/website/hooks/use-pagination';
+
+import GroupChannelSidebar from './components/GroupChannelSidebar';
+import GroupList from './components/GroupList';
+
+const PAGE_SIZE = 24;
+
+const pageContainer = css({
+  '& > *': {
+    marginBottom: '10px',
+  },
+});
+
+const mainSection = css({
+  marginTop: '0',
+});
+
+const GroupMine: React.FC = () => {
+  const [searchParams] = useSearchParams();
+  const { curPage, pageSize, offset } = usePaginationParams(PAGE_SIZE);
+  const [, navigate] = useTransitionNavigate();
+  const mode =
+    searchParams.get('mode') === GroupFilterMode.Managed
+      ? GroupFilterMode.Managed
+      : GroupFilterMode.Joined;
+  const title = mode === GroupFilterMode.Managed ? '我管理的小组' : '我参加的小组';
+  const { data: groups, total } = useGroups(GroupSort.Created, mode, pageSize, offset);
+
+  const handlePageChange = (page: number): void => {
+    navigate({ search: `mode=${mode}&page=${page}` });
+  };
+
+  return (
+    <>
+      <Helmet title={title} />
+      <PageContainer className={pageContainer}>
+        <Layout
+          type='alpha'
+          leftChildren={
+            <Section title={title} wrapperClass={mainSection}>
+              <GroupList groups={groups ?? []} />
+              <Pagination
+                total={total ?? 0}
+                currentPage={curPage}
+                pageSize={pageSize}
+                onChange={handlePageChange}
+              />
+            </Section>
+          }
+          rightChildren={<GroupChannelSidebar />}
+        />
+      </PageContainer>
+    </>
+  );
+};
+
+export default GroupMine;

--- a/packages/website/src/pages/index/group/my-reply.tsx
+++ b/packages/website/src/pages/index/group/my-reply.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import { GroupTopicFilterMode } from '@bangumi/client/client';
+
+import GroupTopicListPage from './components/GroupTopicListPage';
+
+const GroupMyReply: React.FC = () => (
+  <GroupTopicListPage mode={GroupTopicFilterMode.Replied} title='我回复的话题' />
+);
+
+export default GroupMyReply;

--- a/packages/website/src/pages/index/group/my-topic.tsx
+++ b/packages/website/src/pages/index/group/my-topic.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import { GroupTopicFilterMode } from '@bangumi/client/client';
+
+import GroupTopicListPage from './components/GroupTopicListPage';
+
+const GroupMyTopic: React.FC = () => (
+  <GroupTopicListPage mode={GroupTopicFilterMode.Created} title='我发表的话题' />
+);
+
+export default GroupMyTopic;

--- a/packages/website/src/routes.tsx
+++ b/packages/website/src/routes.tsx
@@ -19,9 +19,15 @@ const Episode = lazy(async () => import('./pages/index/ep/[id]'));
 const EpisodeEdit = lazy(async () => import('./pages/index/ep/[id]/edit'));
 const Notifications = lazy(async () => import('./pages/index/notifications'));
 const Group = lazy(async () => import('./pages/index/group/[name]/index'));
+const GroupChannel = lazy(async () => import('./pages/index/group/index'));
+const GroupAll = lazy(async () => import('./pages/index/group/all'));
+const GroupDiscover = lazy(async () => import('./pages/index/group/discover'));
 const GroupForum = lazy(async () => import('./pages/index/group/[name]/index/forum'));
 const GroupHome = lazy(async () => import('./pages/index/group/[name]/index/index'));
 const GroupMembers = lazy(async () => import('./pages/index/group/[name]/index/members'));
+const GroupMine = lazy(async () => import('./pages/index/group/mine'));
+const GroupMyTopic = lazy(async () => import('./pages/index/group/my-topic'));
+const GroupMyReply = lazy(async () => import('./pages/index/group/my-reply'));
 const GroupNewTopic = lazy(async () => import('./pages/index/group/[name]/new_topic'));
 const GroupReply = lazy(async () => import('./pages/index/group/reply/[id]'));
 const GroupReplyEdit = lazy(async () => import('./pages/index/group/reply/[id]/edit'));
@@ -63,11 +69,6 @@ const legacyPagePaths = [
   ]),
   'blog/:id',
   'calendar',
-  'group/all',
-  'group/discover',
-  'group/mine',
-  'group/my_reply',
-  'group/my_topic',
   'index',
   'index/:id',
   'index/:id/comments',
@@ -120,6 +121,12 @@ export const pageRoutes: RouteObject[] = [
       {
         path: 'group',
         children: [
+          { path: '', element: <GroupChannel /> },
+          { path: 'all', element: <GroupAll /> },
+          { path: 'discover', element: <GroupDiscover /> },
+          { path: 'mine', element: <GroupMine /> },
+          { path: 'my_topic', element: <GroupMyTopic /> },
+          { path: 'my_reply', element: <GroupMyReply /> },
           {
             path: ':name',
             children: [


### PR DESCRIPTION
## 变更

补全小组相关缺失页面（之前全部经 LegacyRedirect 跳到旧站）：

- **`/group` 小组频道首页**：热门小组 + 小组最新话题。话题流调用 `getRecentGroupTopics` 的**服务端默认模式**（Joined），由 API 按登录态自动分发（登录=已加入小组话题、未登录=全部话题），**客户端不做登录分支**
- **`/group/all`**：所有小组列表，排序切换（成员数/主题数/帖子数/创建时间/最近活跃）+ 分页
- **`/group/discover`**：全部小组的最新话题
- **`/group/mine`**：我参加的小组（`?mode=managed` 切换为管理的小组）
- **`/group/my_topic` / `group/my_reply`**：我发表/回复的话题
- 公共组件：`GroupList`（小组卡片）、`GroupTopicTable`（跨组话题表）、`GroupChannelSidebar`（频道导航）、`GroupTopicListPage`；hooks `use-groups` / `use-recent-group-topics`
- header「小组」项加 `href='/group'`；`GroupNavigation`「我管理的」指向 `/group/mine?mode=managed`；移除 `legacyPagePaths` 中 6 个 group 路径

**附带修复**：
- `Layout alpha` 移动端溢出：隐藏右侧栏后固定 246px 侧栏列仍占 grid 空间，窄屏 grid 总宽超出视口；改为窄屏单列（小组详情页同样受益）
- `GroupTopicTable` 移动端隐藏「作者」「最后回复」列

## 验证

- `pnpm test`（353 通过，新增 9 个小组页面测试）、`build`、`lint`、`type-check`、`prettier` 全过
- Playwright：6 个新页面桌面渲染正常（话题表/小组卡片/排序 tab/侧栏导航），375px 移动端全部 `scrollWidth=375` 无溢出