### PR TITLE
fix(design): prevent mobile horizontal overflow of long text and code blocks

### DIFF
--- a/packages/design/components/Popover/index.tsx
+++ b/packages/design/components/Popover/index.tsx
@@ -3,15 +3,29 @@ import './style/index.less';
 import classNames from 'classnames';
 import React from 'react';
 
+import { css } from '@bangumi/styled-system/css';
+
 export interface PopoverProps {
   content: React.ReactNode;
   children: React.ReactNode;
   className?: string;
 }
 
+// 未 hover 时隐藏弹出内容，避免 absolute 菜单在移动端撑出水平滚动
+const popover = css({
+  '& .bgm-popover__content': {
+    display: 'none',
+  },
+  _hover: {
+    '& .bgm-popover__content': {
+      display: 'block',
+    },
+  },
+});
+
 const Popover = ({ children, content, className }: PopoverProps) => {
   return (
-    <div className={classNames('bgm-popover', className)}>
+    <div className={classNames('bgm-popover', popover, className)}>
       {children}
       {/* 添加一个wrapper使绝对定位元素能够水平居中 */}
       <div className='bgm-popover__container'>

--- a/packages/design/components/RichContent/index.tsx
+++ b/packages/design/components/RichContent/index.tsx
@@ -3,6 +3,7 @@ import './style';
 import classNames from 'classnames';
 import React from 'react';
 
+import { css } from '@bangumi/styled-system/css';
 import { render } from '@bangumi/utils/bbcode/react';
 
 export interface RichContentProps {
@@ -10,8 +11,16 @@ export interface RichContentProps {
   classname?: string;
 }
 
+// 长文本/长 URL 换行、[code] 块横向截断，避免移动端水平溢出
+const content = css({
+  overflowWrap: 'anywhere',
+  '& pre': {
+    overflowX: 'hidden',
+  },
+});
+
 const RichContent: React.FC<RichContentProps> = ({ bbcode, classname }) => {
-  return <div className={classNames('bgm-rich-content', classname)}>{render(bbcode)}</div>;
+  return <div className={classNames('bgm-rich-content', content, classname)}>{render(bbcode)}</div>;
 };
 
 export default RichContent;

--- a/packages/design/components/Topic/Comment.tsx
+++ b/packages/design/components/Topic/Comment.tsx
@@ -32,10 +32,15 @@ const commentTip = css({
   },
 });
 
-// overflow-wrap 需要在块级容器上生效，这里覆盖评论主体
+// overflow-wrap 需要在块级容器上生效，这里覆盖评论主体；
+// main 是 flex column + align-items flex-start，子项宽度按内容撑开，
+// 需要限制 max-width 才会在窄屏换行
 const commentBody = css({
   overflowWrap: 'anywhere',
   minWidth: '0',
+  '& > *': {
+    maxWidth: '100%',
+  },
 });
 
 export type CommentProps = ((ReplyBase & { isReply: true }) | (Reply & { isReply: false })) & {

--- a/packages/design/components/Topic/Comment.tsx
+++ b/packages/design/components/Topic/Comment.tsx
@@ -7,6 +7,7 @@ import { ozaClient } from '@bangumi/client';
 import type { Reply, ReplyBase, SlimUser } from '@bangumi/client/topic';
 import { State } from '@bangumi/client/topic';
 import { OriginalPoster, TopicClosed, TopicReopen, TopicSilent } from '@bangumi/icons';
+import { css } from '@bangumi/styled-system/css';
 import { getUserProfileLink } from '@bangumi/utils/pages';
 
 import Avatar from '../../components/Avatar';
@@ -17,6 +18,25 @@ import CommentActions from './CommentActions';
 import CommentInfo from './CommentInfo';
 import Reactions from './Reactions';
 import ReplyForm from './ReplyForm';
+
+// 昵称/签名/内容可能包含长文本或 URL，允许换行避免移动端水平溢出；
+// tip 是 flex 容器，内部 flex 项默认 min-width: auto 不收缩，需显式允许收缩；
+// comment-info 里的操作按钮行在窄屏换行
+const commentTip = css({
+  overflowWrap: 'anywhere',
+  '& .creator-info, & .comment-info': {
+    minWidth: '0',
+  },
+  '& .comment-info': {
+    flexWrap: 'wrap',
+  },
+});
+
+// overflow-wrap 需要在块级容器上生效，这里覆盖评论主体
+const commentBody = css({
+  overflowWrap: 'anywhere',
+  minWidth: '0',
+});
 
 export type CommentProps = ((ReplyBase & { isReply: true }) | (Reply & { isReply: false })) & {
   topicId: number;
@@ -130,7 +150,7 @@ const Comment: FC<CommentProps> = ({
         }
         id={elementId}
       >
-        <span className='bgm-comment__tip'>
+        <span className={classNames('bgm-comment__tip', commentTip)}>
           <div className='creator-info'>
             <SpecialStateIcon state={state} />
             <Link to={url}>{creator?.nickname ?? ''}</Link>
@@ -170,9 +190,9 @@ const Comment: FC<CommentProps> = ({
           src={isReply ? (creator?.avatar.medium ?? '') : (creator?.avatar.large ?? '')}
           size={isReply ? 'xsmall' : isMainPost ? 'post' : 'small'}
         />
-        <div className='bgm-comment__box'>
-          <div className='bgm-comment__main'>
-            <span className='bgm-comment__tip'>
+        <div className={classNames('bgm-comment__box', commentBody)}>
+          <div className={classNames('bgm-comment__main', commentBody)}>
+            <span className={classNames('bgm-comment__tip', commentTip)}>
               <div className='creator-info'>
                 <Link to={url}>{creator?.nickname ?? ''}</Link>
                 {originalPosterId === creator?.id ? <OriginalPoster /> : null}

--- a/packages/design/components/Topic/__test__/__snapshots__/Comment.spec.tsx.snap
+++ b/packages/design/components/Topic/__test__/__snapshots__/Comment.spec.tsx.snap
@@ -15,10 +15,10 @@ exports[`Normal Comment > do not show opinions if not login 1`] = `
         />
       </div>
       <div
-        class="bgm-comment__box ov-wrap_anywhere min-w_0"
+        class="bgm-comment__box ov-wrap_anywhere min-w_0 [&_>_*]:max-w_100%"
       >
         <div
-          class="bgm-comment__main ov-wrap_anywhere min-w_0"
+          class="bgm-comment__main ov-wrap_anywhere min-w_0 [&_>_*]:max-w_100%"
         >
           <span
             class="bgm-comment__tip ov-wrap_anywhere [&_.creator-info,_&_.comment-info]:min-w_0 [&_.comment-info]:flex-wrap_wrap"
@@ -83,10 +83,10 @@ exports[`Normal Comment > should highlight comment corresponding to hash 1`] = `
         />
       </div>
       <div
-        class="bgm-comment__box ov-wrap_anywhere min-w_0"
+        class="bgm-comment__box ov-wrap_anywhere min-w_0 [&_>_*]:max-w_100%"
       >
         <div
-          class="bgm-comment__main ov-wrap_anywhere min-w_0"
+          class="bgm-comment__main ov-wrap_anywhere min-w_0 [&_>_*]:max-w_100%"
         >
           <span
             class="bgm-comment__tip ov-wrap_anywhere [&_.creator-info,_&_.comment-info]:min-w_0 [&_.comment-info]:flex-wrap_wrap"
@@ -188,10 +188,10 @@ exports[`Normal Comment > should highlight comment corresponding to hash 1`] = `
           />
         </div>
         <div
-          class="bgm-comment__box ov-wrap_anywhere min-w_0"
+          class="bgm-comment__box ov-wrap_anywhere min-w_0 [&_>_*]:max-w_100%"
         >
           <div
-            class="bgm-comment__main ov-wrap_anywhere min-w_0"
+            class="bgm-comment__main ov-wrap_anywhere min-w_0 [&_>_*]:max-w_100%"
           >
             <span
               class="bgm-comment__tip ov-wrap_anywhere [&_.creator-info,_&_.comment-info]:min-w_0 [&_.comment-info]:flex-wrap_wrap"
@@ -297,10 +297,10 @@ exports[`Normal Comment > should render 0 1`] = `
         />
       </div>
       <div
-        class="bgm-comment__box ov-wrap_anywhere min-w_0"
+        class="bgm-comment__box ov-wrap_anywhere min-w_0 [&_>_*]:max-w_100%"
       >
         <div
-          class="bgm-comment__main ov-wrap_anywhere min-w_0"
+          class="bgm-comment__main ov-wrap_anywhere min-w_0 [&_>_*]:max-w_100%"
         >
           <span
             class="bgm-comment__tip ov-wrap_anywhere [&_.creator-info,_&_.comment-info]:min-w_0 [&_.comment-info]:flex-wrap_wrap"
@@ -408,10 +408,10 @@ exports[`Normal Comment > should render 6 1`] = `
         />
       </div>
       <div
-        class="bgm-comment__box ov-wrap_anywhere min-w_0"
+        class="bgm-comment__box ov-wrap_anywhere min-w_0 [&_>_*]:max-w_100%"
       >
         <div
-          class="bgm-comment__main ov-wrap_anywhere min-w_0"
+          class="bgm-comment__main ov-wrap_anywhere min-w_0 [&_>_*]:max-w_100%"
         >
           <span
             class="bgm-comment__tip ov-wrap_anywhere [&_.creator-info,_&_.comment-info]:min-w_0 [&_.comment-info]:flex-wrap_wrap"
@@ -476,10 +476,10 @@ exports[`Normal Comment > should render 7 1`] = `
         />
       </div>
       <div
-        class="bgm-comment__box ov-wrap_anywhere min-w_0"
+        class="bgm-comment__box ov-wrap_anywhere min-w_0 [&_>_*]:max-w_100%"
       >
         <div
-          class="bgm-comment__main ov-wrap_anywhere min-w_0"
+          class="bgm-comment__main ov-wrap_anywhere min-w_0 [&_>_*]:max-w_100%"
         >
           <span
             class="bgm-comment__tip ov-wrap_anywhere [&_.creator-info,_&_.comment-info]:min-w_0 [&_.comment-info]:flex-wrap_wrap"
@@ -552,10 +552,10 @@ exports[`Normal Comment > should render with reply 1`] = `
         />
       </div>
       <div
-        class="bgm-comment__box ov-wrap_anywhere min-w_0"
+        class="bgm-comment__box ov-wrap_anywhere min-w_0 [&_>_*]:max-w_100%"
       >
         <div
-          class="bgm-comment__main ov-wrap_anywhere min-w_0"
+          class="bgm-comment__main ov-wrap_anywhere min-w_0 [&_>_*]:max-w_100%"
         >
           <span
             class="bgm-comment__tip ov-wrap_anywhere [&_.creator-info,_&_.comment-info]:min-w_0 [&_.comment-info]:flex-wrap_wrap"
@@ -657,10 +657,10 @@ exports[`Normal Comment > should render with reply 1`] = `
           />
         </div>
         <div
-          class="bgm-comment__box ov-wrap_anywhere min-w_0"
+          class="bgm-comment__box ov-wrap_anywhere min-w_0 [&_>_*]:max-w_100%"
         >
           <div
-            class="bgm-comment__main ov-wrap_anywhere min-w_0"
+            class="bgm-comment__main ov-wrap_anywhere min-w_0 [&_>_*]:max-w_100%"
           >
             <span
               class="bgm-comment__tip ov-wrap_anywhere [&_.creator-info,_&_.comment-info]:min-w_0 [&_.comment-info]:flex-wrap_wrap"

--- a/packages/design/components/Topic/__test__/__snapshots__/Comment.spec.tsx.snap
+++ b/packages/design/components/Topic/__test__/__snapshots__/Comment.spec.tsx.snap
@@ -15,13 +15,13 @@ exports[`Normal Comment > do not show opinions if not login 1`] = `
         />
       </div>
       <div
-        class="bgm-comment__box"
+        class="bgm-comment__box ov-wrap_anywhere min-w_0"
       >
         <div
-          class="bgm-comment__main"
+          class="bgm-comment__main ov-wrap_anywhere min-w_0"
         >
           <span
-            class="bgm-comment__tip"
+            class="bgm-comment__tip ov-wrap_anywhere [&_.creator-info,_&_.comment-info]:min-w_0 [&_.comment-info]:flex-wrap_wrap"
           >
             <div
               class="creator-info"
@@ -57,7 +57,7 @@ exports[`Normal Comment > do not show opinions if not login 1`] = `
             </div>
           </span>
           <div
-            class="bgm-rich-content bgm-comment__content"
+            class="bgm-rich-content ov-wrap_anywhere [&_pre]:ov-x_hidden bgm-comment__content"
           >
             123456789~~~
           </div>
@@ -83,13 +83,13 @@ exports[`Normal Comment > should highlight comment corresponding to hash 1`] = `
         />
       </div>
       <div
-        class="bgm-comment__box"
+        class="bgm-comment__box ov-wrap_anywhere min-w_0"
       >
         <div
-          class="bgm-comment__main"
+          class="bgm-comment__main ov-wrap_anywhere min-w_0"
         >
           <span
-            class="bgm-comment__tip"
+            class="bgm-comment__tip ov-wrap_anywhere [&_.creator-info,_&_.comment-info]:min-w_0 [&_.comment-info]:flex-wrap_wrap"
           >
             <div
               class="creator-info"
@@ -133,7 +133,7 @@ exports[`Normal Comment > should highlight comment corresponding to hash 1`] = `
                   <div />
                 </button>
                 <div
-                  class="bgm-popover"
+                  class="bgm-popover [&_.bgm-popover__content]:d_none hover:[&_.bgm-popover__content]:d_block"
                 >
                   <button
                     class="bgm-button bgm-comment-actions__more bgm-button--plain bgm-button--size-small"
@@ -168,7 +168,7 @@ exports[`Normal Comment > should highlight comment corresponding to hash 1`] = `
             </div>
           </span>
           <div
-            class="bgm-rich-content bgm-comment__content"
+            class="bgm-rich-content ov-wrap_anywhere [&_pre]:ov-x_hidden bgm-comment__content"
           >
             123456789~~~
           </div>
@@ -188,13 +188,13 @@ exports[`Normal Comment > should highlight comment corresponding to hash 1`] = `
           />
         </div>
         <div
-          class="bgm-comment__box"
+          class="bgm-comment__box ov-wrap_anywhere min-w_0"
         >
           <div
-            class="bgm-comment__main"
+            class="bgm-comment__main ov-wrap_anywhere min-w_0"
           >
             <span
-              class="bgm-comment__tip"
+              class="bgm-comment__tip ov-wrap_anywhere [&_.creator-info,_&_.comment-info]:min-w_0 [&_.comment-info]:flex-wrap_wrap"
             >
               <div
                 class="creator-info"
@@ -235,7 +235,7 @@ exports[`Normal Comment > should highlight comment corresponding to hash 1`] = `
                     <div />
                   </button>
                   <div
-                    class="bgm-popover"
+                    class="bgm-popover [&_.bgm-popover__content]:d_none hover:[&_.bgm-popover__content]:d_block"
                   >
                     <button
                       class="bgm-button bgm-comment-actions__more bgm-button--plain bgm-button--size-small"
@@ -270,7 +270,7 @@ exports[`Normal Comment > should highlight comment corresponding to hash 1`] = `
               </div>
             </span>
             <div
-              class="bgm-rich-content bgm-comment__content"
+              class="bgm-rich-content ov-wrap_anywhere [&_pre]:ov-x_hidden bgm-comment__content"
             >
               123456789~~~
             </div>
@@ -297,13 +297,13 @@ exports[`Normal Comment > should render 0 1`] = `
         />
       </div>
       <div
-        class="bgm-comment__box"
+        class="bgm-comment__box ov-wrap_anywhere min-w_0"
       >
         <div
-          class="bgm-comment__main"
+          class="bgm-comment__main ov-wrap_anywhere min-w_0"
         >
           <span
-            class="bgm-comment__tip"
+            class="bgm-comment__tip ov-wrap_anywhere [&_.creator-info,_&_.comment-info]:min-w_0 [&_.comment-info]:flex-wrap_wrap"
           >
             <div
               class="creator-info"
@@ -347,7 +347,7 @@ exports[`Normal Comment > should render 0 1`] = `
                   <div />
                 </button>
                 <div
-                  class="bgm-popover"
+                  class="bgm-popover [&_.bgm-popover__content]:d_none hover:[&_.bgm-popover__content]:d_block"
                 >
                   <button
                     class="bgm-button bgm-comment-actions__more bgm-button--plain bgm-button--size-small"
@@ -382,7 +382,7 @@ exports[`Normal Comment > should render 0 1`] = `
             </div>
           </span>
           <div
-            class="bgm-rich-content bgm-comment__content"
+            class="bgm-rich-content ov-wrap_anywhere [&_pre]:ov-x_hidden bgm-comment__content"
           >
             123456789~~~
           </div>
@@ -408,13 +408,13 @@ exports[`Normal Comment > should render 6 1`] = `
         />
       </div>
       <div
-        class="bgm-comment__box"
+        class="bgm-comment__box ov-wrap_anywhere min-w_0"
       >
         <div
-          class="bgm-comment__main"
+          class="bgm-comment__main ov-wrap_anywhere min-w_0"
         >
           <span
-            class="bgm-comment__tip"
+            class="bgm-comment__tip ov-wrap_anywhere [&_.creator-info,_&_.comment-info]:min-w_0 [&_.comment-info]:flex-wrap_wrap"
           >
             <div
               class="creator-info"
@@ -476,13 +476,13 @@ exports[`Normal Comment > should render 7 1`] = `
         />
       </div>
       <div
-        class="bgm-comment__box"
+        class="bgm-comment__box ov-wrap_anywhere min-w_0"
       >
         <div
-          class="bgm-comment__main"
+          class="bgm-comment__main ov-wrap_anywhere min-w_0"
         >
           <span
-            class="bgm-comment__tip"
+            class="bgm-comment__tip ov-wrap_anywhere [&_.creator-info,_&_.comment-info]:min-w_0 [&_.comment-info]:flex-wrap_wrap"
           >
             <div
               class="creator-info"
@@ -552,13 +552,13 @@ exports[`Normal Comment > should render with reply 1`] = `
         />
       </div>
       <div
-        class="bgm-comment__box"
+        class="bgm-comment__box ov-wrap_anywhere min-w_0"
       >
         <div
-          class="bgm-comment__main"
+          class="bgm-comment__main ov-wrap_anywhere min-w_0"
         >
           <span
-            class="bgm-comment__tip"
+            class="bgm-comment__tip ov-wrap_anywhere [&_.creator-info,_&_.comment-info]:min-w_0 [&_.comment-info]:flex-wrap_wrap"
           >
             <div
               class="creator-info"
@@ -602,7 +602,7 @@ exports[`Normal Comment > should render with reply 1`] = `
                   <div />
                 </button>
                 <div
-                  class="bgm-popover"
+                  class="bgm-popover [&_.bgm-popover__content]:d_none hover:[&_.bgm-popover__content]:d_block"
                 >
                   <button
                     class="bgm-button bgm-comment-actions__more bgm-button--plain bgm-button--size-small"
@@ -637,7 +637,7 @@ exports[`Normal Comment > should render with reply 1`] = `
             </div>
           </span>
           <div
-            class="bgm-rich-content bgm-comment__content"
+            class="bgm-rich-content ov-wrap_anywhere [&_pre]:ov-x_hidden bgm-comment__content"
           >
             123456789~~~
           </div>
@@ -657,13 +657,13 @@ exports[`Normal Comment > should render with reply 1`] = `
           />
         </div>
         <div
-          class="bgm-comment__box"
+          class="bgm-comment__box ov-wrap_anywhere min-w_0"
         >
           <div
-            class="bgm-comment__main"
+            class="bgm-comment__main ov-wrap_anywhere min-w_0"
           >
             <span
-              class="bgm-comment__tip"
+              class="bgm-comment__tip ov-wrap_anywhere [&_.creator-info,_&_.comment-info]:min-w_0 [&_.comment-info]:flex-wrap_wrap"
             >
               <div
                 class="creator-info"
@@ -704,7 +704,7 @@ exports[`Normal Comment > should render with reply 1`] = `
                     <div />
                   </button>
                   <div
-                    class="bgm-popover"
+                    class="bgm-popover [&_.bgm-popover__content]:d_none hover:[&_.bgm-popover__content]:d_block"
                   >
                     <button
                       class="bgm-button bgm-comment-actions__more bgm-button--plain bgm-button--size-small"
@@ -739,7 +739,7 @@ exports[`Normal Comment > should render with reply 1`] = `
               </div>
             </span>
             <div
-              class="bgm-rich-content bgm-comment__content"
+              class="bgm-rich-content ov-wrap_anywhere [&_pre]:ov-x_hidden bgm-comment__content"
             >
               123456789~~~
             </div>
@@ -758,7 +758,7 @@ exports[`Special Comment > should render state is 1 1`] = `
     id="post_2056216"
   >
     <span
-      class="bgm-comment__tip"
+      class="bgm-comment__tip ov-wrap_anywhere [&_.creator-info,_&_.comment-info]:min-w_0 [&_.comment-info]:flex-wrap_wrap"
     >
       <div
         class="creator-info"
@@ -794,7 +794,7 @@ exports[`Special Comment > should render state is 2 1`] = `
     id="post_2056216"
   >
     <span
-      class="bgm-comment__tip"
+      class="bgm-comment__tip ov-wrap_anywhere [&_.creator-info,_&_.comment-info]:min-w_0 [&_.comment-info]:flex-wrap_wrap"
     >
       <div
         class="creator-info"
@@ -830,7 +830,7 @@ exports[`Special Comment > should render state is 5 1`] = `
     id="post_2056216"
   >
     <span
-      class="bgm-comment__tip"
+      class="bgm-comment__tip ov-wrap_anywhere [&_.creator-info,_&_.comment-info]:min-w_0 [&_.comment-info]:flex-wrap_wrap"
     >
       <div
         class="creator-info"

--- a/packages/design/components/Topic/__test__/__snapshots__/CommentActions.spec.tsx.snap
+++ b/packages/design/components/Topic/__test__/__snapshots__/CommentActions.spec.tsx.snap
@@ -15,7 +15,7 @@ Object {
           <div />
         </button>
         <div
-          class="bgm-popover"
+          class="bgm-popover [&_.bgm-popover__content]:d_none hover:[&_.bgm-popover__content]:d_block"
         >
           <button
             class="bgm-button bgm-comment-actions__more bgm-button--plain bgm-button--size-small"
@@ -60,7 +60,7 @@ Object {
         <div />
       </button>
       <div
-        class="bgm-popover"
+        class="bgm-popover [&_.bgm-popover__content]:d_none hover:[&_.bgm-popover__content]:d_block"
       >
         <button
           class="bgm-button bgm-comment-actions__more bgm-button--plain bgm-button--size-small"
@@ -162,7 +162,7 @@ Object {
           <div />
         </button>
         <div
-          class="bgm-popover"
+          class="bgm-popover [&_.bgm-popover__content]:d_none hover:[&_.bgm-popover__content]:d_block"
         >
           <button
             class="bgm-button bgm-comment-actions__more bgm-button--plain bgm-button--size-small"
@@ -219,7 +219,7 @@ Object {
         <div />
       </button>
       <div
-        class="bgm-popover"
+        class="bgm-popover [&_.bgm-popover__content]:d_none hover:[&_.bgm-popover__content]:d_block"
       >
         <button
           class="bgm-button bgm-comment-actions__more bgm-button--plain bgm-button--size-small"
@@ -333,7 +333,7 @@ Object {
           <div />
         </button>
         <div
-          class="bgm-popover"
+          class="bgm-popover [&_.bgm-popover__content]:d_none hover:[&_.bgm-popover__content]:d_block"
         >
           <button
             class="bgm-button bgm-comment-actions__more bgm-button--plain bgm-button--size-small"
@@ -383,7 +383,7 @@ Object {
         <div />
       </button>
       <div
-        class="bgm-popover"
+        class="bgm-popover [&_.bgm-popover__content]:d_none hover:[&_.bgm-popover__content]:d_block"
       >
         <button
           class="bgm-button bgm-comment-actions__more bgm-button--plain bgm-button--size-small"
@@ -491,7 +491,7 @@ Object {
           回复
         </button>
         <div
-          class="bgm-popover"
+          class="bgm-popover [&_.bgm-popover__content]:d_none hover:[&_.bgm-popover__content]:d_block"
         >
           <button
             class="bgm-button bgm-comment-actions__more bgm-button--plain bgm-button--size-small"
@@ -538,7 +538,7 @@ Object {
         回复
       </button>
       <div
-        class="bgm-popover"
+        class="bgm-popover [&_.bgm-popover__content]:d_none hover:[&_.bgm-popover__content]:d_block"
       >
         <button
           class="bgm-button bgm-comment-actions__more bgm-button--plain bgm-button--size-small"

--- a/packages/styled-system/styles.css
+++ b/packages/styled-system/styles.css
@@ -2717,6 +2717,10 @@
     min-width: var(--sizes-0);
 }
 
+  .\[\&_\>_\*\]\:max-w_100\% > * {
+    max-width: 100%;
+}
+
   .focus\:bd-c_\#888:is(:focus, [data-focus]) {
     border-color: #888;
 }

--- a/packages/styled-system/styles.css
+++ b/packages/styled-system/styles.css
@@ -2573,6 +2573,14 @@
     font-size: 15px;
 }
 
+  .\[\&_\.bgm-popover__content\]\:d_none .bgm-popover__content {
+    display: none;
+}
+
+  .\[\&_\.comment-info\]\:flex-wrap_wrap .comment-info {
+    flex-wrap: wrap;
+}
+
   .disabled\:cursor_default:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
     cursor: default;
 }
@@ -2701,6 +2709,14 @@
     width: 72px;
 }
 
+  .\[\&_pre\]\:ov-x_hidden pre {
+    overflow-x: hidden;
+}
+
+  .\[\&_\.creator-info\,_\&_\.comment-info\]\:min-w_0 .creator-info,.\[\&_\.creator-info\,_\&_\.comment-info\]\:min-w_0 .comment-info {
+    min-width: var(--sizes-0);
+}
+
   .focus\:bd-c_\#888:is(:focus, [data-focus]) {
     border-color: #888;
 }
@@ -2823,6 +2839,10 @@
 
   .hover\:\[\&_a\]\:c_\#f5a4ab:is(:hover, [data-hover]) a {
     color: #f5a4ab;
+}
+
+  .hover\:\[\&_\.bgm-popover__content\]\:d_block:is(:hover, [data-hover]) .bgm-popover__content {
+    display: block;
 }
 
   .\[\&_h3\]\:\[\&_a\]\:hover\:c_\#54b5df h3 a:is(:hover, [data-hover]) {


### PR DESCRIPTION
## 背景

`next.bgm.tv/group/topic/445583` 移动端水平溢出。帖子内容包含**单纯长文本**（油猴脚本片段/长 URL，非 `[code]` 块），评论组件本身在窄屏也会被长签名/操作按钮/悬浮菜单撑出滚动。

## 变更（全部用 Panda CSS，未改 less）

- **RichContent**：`overflow-wrap: anywhere` 让长文本/长 URL 换行；`[code]` 渲染的 `<pre>` 加 `overflow-x: hidden` 横向截断
- **Topic.Comment**：评论头 `tip` 是 flex 容器，内部 flex 项默认 `min-width: auto` 不收缩；允许 `creator-info`/`comment-info` 收缩换行（昵称/签名含 URL、操作按钮行在窄屏可换行）
- **Popover**：悬浮菜单原来用 `visibility: hidden` 隐藏但仍占布局，absolute 定位在移动端把 `scrollWidth` 撑出视口；改为未 hover 时 `display: none`（hover 仍正常显示）
- 更新受影响的快照

## 验证

- `pnpm test`（353 通过）、`build`、`lint`、`type-check`、`prettier` 全过
- Playwright 375px：话题页（含真实投票长帖）`scrollWidth=375` 无溢出；长脚本文本/长 URL 换行、超长 code 行截断；popover hover 仍显示
- 回归：条目吐槽、人物、条目页 375px 无溢出；桌面端渲染正常