### PR TITLE
fix(website): prevent user homepage horizontal overflow on mobile

### DIFF
--- a/packages/website/src/pages/index/user/[username]/components/UserInfoCard.tsx
+++ b/packages/website/src/pages/index/user/[username]/components/UserInfoCard.tsx
@@ -36,6 +36,7 @@ const quoteIcon = css({
 });
 
 const bioText = css({
+  minWidth: '0',
   color: '#1f1c1c',
   fontSize: '14px',
   lineHeight: '1.6',

--- a/packages/website/src/pages/index/user/[username]/index.tsx
+++ b/packages/website/src/pages/index/user/[username]/index.tsx
@@ -23,6 +23,8 @@ const columns = css({
   boxSizing: 'border-box',
   '@media (max-width: 768px)': {
     flexDirection: 'column',
+    // 单列时让子项占满容器宽度，避免内容按 max-content 撑开导致横向溢出
+    alignItems: 'stretch',
     paddingTop: '16px',
     paddingBottom: '40px',
   },


### PR DESCRIPTION
## 背景

`next.bgm.tv/user/magisutan` 在 375px 下横向溢出。根因：用户主页的左右栏容器（`columns`）在窄屏堆叠成单列时仍保留 `align-items: flex-start`，导致左栏按内容 `max-content` 宽度撑开（长简介文本、收藏统计行），形成页面级横向滚动条。

## 变更

- **`columns`**：窄屏（≤768px）堆叠单列时 `align-items: stretch`，子项占满容器宽度
- **`UserInfoCard` 简介**：`bioText` 作为 flex 子项补 `min-width: 0`，长简介才真正换行而非撑开整行
- 收藏封面列表已按条目内部 `overflow-x: auto` 横向滚动，不再撑出页面级滚动条（沿用现有方案）

## 验证

- `pnpm test`（353 通过）、`build`、`lint`、`type-check`、`prettier` 全过
- Playwright 连线上真实 API：`/user/magisutan` 375px 下 `scrollWidth = 375` 无页面级横向滚动