### PR TITLE
fix(website): improve group topic list readability

### DIFF
--- a/packages/styled-system/styles.css
+++ b/packages/styled-system/styles.css
@@ -1409,8 +1409,8 @@
     display: grid;
 }
 
-  .grid-tc_repeat\(5\,_1fr\) {
-    grid-template-columns: repeat(5, 1fr);
+  .grid-tc_repeat\(auto-fill\,_minmax\(60px\,_1fr\)\) {
+    grid-template-columns: repeat(auto-fill, minmax(60px, 1fr));
 }
 
   .cg_30px {
@@ -1613,10 +1613,6 @@
     line-height: 22px;
 }
 
-  .grid-tc_repeat\(auto-fill\,_minmax\(60px\,_1fr\)\) {
-    grid-template-columns: repeat(auto-fill, minmax(60px, 1fr));
-}
-
   .wb_normal {
     word-break: normal;
 }
@@ -1627,6 +1623,10 @@
 
   .c_\#54b5df\! {
     color: #54b5df !important;
+}
+
+  .grid-tc_repeat\(5\,_1fr\) {
+    grid-template-columns: repeat(5, 1fr);
 }
 
   .page_1 {
@@ -1965,16 +1965,20 @@
     margin-bottom: 40px;
 }
 
-  .w_130px {
-    width: 130px;
-}
-
   .w_110px {
     width: 110px;
 }
 
-  .w_100px {
-    width: 100px;
+  .w_80px {
+    width: 80px;
+}
+
+  .w_40px {
+    width: 40px;
+}
+
+  .w_90px {
+    width: 90px;
 }
 
   .w_75\% {
@@ -2033,10 +2037,6 @@
     margin-top: -7px;
 }
 
-  .w_120px {
-    width: 120px;
-}
-
   .mt_20px {
     margin-top: 20px;
 }
@@ -2049,12 +2049,8 @@
     margin-bottom: 23px;
 }
 
-  .w_40px {
-    width: 40px;
-}
-
-  .w_90px {
-    width: 90px;
+  .w_120px {
+    width: 120px;
 }
 
   .h_40px {
@@ -2075,10 +2071,6 @@
 
   .mb_4px {
     margin-bottom: 4px;
-}
-
-  .w_80px {
-    width: 80px;
 }
 
   .h_80px {
@@ -2439,14 +2431,6 @@
 
   .\[\&_\>_span\]\:c_\#9f9b9b > span {
     color: #9f9b9b;
-}
-
-  .\[\&_thead\]\:fs_18px thead {
-    font-size: 18px;
-}
-
-  .\[\&_thead\]\:lh_18px thead {
-    line-height: 18px;
 }
 
   .\[\&_thead\]\:ta_left thead {

--- a/packages/styled-system/styles.css
+++ b/packages/styled-system/styles.css
@@ -688,6 +688,14 @@
     font: inherit;
 }
 
+  .bg_\#f7f7f4 {
+    background: #f7f7f4;
+}
+
+  .p_15px {
+    padding: 15px;
+}
+
   .p_7\.5px_0 {
     padding: 7.5px 0;
 }
@@ -880,10 +888,6 @@
     border: 2px dashed #e8e3e3;
 }
 
-  .bg_\#f7f7f4 {
-    background: #f7f7f4;
-}
-
   .p_2px_10px {
     padding: 2px 10px;
 }
@@ -1014,6 +1018,10 @@
 
   .bdr_4px {
     border-radius: 4px;
+}
+
+  .bdr_15px {
+    border-radius: 15px;
 }
 
   .gap_20px_30px {
@@ -1429,12 +1437,24 @@
     grid-template-columns: repeat(3, 1fr);
 }
 
+  .c_\#777 {
+    color: #777;
+}
+
   .tbl_fixed {
     table-layout: fixed;
 }
 
   .ta_right {
     text-align: right;
+}
+
+  .c_\#0084b4 {
+    color: #0084b4;
+}
+
+  .cursor_pointer {
+    cursor: pointer;
 }
 
   .ai_flex-start {
@@ -1477,8 +1497,8 @@
     line-height: 1.35;
 }
 
-  .grid-tc_repeat\(3\,_290px\) {
-    grid-template-columns: repeat(3, 290px);
+  .grid-tc_repeat\(auto-fill\,_minmax\(290px\,_1fr\)\) {
+    grid-template-columns: repeat(auto-fill, minmax(290px, 1fr));
 }
 
   .cg_14px {
@@ -1587,10 +1607,6 @@
 
   .op_0\.3 {
     opacity: 0.3;
-}
-
-  .cursor_pointer {
-    cursor: pointer;
 }
 
   .op_0 {
@@ -1973,10 +1989,6 @@
     width: 80px;
 }
 
-  .w_40px {
-    width: 40px;
-}
-
   .w_90px {
     width: 90px;
 }
@@ -2051,6 +2063,10 @@
 
   .w_120px {
     width: 120px;
+}
+
+  .w_40px {
+    width: 40px;
 }
 
   .h_40px {
@@ -2769,6 +2785,10 @@
     color: #54b5df;
 }
 
+  .hover\:c_\#02a3fb:is(:hover, [data-hover]) {
+    color: #02a3fb;
+}
+
   .hover\:c_\#fff:is(:hover, [data-hover]) {
     color: #fff;
 }
@@ -2919,6 +2939,9 @@
     .\[\@media_\(max-width\:_640px\)\]\:fs_20px {
       font-size: 20px;
 }
+    .\[\@media_\(max-width\:_640px\)\]\:grid-tc_repeat\(auto-fill\,_minmax\(160px\,_1fr\)\) {
+      grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+}
     .\[\@media_\(max-width\:_640px\)\]\:grid-tc_1fr {
       grid-template-columns: 1fr;
 }
@@ -2936,6 +2959,9 @@
 }
     .\[\@media_\(max-width\:_640px\)\]\:ml_40px {
       margin-left: 40px;
+}
+    .\[\@media_\(max-width\:_640px\)\]\:w_100\% {
+      width: 100%;
 }
     .\[\@media_\(max-width\:_640px\)\]\:mb_24px {
       margin-bottom: 24px;

--- a/packages/website/src/pages/index/group/[name]/components/TopicsTable.tsx
+++ b/packages/website/src/pages/index/group/[name]/components/TopicsTable.tsx
@@ -9,6 +9,7 @@ import { getUserProfileLink } from '@bangumi/utils/pages';
 const topicTable = css({
   width: '100%',
   color: '#9f9b9b',
+  fontSize: '13px',
   tableLayout: 'fixed',
   '& th, & td': {
     padding: '11px 4px',
@@ -17,8 +18,6 @@ const topicTable = css({
     borderBottom: '1px dotted #e8e3e3',
   },
   '& thead': {
-    fontSize: '18px',
-    lineHeight: '18px',
     textAlign: 'left',
     '& th': {
       fontWeight: 'normal',
@@ -27,24 +26,22 @@ const topicTable = css({
 });
 
 const title = css({
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
+  overflowWrap: 'anywhere',
 });
 
 const author = css({
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
-  width: '120px',
+  width: '90px',
 });
 
 const replies = css({
-  width: '60px',
+  width: '40px',
 });
 
 const updateTime = css({
-  width: '100px',
+  width: '90px',
   textAlign: 'right',
 });
 

--- a/packages/website/src/pages/index/group/[name]/components/TopicsTable.tsx
+++ b/packages/website/src/pages/index/group/[name]/components/TopicsTable.tsx
@@ -6,9 +6,11 @@ import { Typography } from '@bangumi/design';
 import { css } from '@bangumi/styled-system/css';
 import { getUserProfileLink } from '@bangumi/utils/pages';
 
+import { topicListLink } from '../../components/topicListLink';
+
 const topicTable = css({
   width: '100%',
-  color: '#9f9b9b',
+  color: '#777',
   fontSize: '13px',
   tableLayout: 'fixed',
   '& th, & td': {
@@ -37,7 +39,8 @@ const author = css({
 });
 
 const replies = css({
-  width: '40px',
+  width: '30px',
+  textAlign: 'right',
 });
 
 const updateTime = css({
@@ -52,7 +55,7 @@ const TopicsTable: React.FC<{ topics: Topic[] }> = ({ topics }) => {
         <tr>
           <th className={title}>标题</th>
           <th className={author}>作者</th>
-          <th className={replies}>回复数</th>
+          <th className={replies}>回复</th>
           <th className={updateTime}>最后回复于</th>
         </tr>
       </thead>
@@ -61,14 +64,15 @@ const TopicsTable: React.FC<{ topics: Topic[] }> = ({ topics }) => {
           return (
             <tr key={topic.id}>
               <td className={title} title={topic.title}>
-                <Typography.Link to={`/group/topic/${topic.id}`} fontWeight='bold'>
+                <Typography.Link to={`/group/topic/${topic.id}`} noStyle className={topicListLink}>
                   {topic.title}
                 </Typography.Link>
               </td>
               <td className={author} title={topic.creator?.nickname}>
                 <Typography.Link
                   to={getUserProfileLink(topic.creator?.username ?? '')}
-                  fontWeight='bold'
+                  noStyle
+                  className={topicListLink}
                 >
                   {topic.creator?.nickname}
                 </Typography.Link>

--- a/packages/website/src/pages/index/group/[name]/index/index.tsx
+++ b/packages/website/src/pages/index/group/[name]/index/index.tsx
@@ -18,6 +18,13 @@ const recentTopics = css({
   marginTop: '40px',
 });
 
+const descriptionBox = css({
+  // 对齐旧版 grp_box 的浅灰背景
+  background: '#f7f7f4',
+  borderRadius: '15px',
+  padding: '15px',
+});
+
 const GroupHome: React.FC = () => {
   const { name } = useParams();
   if (!name) {
@@ -40,6 +47,7 @@ const GroupHome: React.FC = () => {
     <>
       <Helmet title={`${group.title}小组`} />
       <CollapsibleContent
+        containerClassName={descriptionBox}
         threshold={193}
         content={parsedDescription}
         collapsed={descriptionCollapsed}

--- a/packages/website/src/pages/index/group/[name]/index/members.tsx
+++ b/packages/website/src/pages/index/group/[name]/index/members.tsx
@@ -16,9 +16,13 @@ import { useGroupContext } from '..';
 const members = css({
   marginBottom: '20px',
   display: 'grid',
-  gridTemplateColumns: 'repeat(3, 290px)',
+  gridTemplateColumns: 'repeat(auto-fill, minmax(290px, 1fr))',
   columnGap: '14px',
   rowGap: '20px',
+  // 移动端每行至少两个成员，容器够宽时自动增加列数
+  '@media (max-width: 640px)': {
+    gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))',
+  },
 });
 
 const pagination = css({

--- a/packages/website/src/pages/index/group/components/GroupHeader.tsx
+++ b/packages/website/src/pages/index/group/components/GroupHeader.tsx
@@ -1,17 +1,18 @@
 import dayjs from 'dayjs';
-import React, { useState } from 'react';
+import React from 'react';
 
 import type { Group } from '@bangumi/client/client';
-import { CollapsibleContent, Image, Typography } from '@bangumi/design';
+import { Image, Typography } from '@bangumi/design';
 import { css } from '@bangumi/styled-system/css';
-import { render as renderBBCode } from '@bangumi/utils/bbcode/react';
-
-import GroupActions from './GroupActions';
 
 const { Text } = Typography;
 
 const groupHeader = css({
   display: 'flex',
+  // 对齐旧版 grp_box 的浅灰背景
+  background: '#f7f7f4',
+  borderRadius: '15px',
+  padding: '15px',
   '& > *': {
     marginRight: '20px',
   },
@@ -37,13 +38,7 @@ const infoCol = css({
   padding: '7.5px 0',
 });
 
-// 原 GroupHeader.module.less 未定义这两个类，className 原本为 undefined
-const groupDescription = css({});
-const groupButtons = css({});
-
 export const GroupHeader: React.FC<{ group: Group }> = ({ group }) => {
-  const [collapsed, setCollapsed] = useState(true);
-
   return (
     <div className={groupHeader}>
       <div className={thumbnail}>
@@ -60,14 +55,6 @@ export const GroupHeader: React.FC<{ group: Group }> = ({ group }) => {
             名成员{' '}
           </Text>
         </div>
-        <CollapsibleContent
-          content={renderBBCode(group.description)}
-          containerClassName={groupDescription}
-          threshold={158}
-          collapsed={collapsed}
-          onChange={setCollapsed}
-        />
-        <GroupActions group={group} size='medium' className={groupButtons} />
       </div>
     </div>
   );

--- a/packages/website/src/pages/index/group/components/GroupLayout.tsx
+++ b/packages/website/src/pages/index/group/components/GroupLayout.tsx
@@ -48,7 +48,7 @@ const pageContainer = css({
 
 const newMembers = css({
   display: 'grid',
-  gridTemplateColumns: 'repeat(5, 1fr)',
+  gridTemplateColumns: 'repeat(auto-fill, minmax(60px, 1fr))',
   columnGap: '30px',
   rowGap: '15px',
 });

--- a/packages/website/src/pages/index/group/components/GroupTopicTable.tsx
+++ b/packages/website/src/pages/index/group/components/GroupTopicTable.tsx
@@ -9,6 +9,7 @@ import { getUserProfileLink } from '@bangumi/utils/pages';
 const topicTable = css({
   width: '100%',
   color: '#9f9b9b',
+  fontSize: '13px',
   tableLayout: 'fixed',
   '& th, & td': {
     padding: '11px 4px',
@@ -17,8 +18,6 @@ const topicTable = css({
     borderBottom: '1px dotted #e8e3e3',
   },
   '& thead': {
-    fontSize: '18px',
-    lineHeight: '18px',
     textAlign: 'left',
     '& th': {
       fontWeight: 'normal',
@@ -27,32 +26,30 @@ const topicTable = css({
 });
 
 const title = css({
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
+  overflowWrap: 'anywhere',
 });
 
 const group = css({
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
-  width: '130px',
+  width: '110px',
 });
 
 const author = css({
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
-  width: '110px',
+  width: '80px',
   smDown: { display: 'none' },
 });
 
 const replies = css({
-  width: '60px',
+  width: '40px',
 });
 
 const updateTime = css({
-  width: '100px',
+  width: '90px',
   textAlign: 'right',
   smDown: { display: 'none' },
 });

--- a/packages/website/src/pages/index/group/components/GroupTopicTable.tsx
+++ b/packages/website/src/pages/index/group/components/GroupTopicTable.tsx
@@ -6,9 +6,11 @@ import { Typography } from '@bangumi/design';
 import { css } from '@bangumi/styled-system/css';
 import { getUserProfileLink } from '@bangumi/utils/pages';
 
+import { topicListLink } from './topicListLink';
+
 const topicTable = css({
   width: '100%',
-  color: '#9f9b9b',
+  color: '#777',
   fontSize: '13px',
   tableLayout: 'fixed',
   '& th, & td': {
@@ -45,7 +47,8 @@ const author = css({
 });
 
 const replies = css({
-  width: '40px',
+  width: '30px',
+  textAlign: 'right',
 });
 
 const updateTime = css({
@@ -63,7 +66,7 @@ const GroupTopicTable: React.FC<{ topics: GroupTopic[] }> = ({ topics }) => {
           <th className={title}>标题</th>
           <th className={group}>小组</th>
           <th className={author}>作者</th>
-          <th className={replies}>回复数</th>
+          <th className={replies}>回复</th>
           <th className={updateTime}>最后回复于</th>
         </tr>
       </thead>
@@ -72,19 +75,24 @@ const GroupTopicTable: React.FC<{ topics: GroupTopic[] }> = ({ topics }) => {
           return (
             <tr key={topic.id}>
               <td className={title} title={topic.title}>
-                <Typography.Link to={`/group/topic/${topic.id}`} fontWeight='bold'>
+                <Typography.Link to={`/group/topic/${topic.id}`} noStyle className={topicListLink}>
                   {topic.title}
                 </Typography.Link>
               </td>
               <td className={group} title={topic.group.title}>
-                <Typography.Link to={`/group/${topic.group.name}`} fontWeight='bold'>
+                <Typography.Link
+                  to={`/group/${topic.group.name}`}
+                  noStyle
+                  className={topicListLink}
+                >
                   {topic.group.title}
                 </Typography.Link>
               </td>
               <td className={author} title={topic.creator?.nickname}>
                 <Typography.Link
                   to={getUserProfileLink(topic.creator?.username ?? '')}
-                  fontWeight='bold'
+                  noStyle
+                  className={topicListLink}
                 >
                   {topic.creator?.nickname}
                 </Typography.Link>

--- a/packages/website/src/pages/index/group/components/UserCard.tsx
+++ b/packages/website/src/pages/index/group/components/UserCard.tsx
@@ -30,6 +30,10 @@ const userCardMode = {
   }),
   horizontal: css({
     width: '290px',
+    // 移动端网格列宽小于 290px，宽度自适应
+    '@media (max-width: 640px)': {
+      width: '100%',
+    },
   }),
 } satisfies Record<NonNullable<UserCardProps['mode']>, string>;
 

--- a/packages/website/src/pages/index/group/components/topicListLink.ts
+++ b/packages/website/src/pages/index/group/components/topicListLink.ts
@@ -1,0 +1,20 @@
+import { css } from '@bangumi/styled-system/css';
+
+/**
+ * 话题列表内的链接样式。
+ *
+ * 配合 Typography.Link 的 noStyle 使用，不依赖 .bgm-link 的 less 注入样式，
+ * 避免未分层 less 样式覆盖 Panda layer 的问题。颜色对齐旧版 a.l
+ * （#0084b4，白底对比度 4.23:1）。
+ */
+export const topicListLink = css({
+  display: 'inline-block',
+  color: '#0084b4',
+  cursor: 'pointer',
+  fontWeight: 'bold',
+  textDecoration: 'none',
+  _hover: {
+    color: '#02a3fb',
+    textDecoration: 'underline',
+  },
+});


### PR DESCRIPTION
## 背景

`/group/{name}` 帖子列表有三个显示问题：表头 18px 太大、标题单行省略显示不全、回复数/作者/最后回复时间列占用水平空间过多。

## 变更

**话题列表（`TopicsTable` / `GroupTopicTable`）**
- 表格 `font-size: 13px`，去掉过大的 18px 表头（对齐旧版 `topic_list` 样式）
- 标题去掉单行省略，改 `overflow-wrap: anywhere` 多行换行显示完整
- 表格色 `#9f9f9b` → `#777`（对比度 2.66 → 4.48:1，对齐旧版表头色）
- **标题/作者/小组名链接**：新增共享 Panda 类 `topicListLink`（`#0084b4`、hover `#02a3fb` + underline，对齐旧版 `a.l`），配合 `Typography.Link noStyle` 使用——不再依赖 `.bgm-link` 的 less 注入样式（避免 layer 优先级覆盖），无 `!important`
- 压缩侧列（对齐旧版宽度）：作者 `120→90px`、回复 `60→30px`（右对齐，表头「回复」单行）、最后回复 `100→90px`

**`GroupHeader` / 小组首页**
- 删除重复简介（`GroupHome` 保留一处，对齐旧版 `group_header` 无简介）
- 删除头部「发表新主题」按钮（保留侧栏「小组功能」与话题详情页的入口）
- 小组信息与简介加灰背景（`#f7f7f4`、圆角 15px，对齐旧版 `grp_box`）

**成员页**
- 网格固定 `repeat(3, 290px)` 在移动端溢出 → `auto-fill` 自适应列数，移动端每行至少 2 个
- `UserCard` horizontal 模式移动端宽度自适应列宽

**`GroupLayout`** 顺带修复桌面端溢出：侧栏「最近加入」成员 grid 固定 5 列超出 246px 侧栏 → `auto-fill minmax(60px, 1fr)`

## 验证

- `pnpm test` 353 通过、build/lint/type-check/prettier 全过
- Playwright 连线上真实 API：`/group/sandbox`、`/group/dev/members` 在 375px 与 1280px 下均无横向溢出；标题 `#0084b4`、表头 `#777`、灰背景生效；移动端成员每行 2 个