### PR TITLE
feat(website): split e2e tests into offline fixtures and server-backed groups

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -26,12 +26,10 @@ jobs:
         run: pnpm --filter @bangumi/website run install-playwright-deps
 
       - name: Run test
-        if: ${{ false }}
         run: pnpm test:e2e
 
       - name: Upload test results
-        # if: always()
-        if: ${{ false }}
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: playwright-report

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,6 +3,9 @@ packages/design/storybook-static
 packages/styled-system
 pnpm-lock.yaml
 *.snap
+# playwright 产物
+packages/website/playwright-report
+packages/website/test-results
 # submodules
 packages/utils/wiki-syntax-spec/
 

--- a/packages/website/e2e/common/fixtures.ts
+++ b/packages/website/e2e/common/fixtures.ts
@@ -1,0 +1,37 @@
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+
+import type { Page, Route } from '@playwright/test';
+
+const fixturesDirectory = path.join(__dirname, '../../src/mocks/fixtures');
+
+/** 按 mocks/utils.ts 的命名约定加载 JSON fixture；无匹配文件时返回 undefined */
+async function loadFixture(pathname: string, method: string): Promise<object | undefined> {
+  const fixturePath = path.join(fixturesDirectory, `${pathname}-${method.toUpperCase()}.json`);
+  try {
+    await fsp.access(fixturePath);
+  } catch {
+    return undefined;
+  }
+  return JSON.parse(await fsp.readFile(fixturePath, 'utf8')) as object;
+}
+
+/**
+ * 拦截 /p1/ API 请求并用本地 fixtures 响应，未匹配的请求直接失败，
+ * 不透传到真实后端，保证 e2e 不依赖外部服务。
+ */
+export function useFixtures(page: Page): void {
+  page.route('**/p1/**', async (route: Route) => {
+    const { pathname } = new URL(route.request().url());
+    const fixture = await loadFixture(pathname, route.request().method());
+    if (fixture === undefined) {
+      console.error(`e2e fixture missing for ${route.request().method()} ${pathname}`);
+      return route.abort();
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(fixture),
+    });
+  });
+}

--- a/packages/website/e2e/specs/404.spec.ts
+++ b/packages/website/e2e/specs/404.spec.ts
@@ -1,7 +1,10 @@
 import { expect, test } from '@playwright/test';
 
+import { useFixtures } from '../common/fixtures';
+
 test.describe('404', () => {
   test('返回首页', async ({ page }) => {
+    useFixtures(page);
     await page.goto('/');
     await page.goto('/anypage');
     await expect(page.getByText('呜咕，出错了…')).toBeVisible();
@@ -10,6 +13,7 @@ test.describe('404', () => {
   });
 
   test('返回上页', async ({ page }) => {
+    useFixtures(page);
     await page.goto('/');
     await page.goto('/anypage');
     await expect(page.getByText('呜咕，出错了…')).toBeVisible();

--- a/packages/website/e2e/specs/group.spec.ts
+++ b/packages/website/e2e/specs/group.spec.ts
@@ -17,14 +17,12 @@ test.describe('已登录用户', () => {
   test('登录用户', async ({ page }) => {
     test.slow();
     await page.goto('/group/sandbox');
-    await page.pause();
 
     await expect(
       page.getByRole('link', {
         name: '发表新主题',
       }),
     ).toBeVisible();
-    await expect(page.getByText('退出该小组')).toBeVisible();
 
     await page.getByPlaceholder('给新帖取一个标题').click();
     await page.getByPlaceholder('给新帖取一个标题').fill('测试贴123');

--- a/packages/website/e2e/specs/main.spec.ts
+++ b/packages/website/e2e/specs/main.spec.ts
@@ -1,14 +1,16 @@
 import { expect, test } from '@playwright/test';
 
-import { testAsUser } from '../common/login';
+import { useFixtures } from '../common/fixtures';
 
 test.describe('main page', () => {
   test('has title', async ({ page }) => {
+    useFixtures(page);
     await page.goto('/');
     await expect(page).toHaveTitle('Bangumi 番组计划');
   });
 
   test('移动端首页不应横向溢出', async ({ page }) => {
+    useFixtures(page);
     await page.setViewportSize({ width: 375, height: 812 });
     await page.goto('/');
 
@@ -21,6 +23,7 @@ test.describe('main page', () => {
   });
 
   test('移动端可以展开导航菜单', async ({ page }) => {
+    useFixtures(page);
     await page.setViewportSize({ width: 375, height: 812 });
     await page.goto('/');
 
@@ -40,6 +43,7 @@ test.describe('main page', () => {
   });
 
   test('移动端初始状态搜索面板不可见', async ({ page }) => {
+    useFixtures(page);
     await page.setViewportSize({ width: 375, height: 812 });
     await page.goto('/');
 
@@ -49,20 +53,7 @@ test.describe('main page', () => {
   });
 
   test('移动端已登录操作区保持水平对齐', async ({ page }) => {
-    await page.route('**/p1/me', async (route) => {
-      await route.fulfill({
-        json: {
-          id: 1,
-          username: 'test-user',
-          nickname: '测试用户',
-          avatar: {
-            small: '/favicon.ico',
-            medium: '/favicon.ico',
-            large: '/favicon.ico',
-          },
-        },
-      });
-    });
+    useFixtures(page);
     await page.setViewportSize({ width: 436, height: 812 });
     await page.goto('/');
 
@@ -71,14 +62,11 @@ test.describe('main page', () => {
     await expect(actions).toHaveCSS('align-items', 'center');
     await expect(page.getByRole('button', { name: '搜索' })).toBeVisible();
     await expect(page.locator('a[href="/notifications"]')).toBeVisible();
-    await expect(page.locator('header a[href="/user/test-user"]')).toBeVisible();
+    await expect(page.locator('header a[href="/user/382951"]')).toBeVisible();
   });
-});
 
-test.describe('已登录用户', () => {
-  testAsUser('treeholechan');
-
-  test('应该能够看到收藏菜单', async ({ page }) => {
+  test('登录用户可以看到收藏菜单', async ({ page }) => {
+    useFixtures(page);
     await page.goto('/');
     await expect(
       page

--- a/packages/website/playwright.config.ts
+++ b/packages/website/playwright.config.ts
@@ -51,14 +51,23 @@ export default defineConfig({
 
   projects: [
     {
-      name: 'setup',
-      testDir: './e2e/setup',
-      testMatch: /.*\.setup\.ts/,
-    },
-    {
-      name: 'chromium',
+      // 离线可跑：页面渲染/布局/404，API 全部用本地 fixtures 拦截
+      name: 'fixtures',
       use: { ...devices['Desktop Chrome'] },
-      dependencies: ['setup'],
+      testMatch: /(main|404)\.spec\.ts/,
     },
+    // TODO: 需要真实后端（本地 next.bgm.tv 或 CI 的 server-private），
+    // server 集成就绪后恢复以下 project（group.spec.ts / e2e/setup）
+    // {
+    //   name: 'setup',
+    //   testDir: './e2e/setup',
+    //   testMatch: /.*\.setup\.ts/,
+    // },
+    // {
+    //   name: 'server',
+    //   use: { ...devices['Desktop Chrome'] },
+    //   dependencies: ['setup'],
+    //   testMatch: /group\.spec\.ts/,
+    // },
   ],
 });

--- a/packages/website/src/components/PageRoutes/LegacyRedirect.spec.tsx
+++ b/packages/website/src/components/PageRoutes/LegacyRedirect.spec.tsx
@@ -23,20 +23,29 @@ it('redirects a registered legacy path to the legacy site', async () => {
   });
 });
 
-it.each([
-  '/calendar',
-  '/blog/42',
-  '/subject/12/collections',
-  '/subject/12/stats',
-  '/subject/topic/42',
-])('registers %s as a legacy route', (path) => {
-  const matches = matchRoutes(pageRoutes, path);
-  const element = matches?.at(-1)?.route.element;
-  expect(React.isValidElement(element)).toBe(true);
-  if (React.isValidElement(element)) {
-    expect(element.type).toBe(LegacyRedirect);
-  }
-});
+it.each(['/calendar', '/blog/42', '/subject/12/collections', '/subject/12/stats'])(
+  'registers %s as a legacy route',
+  (path) => {
+    const matches = matchRoutes(pageRoutes, path);
+    const element = matches?.at(-1)?.route.element;
+    expect(React.isValidElement(element)).toBe(true);
+    if (React.isValidElement(element)) {
+      expect(element.type).toBe(LegacyRedirect);
+    }
+  },
+);
+
+it.each(['/subject/topic/42', '/subject/ep/42'])(
+  'forwards %s to the new frontend instead of the legacy site',
+  (path) => {
+    const matches = matchRoutes(pageRoutes, path);
+    const element = matches?.at(-1)?.route.element;
+    expect(React.isValidElement(element)).toBe(true);
+    if (React.isValidElement(element)) {
+      expect(element.type).not.toBe(LegacyRedirect);
+    }
+  },
+);
 
 it('keeps unknown paths on the not-found route', () => {
   const matches = matchRoutes(pageRoutes, '/not-a-known-page');

--- a/packages/website/src/routes.tsx
+++ b/packages/website/src/routes.tsx
@@ -1,5 +1,6 @@
 import React, { lazy } from 'react';
 import type { RouteObject } from 'react-router-dom';
+import { Navigate, useParams } from 'react-router-dom';
 
 import LegacyRedirect from './components/PageRoutes/LegacyRedirect';
 
@@ -76,13 +77,23 @@ const legacyPagePaths = [
   'onair',
   'subject/:id/collections',
   'subject/:id/stats',
-  'subject/ep/:id',
   'subject/tag/:tag',
-  'subject/topic/:id',
   'tokei',
   'user/:username/timeline/status/:id',
   'wiki',
 ] as const;
+
+/** 旧版条目页剧集 URL 转发到新版 ep/:id */
+const EpisodeRedirect: React.FC = () => {
+  const { id } = useParams();
+  return <Navigate to={`/ep/${id}`} replace />;
+};
+
+/** 旧版条目讨论区话题 URL 转发到新版 /group/topic/:id */
+const TopicRedirect: React.FC = () => {
+  const { id } = useParams();
+  return <Navigate to={`/group/topic/${id}`} replace />;
+};
 
 export const pageRoutes: RouteObject[] = [
   {
@@ -90,6 +101,8 @@ export const pageRoutes: RouteObject[] = [
     element: <RootIndex />,
     children: [
       ...legacyPagePaths.map((path) => ({ path, element: <LegacyRedirect /> })),
+      { path: 'subject/ep/:id', element: <EpisodeRedirect /> },
+      { path: 'subject/topic/:id', element: <TopicRedirect /> },
       { path: '*', element: <MatchAll /> },
       { path: '', element: <HomeIndex /> },
       {


### PR DESCRIPTION
## 背景

e2e 测试此前依赖真实后端（next.bgm.tv）+ 真实账号登录，CI 一直禁用（`if: false`）。本次拆分：

## 变更

**fixtures 组（离线可跑）**
- 新增 `e2e/common/fixtures.ts`：`useFixtures(page)` 用 `page.route` 拦截 `/p1/` 请求，从 `src/mocks/fixtures/p1/` 读 JSON 响应（与 `scripts/screenshot.mjs --use-fixtures` 同机制），未匹配的请求 abort 不透传
- `main.spec.ts` 全 fixtures 化：登录态用 `/p1/me` fixture 模拟，无需真实账号
- `404.spec.ts` 挂 `useFixtures`
- 8 个测试离线全过（不依赖任何外部服务）

**server 组（保留待集成）**
- `group.spec.ts`（登录/发帖/回复）+ `auth.setup.ts`（真实登录）文件保留，修正过时断言（删 `page.pause()`、「退出该小组」）
- `playwright.config.ts` 中 `setup`/`server` project 注释保留，后续接 server-private 时恢复

**其他**
- 旧 URL 转发：已实现的 `subject/ep/:id` → `/ep/:id`、`subject/topic/:id` → `/group/topic/:id`，从 `legacyPagePaths` 移除（不再跳旧站）
- 启用 CI e2e job（去掉 `if: false`），跑 fixtures 组 + 上传 report
- `.prettierignore` 忽略 playwright 产物

## 验证

- `pnpm test:e2e`（fixtures 组）：8 通过，离线 4.6s
- `pnpm test` 354 通过、type-check/lint/prettier 通过