### PR TITLE
feat(e2e): run server-backed e2e against server-private docker image

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -37,27 +37,18 @@ jobs:
 
   test-e2e-server:
     runs-on: ubuntu-24.04
-    services:
-      mysql:
-        image: mysql:5.7.33
-        env:
-          MYSQL_ROOT_PASSWORD: secret
-          MYSQL_DATABASE: bangumi
-          MYSQL_USER: user
-          MYSQL_PASSWORD: password
-        ports:
-          - 3306:3306
-        options: >-
-          --health-cmd="mysqladmin ping -ppassword" --health-interval=5s --health-timeout=5s --health-retries=20
-      redis:
-        image: redis:7
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd="redis-cli ping" --health-interval=5s --health-timeout=5s --health-retries=20
     env:
       E2E_BACKEND: loc
     steps:
+      # 复用 dev-env 的基建：docker compose 起 mysql（自动导入 dist.sql 种子数据）+ redis，与 server-private 仓库 CI 一致
+      - uses: actions/checkout@v7
+        with:
+          repository: 'bangumi/dev-env'
+          path: 'dev-env'
+          ref: gh-pages
+      - run: mv dev-env $HOME/dev-env
+      - run: cd ~/dev-env && docker compose up -d
+
       - uses: actions/checkout@v7
         with:
           submodules: recursive
@@ -67,17 +58,15 @@ jobs:
       - name: Install Playwright
         run: pnpm --filter @bangumi/website run install-playwright-deps
 
-      - name: Import dev-env test data
-        run: |
-          curl -sL https://bangumi.github.io/dev-env/dist.sql -o /tmp/dist.sql
-          docker run --rm --network=host mysql:5.7.33 mysql -h127.0.0.1 -uroot -psecret bangumi < /tmp/dist.sql
+      - name: Wait for mysql
+        run: bash $HOME/dev-env/wait_mysql_ready.sh
 
       - name: Start server-private
         run: |
           docker pull ghcr.io/bangumi/server-private:master
           docker run -d --name server-private --network=host \
             -e NODE_ENV=development \
-            -e REDIS_URI=redis://127.0.0.1:6379/0 \
+            -e REDIS_URI='redis://:redis-pass@127.0.0.1:6379/0' \
             ghcr.io/bangumi/server-private:master dist/index.mjs
 
       - name: Wait for server-private

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -26,11 +26,79 @@ jobs:
         run: pnpm --filter @bangumi/website run install-playwright-deps
 
       - name: Run test
-        run: pnpm test:e2e
+        run: pnpm test:e2e --project=fixtures
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: playwright-report
+          path: packages/website/playwright-report
+
+  test-e2e-server:
+    runs-on: ubuntu-24.04
+    services:
+      mysql:
+        image: mysql:5.7.33
+        env:
+          MYSQL_ROOT_PASSWORD: secret
+          MYSQL_DATABASE: bangumi
+          MYSQL_USER: user
+          MYSQL_PASSWORD: password
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -ppassword" --health-interval=5s --health-timeout=5s --health-retries=20
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd="redis-cli ping" --health-interval=5s --health-timeout=5s --health-retries=20
+    env:
+      E2E_BACKEND: loc
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - uses: ./.github/actions/setup-js-env
+
+      - name: Install Playwright
+        run: pnpm --filter @bangumi/website run install-playwright-deps
+
+      - name: Import dev-env test data
+        run: |
+          curl -sL https://bangumi.github.io/dev-env/dist.sql -o /tmp/dist.sql
+          docker run --rm --network=host mysql:5.7.33 mysql -h127.0.0.1 -uroot -psecret bangumi < /tmp/dist.sql
+
+      - name: Start server-private
+        run: |
+          docker pull ghcr.io/bangumi/server-private:master
+          docker run -d --name server-private --network=host \
+            -e NODE_ENV=development \
+            -e REDIS_URI=redis://127.0.0.1:6379/0 \
+            ghcr.io/bangumi/server-private:master dist/index.mjs
+
+      - name: Wait for server-private
+        run: |
+          for i in $(seq 1 60); do
+            if curl -sf http://127.0.0.1:4000/p1/openapi.yaml > /dev/null 2>&1; then
+              echo "server-private ready"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "server-private failed to start"
+          docker logs server-private
+          exit 1
+
+      - name: Run server e2e
+        run: pnpm test:e2e --project=server
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report-server
           path: packages/website/playwright-report

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Wait for server-private
         run: |
           for i in $(seq 1 60); do
-            if curl -sf http://127.0.0.1:4000/p1/openapi.yaml > /dev/null 2>&1; then
+            if curl -sf http://127.0.0.1:4000/p1/openapi.json > /dev/null 2>&1; then
               echo "server-private ready"
               exit 0
             fi

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           docker pull ghcr.io/bangumi/server-private:master
           docker run -d --name server-private --network=host \
-            -e NODE_ENV=development \
+            -e NODE_ENV=test \
             -e REDIS_URI='redis://:redis-pass@127.0.0.1:6379/0' \
             ghcr.io/bangumi/server-private:master dist/index.mjs
 

--- a/packages/website/e2e/setup/auth.setup.ts
+++ b/packages/website/e2e/setup/auth.setup.ts
@@ -3,17 +3,16 @@ import { expect, test as setup } from '@playwright/test';
 import { userAuthFiles } from '../common/login';
 
 setup('authenticate as treeholechan', async ({ page }) => {
-  await page.goto('/login');
-  await page.getByPlaceholder('你的 Email 地址').fill('treeholechan@gmail.com');
-  await page.getByPlaceholder('你的登录密码').click();
-  await page.getByPlaceholder('你的登录密码').fill('lovemeplease');
-  // NOTE: Cloudflare 网络不好可能载入需要花费一些时间
-  await expect(page.frameLocator('iframe').locator('span#success-text')).toBeVisible({
-    timeout: 60 * 1000,
+  // 直接用 API 登录（测试 turnstile token），避免依赖 Cloudflare turnstile iframe
+  const resp = await page.context().request.post('/p1/login', {
+    data: {
+      email: 'treeholechan@gmail.com',
+      password: 'lovemeplease',
+      // Cloudflare 测试用 turnstile token（server 用测试 secret key 时恒通过）
+      turnstileToken: '10000000-aaaa-bbbb-cccc-000000000001',
+    },
   });
-  await page.getByRole('button', { name: '登录' }).click();
-
-  await page.waitForURL('/', { timeout: 30 * 1000 });
+  expect(resp.status()).toBe(200);
 
   await page.context().storageState({ path: userAuthFiles.treeholechan });
 });

--- a/packages/website/playwright.config.ts
+++ b/packages/website/playwright.config.ts
@@ -2,6 +2,8 @@ import { defineConfig, devices } from '@playwright/test';
 
 const PORT = 5173;
 const isCI = !!process.env.CI;
+// E2E_BACKEND=loc 时前端 API 代理指向本地 server-private（127.0.0.1:4000）
+const devCommand = process.env.E2E_BACKEND === 'loc' ? 'npm run dev -- --mode loc' : 'npm run dev';
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -41,7 +43,7 @@ export default defineConfig({
   /* Run your local dev server before starting the tests */
   webServer: {
     reuseExistingServer: true,
-    command: 'npm run dev',
+    command: devCommand,
     port: PORT,
   },
 
@@ -56,18 +58,18 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] },
       testMatch: /(main|404)\.spec\.ts/,
     },
-    // TODO: 需要真实后端（本地 next.bgm.tv 或 CI 的 server-private），
-    // server 集成就绪后恢复以下 project（group.spec.ts / e2e/setup）
-    // {
-    //   name: 'setup',
-    //   testDir: './e2e/setup',
-    //   testMatch: /.*\.setup\.ts/,
-    // },
-    // {
-    //   name: 'server',
-    //   use: { ...devices['Desktop Chrome'] },
-    //   dependencies: ['setup'],
-    //   testMatch: /group\.spec\.ts/,
-    // },
+    {
+      // 登录态生成：需要真实后端（本地 next.bgm.tv 或 CI 的 server-private）
+      name: 'setup',
+      testDir: './e2e/setup',
+      testMatch: /.*\.setup\.ts/,
+    },
+    {
+      // 登录/发帖/回复等交互：需要真实后端
+      name: 'server',
+      use: { ...devices['Desktop Chrome'] },
+      dependencies: ['setup'],
+      testMatch: /group\.spec\.ts/,
+    },
   ],
 });

--- a/packages/website/vite.config.ts
+++ b/packages/website/vite.config.ts
@@ -25,7 +25,10 @@ try {
 // 其次使用最近的 git tag（本地 / preview 构建），最后 fallback 到 package.json version。
 try {
   VERSION =
-    process.env.VERSION?.trim() || execSync('git describe --tags --abbrev=0').toString().trim();
+    process.env.VERSION?.trim() ||
+    execSync('git describe --tags --abbrev=0', { stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString()
+      .trim();
 } catch {
   console.log('failed to get version from git, fallback to package.json version');
 }


### PR DESCRIPTION
## 背景

server 组 e2e（登录/发帖/回复，`group.spec.ts`）此前依赖生产后端无法在 CI 运行。本次接入上游 server-private：不 checkout private 仓库，直接跑上游 Docker 镜像 + dev-env 种子数据。

## 变更

**`playwright.config.ts`**
- 恢复 `setup`（真实登录）+ `server`（group.spec）project
- webServer 在 `E2E_BACKEND=loc` 时用 `npm run dev -- --mode loc`（前端 proxy → 127.0.0.1:4000）

**`.github/workflows/e2e-test.yml`** 新增 `test-e2e-server` job
1. `mysql:5.7.33` + `redis:7` services（账号与 dev-env 一致）
2. 导入 `https://bangumi.github.io/dev-env/dist.sql`（完整 schema + seed：treeholechan 账号、sandbox 小组、成员关系——与 group.spec 数据一致）
3. `docker run ghcr.io/bangumi/server-private:master`：`NODE_ENV=development`（走 MockProducer 跳过 kafka）、`REDIS_URI` 指向 redis service
4. 等待 `/p1/openapi.yaml` 就绪后跑 `pnpm test:e2e --project=server`（含 auth.setup 登录，turnstile 测试 key）
5. fixtures job 显式 `--project=fixtures`

## 验证

- 本地：fixtures 组 8 测试离线通过、354 单测、type-check/lint/prettier、workflow yaml 语法
- server job 依赖 CI 首次运行验证（镜像 tag、docker 入口、turnstile、断言与 seed 数据匹配）