### PR TITLE
fix(website): send real turnstile tokens when posting/reply/say

### DIFF
--- a/packages/design/components/EditorForm/index.tsx
+++ b/packages/design/components/EditorForm/index.tsx
@@ -21,6 +21,8 @@ export interface EditorFormProps extends EditorProps {
   cancelText?: string;
   /** 取消按钮的回调 */
   onCancel?: () => void;
+  /** 渲染在确认按钮右侧的额外内容（如验证码） */
+  submitExtra?: React.ReactNode;
   /**
    * 是否隐藏取消按钮
    * @default false
@@ -37,6 +39,7 @@ const EditorForm = forwardRef<HTMLTextAreaElement, EditorFormProps>(
       onConfirm,
       cancelText = '取消',
       onCancel,
+      submitExtra,
       hideCancel = false,
       ...props
     },
@@ -53,6 +56,7 @@ const EditorForm = forwardRef<HTMLTextAreaElement, EditorFormProps>(
           >
             {confirmText}
           </Button>
+          {submitExtra}
           {!hideCancel && (
             <Button type='text' className='bgm-editor__button' onClick={onCancel}>
               {cancelText}

--- a/packages/design/components/EditorForm/style/index.less
+++ b/packages/design/components/EditorForm/style/index.less
@@ -63,6 +63,8 @@
     flex-direction: column;
     align-items: flex-start;
     justify-content: flex-start;
+    // 允许在窄容器（如移动端）内收缩，避免内容按 max-content 撑开
+    min-width: 0;
   }
 
   &__submit {
@@ -72,6 +74,8 @@
     align-items: center;
     justify-content: flex-start;
     gap: 10px;
+    // 验证码等额外内容在窄屏放不下时换行，避免横向溢出
+    flex-wrap: wrap;
 
     .bgm-editor__bbcode-tip {
       color: @gray-60;

--- a/packages/design/components/Topic/ReplyForm.tsx
+++ b/packages/design/components/Topic/ReplyForm.tsx
@@ -1,7 +1,9 @@
+import { Turnstile } from '@marsidev/react-turnstile';
 import React, { memo, useState } from 'react';
 
 import { ozaClient } from '@bangumi/client';
 
+import { toast } from '../..';
 import type { EditorFormProps } from '../../components/EditorForm';
 import EditorForm from '../../components/EditorForm';
 
@@ -31,16 +33,21 @@ const ReplyForm = ({
   ...props
 }: ReplyFormProps) => {
   const [sending, setSending] = useState(false);
+  const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
 
   const sendReply = async () => {
     if (!content) return; // TODO: show validation message
     if (sending) return; // TODO: disable button instead
+    if (!turnstileToken) {
+      toast('请先完成验证码验证');
+      return;
+    }
     setSending(true);
     try {
       const response = await ozaClient.createGroupReply(topicId, {
         content,
         replyTo,
-        turnstileToken: '',
+        turnstileToken,
       });
       if (response.status === 200) {
         // document.getElementById(`post_${res.data.id}`)?.scrollIntoView({ block: 'center' });
@@ -56,16 +63,27 @@ const ReplyForm = ({
   };
 
   return (
-    <EditorForm
-      onCancel={onCancel}
-      placeholder={placeholder}
-      value={content}
-      // TODO: use loading state
-      confirmText={sending ? '...' : undefined}
-      onChange={onChange}
-      onConfirm={sendReply}
-      {...props}
-    />
+    <>
+      <EditorForm
+        onCancel={onCancel}
+        placeholder={placeholder}
+        value={content}
+        // TODO: use loading state
+        confirmText={sending ? '...' : undefined}
+        onChange={onChange}
+        onConfirm={sendReply}
+        submitExtra={
+          <Turnstile
+            options={{ theme: 'light', size: 'invisible', action: 'post_reply' }}
+            siteKey={import.meta.env.VITE_TURNSTILE_SITE_KEY}
+            onSuccess={setTurnstileToken}
+            onError={() => setTurnstileToken(null)}
+            onExpire={() => setTurnstileToken(null)}
+          />
+        }
+        {...props}
+      />
+    </>
   );
 };
 

--- a/packages/design/components/Topic/__test__/Comment.spec.tsx
+++ b/packages/design/components/Topic/__test__/Comment.spec.tsx
@@ -13,6 +13,17 @@ import singleComment from './fixtures/singleComment.json';
 import specialComment from './fixtures/specialComment.json';
 import mockedCurrentUser from './fixtures/user.json';
 
+// 测试环境没有 turnstile 脚本，mock 成自动通过的验证码
+vi.mock('@marsidev/react-turnstile', () => {
+  const Turnstile = ({ onSuccess }: { onSuccess?: (token: string) => void }) => {
+    React.useEffect(() => {
+      onSuccess?.('fake-token');
+    });
+    return <div />;
+  };
+  return { Turnstile };
+});
+
 function render(component: React.ReactElement, routerEntries?: string[]) {
   return _render(<MemoryRouter initialEntries={routerEntries}>{component}</MemoryRouter>);
 }

--- a/packages/design/package.json
+++ b/packages/design/package.json
@@ -9,7 +9,8 @@
     "eventemitter3": "^5.0.4",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "reset-css": "^5.0.2"
+    "reset-css": "^5.0.2",
+    "@marsidev/react-turnstile": "^1.5.2"
   },
   "devDependencies": {
     "@bangumi/client": "workspace:0.0.0",

--- a/packages/styled-system/styles.css
+++ b/packages/styled-system/styles.css
@@ -2593,6 +2593,10 @@
     height: 100%;
 }
 
+  .\[\&_div\]\:h_78px div {
+    height: 78px;
+}
+
   .before\:top_-5px::before {
     top: -5px;
 }
@@ -2667,10 +2671,6 @@
 
   .\[\&_\>_\.bgm-menu-item\]\:w_100\% > .bgm-menu-item,.\[\&_\>_\*\]\:w_100\% > * {
     width: 100%;
-}
-
-  .\[\&_div\]\:h_78px div {
-    height: 78px;
 }
 
   .last\:mb_0:last-child {

--- a/packages/website/src/components/TurnstileCaptcha.tsx
+++ b/packages/website/src/components/TurnstileCaptcha.tsx
@@ -1,0 +1,39 @@
+import { Turnstile } from '@marsidev/react-turnstile';
+import React from 'react';
+
+import { css } from '@bangumi/styled-system/css';
+
+const wrapper = css({
+  display: 'flex',
+  justifyContent: 'center',
+  '& div': {
+    height: '78px',
+  },
+});
+
+interface TurnstileCaptchaProps {
+  /** turnstile action，用于 Cloudflare 后台区分场景 */
+  action: string;
+  /** 验证成功回调，token 失效（过期/错误）时回调 null */
+  onToken: (token: string | null) => void;
+}
+
+/**
+ * Cloudflare Turnstile 验证码，site key 与登录页一致（由环境注入）。
+ * dev 环境使用测试 key，自动通过无需交互。
+ */
+const TurnstileCaptcha: React.FC<TurnstileCaptchaProps> = ({ action, onToken }) => {
+  return (
+    <div className={wrapper}>
+      <Turnstile
+        options={{ theme: 'light', size: 'invisible', action }}
+        siteKey={import.meta.env.VITE_TURNSTILE_SITE_KEY}
+        onSuccess={onToken}
+        onError={() => onToken(null)}
+        onExpire={() => onToken(null)}
+      />
+    </div>
+  );
+};
+
+export default TurnstileCaptcha;

--- a/packages/website/src/pages/index/group/components/TopicForm.tsx
+++ b/packages/website/src/pages/index/group/components/TopicForm.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import { ozaClient } from '@bangumi/client';
 import { EditorForm, Form, Input, toast } from '@bangumi/design';
 import { css } from '@bangumi/styled-system/css';
+import TurnstileCaptcha from '@bangumi/website/components/TurnstileCaptcha';
 import type { UseGroupTopicRet } from '@bangumi/website/hooks/use-group-topic';
 
 interface FormData {
@@ -62,11 +63,16 @@ const TopicForm = ({ quickPost = false, groupName, topic }: TopicFormProps) => {
     defaultValues: topic?.data as FormData | undefined,
   });
   const [sending, setSending] = useState(false);
+  const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
 
   const postNewTopic = async (data: FormData, groupName: string) => {
+    if (!turnstileToken) {
+      toast('请先完成验证码验证');
+      return;
+    }
     const response = await ozaClient.createGroupTopic(groupName, {
       ...data,
-      turnstileToken: '',
+      turnstileToken,
     });
     if (response.status === 200) {
       navigate(`/group/topic/${response.data.id}`);
@@ -121,6 +127,7 @@ const TopicForm = ({ quickPost = false, groupName, topic }: TopicFormProps) => {
           onConfirm={async () => handleSubmit(onSubmit, showErrors)()}
           // TODO: use loading state
           confirmText={sending ? '...' : quickPost ? '快速发帖' : undefined}
+          submitExtra={<TurnstileCaptcha action='post_topic' onToken={setTurnstileToken} />}
           rows={!quickPost ? 15 : undefined}
           {...field}
         />

--- a/packages/website/src/pages/index/index/components/TimelineBlock.tsx
+++ b/packages/website/src/pages/index/index/components/TimelineBlock.tsx
@@ -13,6 +13,7 @@ import {
   getSubjectLink,
   getUserProfileLink,
 } from '@bangumi/utils/pages';
+import TurnstileCaptcha from '@bangumi/website/components/TurnstileCaptcha';
 import { useHomePage } from '@bangumi/website/hooks/use-home-page';
 
 import styles from './TimelineBlock.module.less';
@@ -400,6 +401,7 @@ const TimelineBlock: React.FC<{ timeline: Timeline[] }> = ({ timeline }) => {
   const [filter, setFilter] = useState<TimelineFilter>('all');
   const [content, setContent] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
 
   const filtered = timeline.filter((item) => matchesFilter(item, filter));
   const grouped = new Map<string, Timeline[]>();
@@ -414,9 +416,13 @@ const TimelineBlock: React.FC<{ timeline: Timeline[] }> = ({ timeline }) => {
     if (!value || submitting) {
       return;
     }
+    if (!turnstileToken) {
+      toast('请先完成验证码验证');
+      return;
+    }
     setSubmitting(true);
     try {
-      await ok(ozaClient.createTimelineSay({ content: value, turnstileToken: '' }));
+      await ok(ozaClient.createTimelineSay({ content: value, turnstileToken }));
       setContent('');
       await mutate();
     } catch (error) {
@@ -459,6 +465,7 @@ const TimelineBlock: React.FC<{ timeline: Timeline[] }> = ({ timeline }) => {
           >
             写好了
           </button>
+          <TurnstileCaptcha action='post_timeline' onToken={setTurnstileToken} />
         </div>
       </form>
       {grouped.size === 0 ? (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,6 +183,9 @@ importers:
       '@bangumi/styled-system':
         specifier: workspace:0.0.0
         version: link:../styled-system
+      '@marsidev/react-turnstile':
+        specifier: ^1.5.2
+        version: 1.5.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       dayjs:
         specifier: ^1.11.21
         version: 1.11.21


### PR DESCRIPTION
## 背景

`TopicForm`、`ReplyForm`、时间线吐槽框硬编码 `turnstileToken: ''`，生产环境（server 校验 token）下发帖/回复/发吐槽全部被拒。

## 变更

- 新增共享组件 `TurnstileCaptcha`（website）：封装 `@marsidev/react-turnstile`，`size: 'invisible'`（无 UI 自动验证），site key 用 `VITE_TURNSTILE_SITE_KEY`（与登录页一致），处理 onError/onExpire
- `TopicForm`（发帖）/ `TimelineBlock`（吐槽）：widget 渲染在提交按钮右侧，提交前校验 token（缺失 toast 提示）
- `ReplyForm`（design）：自包含管理 token，所有调用方（话题详情页、`Comment` 内联回复弹窗）自动生效；`@marsidev/react-turnstile` 加入 design 依赖
- `EditorForm`（design）：新增 `submitExtra` prop（确认按钮右侧）；`.bgm-editor__form` 加 `min-width: 0`、`.bgm-editor__submit` 加 `flex-wrap: wrap`，修复移动端 editor 横向溢出
- `Comment.spec`：mock turnstile（测试环境无 Cloudflare 脚本）

## 验证

- `/group/topic/430381` 1280px 与 375px 均无横向溢出；invisible 模式提交区无验证码 UI
- `pnpm test` 354 通过、type-check/lint/prettier/build 通过、fixtures e2e 8 个通过