### PR TITLE
fix(website): collections tab mobile overflow and header avatar overlap

### DIFF
--- a/packages/styled-system/styles.css
+++ b/packages/styled-system/styles.css
@@ -1641,8 +1641,8 @@
     color: #54b5df !important;
 }
 
-  .grid-tc_repeat\(5\,_1fr\) {
-    grid-template-columns: repeat(5, 1fr);
+  .grid-tc_repeat\(5\,_minmax\(0\,_1fr\)\) {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
 }
 
   .page_1 {

--- a/packages/website/src/pages/index/user/collections/[username]/components/CollectionGroup.tsx
+++ b/packages/website/src/pages/index/user/collections/[username]/components/CollectionGroup.tsx
@@ -36,7 +36,8 @@ const coverList = css({
   margin: '0',
   padding: '0',
   display: 'grid',
-  gridTemplateColumns: 'repeat(5, 1fr)',
+  // minmax(0, 1fr) 允许列收缩到容器宽度，避免封面图固有宽度撑开网格
+  gridTemplateColumns: 'repeat(5, minmax(0, 1fr))',
   gap: '10px',
 });
 
@@ -123,7 +124,8 @@ const CollectionGroupItem: React.FC<{
       <ul className={coverList}>
         {data.map((subject) => (
           <li key={subject.id} className={coverItem}>
-            <Link to={getSubjectLink(subject.id)} title={subject.nameCN || subject.name}>
+            {/* noStyle：.bgm-link 的 less 样式（display: inline-block）会覆盖 coverItem 的 display: block，导致封面按内容宽度撑开 */}
+            <Link to={getSubjectLink(subject.id)} noStyle title={subject.nameCN || subject.name}>
               <Image src={subject.images?.medium ?? ''} alt={subject.nameCN || subject.name} />
               <span className={coverName}>{subject.nameCN || subject.name}</span>
             </Link>

--- a/packages/website/src/pages/index/user/collections/[username]/index.tsx
+++ b/packages/website/src/pages/index/user/collections/[username]/index.tsx
@@ -53,6 +53,8 @@ const columns = css({
   gap: '20px',
   '@media (max-width: 768px)': {
     flexDirection: 'column',
+    // 单列时让子项占满容器宽度，避免内容按 max-content 撑开导致横向溢出
+    alignItems: 'stretch',
   },
 });
 

--- a/packages/website/src/pages/index/user/components/UserHeader.module.less
+++ b/packages/website/src/pages/index/user/components/UserHeader.module.less
@@ -122,9 +122,9 @@
   }
 
   .avatar {
-    flex-basis: 88px;
-    width: 88px;
-    height: 88px;
+    flex-basis: 64px;
+    width: 64px;
+    height: 64px;
   }
 
   .nickname {
@@ -145,7 +145,8 @@
   }
 
   .tabs {
-    margin-left: 100px;
+    // 头像 64px + 容器 padding 16px
+    margin-left: 80px;
 
     a {
       padding: 0 12px;


### PR DESCRIPTION
## 背景

用户主页「收藏」tab 在移动端横向溢出 + 头部头像覆盖 tab 栏。

## 变更

**收藏页移动端溢出**
- `columns` 移动端堆叠单列时仍 `align-items: flex-start`（与 #1017 用户主页同类问题）→ 改 `stretch`
- 封面网格 `repeat(5, 1fr)` → `repeat(5, minmax(0, 1fr))`（1fr 默认 `minmax(auto, 1fr)` 被封面固有宽度撑开）
- 封面链接 `noStyle`：`coverItem` 的 Panda `display: block` 被未分层的 `.bgm-link` less `inline-block` 覆盖，导致封面按内容宽度（~108-143px）而非 grid 列宽渲染

**头像覆盖 tab 栏**
- 移动端（≤md）头像 88px 超出 72px 的 profile 容器，向下覆盖 tab 栏顶部 → 缩至 64px，tab 起始 `margin-left` 100→80px

## 验证

- 5 个收藏类型页 + statusType + 其他用户 + 桌面端：`scrollWidth == clientWidth`
- 移动端头像 bottom 121 < tab 栏 top 122（无重叠），截图确认布局协调
- `pnpm test` 354 通过、type-check/lint/prettier/build 通过、fixtures e2e 8 个通过