### PR TITLE
feat(website): add shared episode button with collection status styles

### DIFF
--- a/packages/styled-system/styles.css
+++ b/packages/styled-system/styles.css
@@ -548,6 +548,34 @@
     margin: 2px 0 0;
 }
 
+  .p_0_4px {
+    padding: 0 4px;
+}
+
+  .bd_1px_solid_\#e8e3e3 {
+    border: 1px solid #e8e3e3;
+}
+
+  .bg_\#daeaff {
+    background: #daeaff;
+}
+
+  .bg_\#4897ff {
+    background: #4897ff;
+}
+
+  .bg_\#ffadd1 {
+    background: #ffadd1;
+}
+
+  .bg_\#ccc {
+    background: #ccc;
+}
+
+  .bg_\#e0e0e0 {
+    background: #e0e0e0;
+}
+
   .bg_rgba\(254\,_254\,_254\,_0\.96\) {
     background: rgba(254, 254, 254, 0.96);
 }
@@ -808,10 +836,6 @@
     padding: 7px 16px;
 }
 
-  .bd_1px_solid_\#e8e3e3 {
-    border: 1px solid #e8e3e3;
-}
-
   .m_0_0_0_132px {
     margin: 0 0 0 132px;
 }
@@ -1056,6 +1080,38 @@
     flex: 1 1 auto;
 }
 
+  .bdr_3px {
+    border-radius: 3px;
+}
+
+  .td_none {
+    text-decoration: none;
+}
+
+  .bd-c_\#00a8ff {
+    border-color: #00a8ff;
+}
+
+  .bd-c_\#4897ff {
+    border-color: #4897ff;
+}
+
+  .bd-c_\#ff2293 {
+    border-color: #ff2293;
+}
+
+  .bd-c_\#666 {
+    border-color: #666;
+}
+
+  .td_line-through {
+    text-decoration: line-through;
+}
+
+  .bd-c_\#b6b6b6 {
+    border-color: #b6b6b6;
+}
+
   .bdr_5px {
     border-radius: 5px;
 }
@@ -1094,10 +1150,6 @@
 
   .ring_none {
     outline: var(--borders-none);
-}
-
-  .td_none {
-    text-decoration: none;
 }
 
   .bdr_9999px {
@@ -1300,10 +1352,6 @@
     margin-block: 20px;
 }
 
-  .bdr_3px {
-    border-radius: 3px;
-}
-
   .gap_18px {
     gap: 18px;
 }
@@ -1400,6 +1448,34 @@
     display: inline-block;
 }
 
+  .bx-s_border-box {
+    box-sizing: border-box;
+}
+
+  .ta_center {
+    text-align: center;
+}
+
+  .lh_22px {
+    line-height: 22px;
+}
+
+  .c_\#0066cc {
+    color: #0066cc;
+}
+
+  .c_\#fff {
+    color: #fff;
+}
+
+  .c_\#ff2293 {
+    color: #ff2293;
+}
+
+  .c_\#909090 {
+    color: #909090;
+}
+
   .va_top {
     vertical-align: top;
 }
@@ -1410,10 +1486,6 @@
 
   .ai_center {
     align-items: center;
-}
-
-  .c_\#fff {
-    color: #fff;
 }
 
   .lh_18px {
@@ -1470,10 +1542,6 @@
 
   .fw_400 {
     font-weight: 400;
-}
-
-  .bx-s_border-box {
-    box-sizing: border-box;
 }
 
   .bg-c_\#f47a81 {
@@ -1842,10 +1910,6 @@
     line-height: 150%;
 }
 
-  .ta_center {
-    text-align: center;
-}
-
   .bd-cl_collapse {
     border-collapse: collapse;
 }
@@ -1914,10 +1978,6 @@
     visibility: hidden;
 }
 
-  .lh_22px {
-    line-height: 22px;
-}
-
   .fs_0\.75rem {
     font-size: 0.75rem;
 }
@@ -1980,6 +2040,14 @@
 
   .w_100\% {
     width: 100%;
+}
+
+  .min-w_24px {
+    min-width: 24px;
+}
+
+  .h_24px {
+    height: 24px;
 }
 
   .min-h_31px {
@@ -2576,10 +2644,6 @@
 
   .w_24px {
     width: 24px;
-}
-
-  .h_24px {
-    height: 24px;
 }
 
   .\[\&_\.bgm-popover__content\]\:bd_0 .bgm-popover__content {
@@ -3622,7 +3686,7 @@
     max-width: 100%;
 }
 
-  .\[\&\:link\,_\&\:visited\,_\&\:active\]\:td_none:link,.\[\&\:link\,_\&\:visited\,_\&\:active\]\:td_none:visited,.\[\&\:link\,_\&\:visited\,_\&\:active\]\:td_none:active {
+  .\[\&\:link\,_\&\:visited\,_\&\:active\]\:td_none:link,.\[\&\:link\,_\&\:visited\,_\&\:active\]\:td_none:visited,.\[\&\:link\,_\&\:visited\,_\&\:active\]\:td_none:active,.focusVisible\:td_none:is(:focus-visible, [data-focus-visible]) {
     text-decoration: none;
 }
 
@@ -4080,6 +4144,9 @@
 }
 
   @media (max-width: 640px) {
+    .\[\@media_\(max-width\:_640px\)\]\:p_1px_3px {
+      padding: 1px 3px;
+}
     .\[\@media_\(max-width\:_640px\)\]\:p_12px {
       padding: 12px;
 }
@@ -4094,6 +4161,9 @@
 }
     .\[\@media_\(max-width\:_640px\)\]\:flex_0_0_20vw {
       flex: 0 0 20vw;
+}
+    .\[\@media_\(max-width\:_640px\)\]\:fs_11px {
+      font-size: 11px;
 }
     .\[\@media_\(max-width\:_640px\)\]\:order_2 {
       order: 2;
@@ -4127,6 +4197,9 @@
 }
     .\[\@media_\(max-width\:_640px\)\]\:fs_14px {
       font-size: 14px;
+}
+    .\[\@media_\(max-width\:_640px\)\]\:min-w_22px {
+      min-width: 22px;
 }
     .\[\@media_\(max-width\:_640px\)\]\:w_auto {
       width: auto;

--- a/packages/website/src/components/EpisodeButton/index.tsx
+++ b/packages/website/src/components/EpisodeButton/index.tsx
@@ -1,0 +1,139 @@
+import dayjs from 'dayjs';
+import React from 'react';
+
+import type { Episode, UpdateEpisodeProgress } from '@bangumi/client/client';
+import { EpisodeCollectionStatus } from '@bangumi/client/client';
+import { Typography } from '@bangumi/design';
+import { css, cx } from '@bangumi/styled-system/css';
+import { getEpisodeLink } from '@bangumi/utils/pages';
+
+import EpisodeProgressPopover from '../EpisodeProgressPopover';
+
+const { Link } = Typography;
+
+const epBtn = css({
+  display: 'inline-block',
+  minWidth: '24px',
+  height: '24px',
+  boxSizing: 'border-box',
+  padding: '0 4px',
+  textAlign: 'center',
+  border: '1px solid #e8e3e3',
+  borderRadius: '3px',
+  fontSize: '12px',
+  lineHeight: '22px',
+  color: '#1f1c1c',
+  textDecoration: 'none',
+  _hover: { textDecoration: 'none' },
+  _focusVisible: { textDecoration: 'none' },
+  '@media (max-width: 640px)': {
+    minWidth: '22px',
+    padding: '1px 3px',
+    fontSize: '11px',
+  },
+});
+
+// noStyle：章节按钮不依赖 .bgm-link 的全局链接色（如首页容器统一 #0084b4），
+// 也避免非分层 less 覆盖 Panda layer 的优先级问题
+
+/** 已放送且未收藏：浅蓝底蓝字，对齐 PHP epBtnAir */
+const epAired = css({
+  borderColor: '#00a8ff',
+  background: '#daeaff',
+  color: '#0066cc',
+});
+
+/** 看过：深蓝实心白字，对齐 PHP epBtnWatched */
+const epDone = css({
+  background: '#4897ff',
+  borderColor: '#4897ff',
+  color: '#fff',
+});
+
+/** 想看：粉色底粉字，对齐 PHP epBtnQueue */
+const epQueue = css({
+  borderColor: '#ff2293',
+  background: '#ffadd1',
+  color: '#ff2293',
+});
+
+/** 抛弃：灰底白字 + 删除线，对齐 PHP epBtnDrop */
+const epDrop = css({
+  background: '#ccc',
+  borderColor: '#666',
+  color: '#fff',
+  textDecoration: 'line-through',
+});
+
+/** 未放送：浅灰底灰字，对齐 PHP epBtnNA */
+const epUpcoming = css({
+  borderColor: '#b6b6b6',
+  background: '#e0e0e0',
+  color: '#909090',
+});
+
+const EPISODE_STATUS_KEYS: Record<EpisodeCollectionStatus, string> = {
+  [EpisodeCollectionStatus.None]: 'none',
+  [EpisodeCollectionStatus.Wish]: 'wish',
+  [EpisodeCollectionStatus.Done]: 'done',
+  [EpisodeCollectionStatus.Dropped]: 'dropped',
+};
+
+export interface EpisodeButtonProps {
+  episode: Episode;
+  canManage?: boolean;
+  submitting: boolean;
+  onUpdate: (body: UpdateEpisodeProgress) => void;
+}
+
+/**
+ * 章节按钮：条目页与首页进度管理器共用。
+ * 收藏状态优先于放送时间决定样式（对齐 PHP subject_box_prg / home_prg_item_eps），
+ * 点击跳转章节页，浮层内可修改进度。
+ */
+const EpisodeButton: React.FC<EpisodeButtonProps> = ({
+  episode,
+  canManage = true,
+  submitting,
+  onUpdate,
+}) => {
+  const status = episode.collection?.status;
+  const upcoming =
+    episode.airdate !== '' &&
+    dayjs(episode.airdate).isValid() &&
+    dayjs(episode.airdate).isAfter(dayjs(), 'day');
+  const statusClass =
+    status === EpisodeCollectionStatus.Done
+      ? epDone
+      : status === EpisodeCollectionStatus.Dropped
+        ? epDrop
+        : status === EpisodeCollectionStatus.Wish
+          ? epQueue
+          : upcoming
+            ? epUpcoming
+            : epAired;
+
+  return (
+    <EpisodeProgressPopover
+      episode={episode}
+      canManage={canManage}
+      submitting={submitting}
+      onUpdate={onUpdate}
+    >
+      {(triggerProps) => (
+        <Link
+          {...triggerProps}
+          to={getEpisodeLink(episode.id)}
+          noStyle
+          className={cx(epBtn, statusClass)}
+          title={`ep.${episode.sort} ${episode.name || episode.nameCN}`}
+          data-episode-status={status === undefined ? 'none' : EPISODE_STATUS_KEYS[status]}
+        >
+          {String(episode.sort).padStart(2, '0')}
+        </Link>
+      )}
+    </EpisodeProgressPopover>
+  );
+};
+
+export default EpisodeButton;

--- a/packages/website/src/pages/index/index/HomePage.spec.tsx
+++ b/packages/website/src/pages/index/index/HomePage.spec.tsx
@@ -278,11 +278,11 @@ describe('HomePage', () => {
     await waitFor(() => {
       expect(screen.getAllByTitle(/^ep\.\d+ /)).toHaveLength(12);
     });
-    // 已看集数标记为 pressed，未看集数不是
-    expect(screen.getByTitle('ep.1 第1话')).toHaveAttribute('aria-pressed', 'true');
-    expect(screen.getByTitle('ep.5 第5话')).toHaveAttribute('aria-pressed', 'true');
-    expect(screen.getByTitle('ep.6 第6话')).toHaveAttribute('aria-pressed', 'false');
-    expect(screen.getByTitle('ep.12 第12话')).toHaveAttribute('aria-pressed', 'false');
+    // 已看集数标记为已收藏，未看集数不是
+    expect(screen.getByTitle('ep.1 第1话')).toHaveAttribute('data-episode-status', 'done');
+    expect(screen.getByTitle('ep.5 第5话')).toHaveAttribute('data-episode-status', 'done');
+    expect(screen.getByTitle('ep.6 第6话')).toHaveAttribute('data-episode-status', 'none');
+    expect(screen.getByTitle('ep.12 第12话')).toHaveAttribute('data-episode-status', 'none');
 
     // 切回分栏视图后，当前条目的集数按钮仍然可用
     fireEvent.click(screen.getByRole('button', { name: '列表视图' }));
@@ -397,6 +397,24 @@ describe('HomePage', () => {
       ),
     );
     await renderHome();
+
+    // 章节按钮样式随收藏状态变化
+    expect(screen.getByTitle(`ep.${done!.sort} ${done!.name}`)).toHaveAttribute(
+      'data-episode-status',
+      'done',
+    );
+    expect(screen.getByTitle(`ep.${wish!.sort} ${wish!.name}`)).toHaveAttribute(
+      'data-episode-status',
+      'wish',
+    );
+    expect(screen.getByTitle(`ep.${dropped!.sort} ${dropped!.name}`)).toHaveAttribute(
+      'data-episode-status',
+      'dropped',
+    );
+    expect(screen.getByTitle(`ep.${none!.sort} ${none!.name}`)).toHaveAttribute(
+      'data-episode-status',
+      'none',
+    );
 
     const doneDetail = document.querySelector(`[data-ep-id='${done!.id}']`)!;
     expect(within(doneDetail as HTMLElement).queryByRole('button', { name: '看过' })).toBeNull();

--- a/packages/website/src/pages/index/index/components/PrgManager.module.less
+++ b/packages/website/src/pages/index/index/components/PrgManager.module.less
@@ -400,12 +400,6 @@
   .epGroup {
     gap: 3px;
   }
-
-  .epBtn {
-    border-color: #008cff;
-    color: #087af5;
-    background: #f2f8ff;
-  }
 }
 
 .card {
@@ -559,20 +553,6 @@
   margin-right: 2px;
 }
 
-.epBtn,
-.epBtnWatched,
-.epBtnUnavailable {
-  min-width: 24px;
-  padding: 2px 4px;
-  border: 1px solid @gray-10;
-  border-radius: 4px;
-  font-size: 12px;
-  line-height: 16px;
-  text-align: center;
-  cursor: pointer;
-  font-family: 'Lucida Grande', 'Lucida Sans', Helvetica, Arial, Verdana, sans-serif;
-}
-
 @media (max-width: @sm) {
   .tabs {
     overflow-x: auto;
@@ -634,35 +614,4 @@
   .gridList {
     grid-template-columns: minmax(0, 1fr);
   }
-
-  .epBtn,
-  .epBtnWatched,
-  .epBtnUnavailable {
-    min-width: 22px;
-    padding: 1px 3px;
-    font-size: 11px;
-  }
-}
-
-.epBtn {
-  color: @gray-60;
-  background: #fff;
-
-  &:hover {
-    border-color: @blue-100;
-    color: @blue-100;
-  }
-}
-
-.epBtnWatched {
-  color: #fff;
-  background: @blue-100;
-  border-color: @blue-100;
-}
-
-.epBtnUnavailable {
-  border-color: #bcbcbc;
-  color: @gray-60;
-  background: #e5e5e5;
-  cursor: default;
 }

--- a/packages/website/src/pages/index/index/components/PrgManager.tsx
+++ b/packages/website/src/pages/index/index/components/PrgManager.tsx
@@ -1,5 +1,4 @@
 import { ok } from '@oazapfts/runtime';
-import { DateTime } from 'luxon';
 import React, { useState } from 'react';
 
 import { ozaClient } from '@bangumi/client';
@@ -13,7 +12,7 @@ import { EpisodeCollectionStatus, EpisodeType, SubjectType } from '@bangumi/clie
 import { toast, Typography } from '@bangumi/design';
 import { GridView, ListView } from '@bangumi/icons';
 import { getSubjectLink, getSubjectWikiEditLink } from '@bangumi/utils/pages';
-import EpisodeProgressPopover from '@bangumi/website/components/EpisodeProgressPopover';
+import EpisodeButton from '@bangumi/website/components/EpisodeButton';
 import { useHomePage } from '@bangumi/website/hooks/use-home-page';
 
 import styles from './PrgManager.module.less';
@@ -60,13 +59,6 @@ function totalText(total: number): string {
   return total === 0 ? '??' : String(total);
 }
 
-function isEpisodeUnavailable(airdate: string): boolean {
-  const airDate = DateTime.fromISO(airdate);
-  return (
-    airDate.isValid && airDate.startOf('day').toMillis() > DateTime.now().startOf('day').toMillis()
-  );
-}
-
 function getErrorMessage(error: unknown): string {
   if (error instanceof Error) {
     return error.message;
@@ -86,41 +78,6 @@ function groupEps(eps: Episode[]): [EpisodeType, Episode[]][] {
     type,
     [...list].sort((a, b) => a.sort - b.sort),
   ]);
-}
-
-function EpButton({
-  ep,
-  submitting,
-  onUpdate,
-}: {
-  ep: Episode;
-  submitting: boolean;
-  onUpdate: (body: UpdateEpisodeProgress) => void;
-}) {
-  const watched = ep.collection?.status === EpisodeCollectionStatus.Done;
-  const unavailable = Boolean(ep.airdate) && isEpisodeUnavailable(ep.airdate);
-  const buttonClass = watched
-    ? styles.epBtnWatched
-    : unavailable
-      ? styles.epBtnUnavailable
-      : styles.epBtn;
-
-  return (
-    <EpisodeProgressPopover episode={ep} submitting={submitting} onUpdate={onUpdate}>
-      {(triggerProps) => (
-        <button
-          {...triggerProps}
-          type='button'
-          className={buttonClass}
-          title={`ep.${ep.sort} ${ep.name}`}
-          aria-pressed={watched}
-          disabled={unavailable}
-        >
-          {String(ep.sort).padStart(2, '0')}
-        </button>
-      )}
-    </EpisodeProgressPopover>
-  );
 }
 
 function PrgNavItem({
@@ -326,9 +283,9 @@ function PrgCard({ item, detailed = false }: { item: ProgressItem; detailed?: bo
                   <span className={styles.epSubtitle}>{EP_TYPE_LABELS[type]}</span>
                 )}
                 {eps.map((ep) => (
-                  <EpButton
+                  <EpisodeButton
                     key={ep.id}
-                    ep={ep}
+                    episode={ep}
                     submitting={submitting}
                     onUpdate={(body) => void handleEpStatus(ep, body)}
                   />

--- a/packages/website/src/pages/index/subject/[id]/SubjectDetail.spec.tsx
+++ b/packages/website/src/pages/index/subject/[id]/SubjectDetail.spec.tsx
@@ -202,6 +202,42 @@ describe('SubjectDetail', () => {
     });
   });
 
+  it('should style episode buttons by collection status', async () => {
+    const [doneEp, noneEp] = homeData.episodes;
+    const progressData = {
+      ...homeData,
+      episodes: [
+        {
+          ...doneEp!,
+          collection: { status: EpisodeCollectionStatus.Done, updatedAt: 1775000000 },
+        },
+        {
+          ...noneEp!,
+          collection: { status: EpisodeCollectionStatus.Wish, updatedAt: 1775000000 },
+        },
+        {
+          ...noneEp!,
+          id: 102,
+          sort: 3,
+          name: '第3话',
+          collection: { status: EpisodeCollectionStatus.Dropped, updatedAt: 1775000000 },
+        },
+        { ...noneEp!, id: 103, sort: 4, name: '第4话', collection: undefined },
+      ],
+    };
+
+    await act(async () => {
+      renderPage(<SubjectDetail data={progressData} />);
+    });
+
+    // 章节按钮样式随收藏状态变化
+    const epBtn = (sort: number) => screen.getByTitle(`ep.${sort} 第${sort}话`);
+    expect(epBtn(1)).toHaveAttribute('data-episode-status', 'done');
+    expect(epBtn(2)).toHaveAttribute('data-episode-status', 'wish');
+    expect(epBtn(3)).toHaveAttribute('data-episode-status', 'dropped');
+    expect(epBtn(4)).toHaveAttribute('data-episode-status', 'none');
+  });
+
   it('should render the collection panel in a separate sidebar', async () => {
     setup();
     await renderSubject();

--- a/packages/website/src/pages/index/subject/[id]/components/SubjectDetailBlocks.module.less
+++ b/packages/website/src/pages/index/subject/[id]/components/SubjectDetailBlocks.module.less
@@ -86,45 +86,6 @@
   gap: 3px;
 }
 
-.epBtn {
-  display: inline-block;
-  width: auto;
-  min-width: 24px;
-  height: 24px;
-  box-sizing: border-box;
-  padding: 0 4px;
-  text-align: center;
-  border: 1px solid @gray-10;
-  border-radius: 3px;
-  font-size: 12px;
-  line-height: 22px;
-  color: @gray-100;
-  text-decoration: none;
-
-  &:hover,
-  &:focus-visible {
-    text-decoration: none;
-  }
-}
-
-.epDone {
-  background: @blue-doing;
-  border-color: @blue-doing;
-  color: #fff;
-}
-
-.epAired {
-  border-color: #00a8ff;
-  background: #e5f5ff;
-  color: #06c;
-}
-
-.epUpcoming {
-  border-color: #b6b6b6;
-  background: #e0e0e0;
-  color: #909090;
-}
-
 .epAllLink.epAllLink {
   text-decoration: none;
 

--- a/packages/website/src/pages/index/subject/[id]/components/SubjectDetailBlocks.tsx
+++ b/packages/website/src/pages/index/subject/[id]/components/SubjectDetailBlocks.tsx
@@ -15,17 +15,11 @@ import type {
   Topic,
   UpdateEpisodeProgress,
 } from '@bangumi/client/client';
-import {
-  CollectionType,
-  EpisodeCollectionStatus,
-  EpisodeType,
-  SubjectType,
-} from '@bangumi/client/client';
+import { CollectionType, EpisodeType, SubjectType } from '@bangumi/client/client';
 import { Avatar, Rate, toast, Typography } from '@bangumi/design';
 import {
   getBlogLink,
   getCharacterLink,
-  getEpisodeLink,
   getPersonLink,
   getSubjectBoardLink,
   getSubjectCharactersLink,
@@ -38,7 +32,7 @@ import {
   getSubjectTopicLink,
   getUserProfileLink,
 } from '@bangumi/utils/pages';
-import EpisodeProgressPopover from '@bangumi/website/components/EpisodeProgressPopover';
+import EpisodeButton from '@bangumi/website/components/EpisodeButton';
 import { useSubjectHome } from '@bangumi/website/hooks/use-subject-home';
 import { useUser } from '@bangumi/website/hooks/use-user';
 
@@ -50,49 +44,6 @@ const { Link } = Typography;
 
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : '操作失败，请稍后再试';
-}
-
-function EpisodePopoverItem({
-  episode,
-  canManage,
-  submitting,
-  onUpdate,
-}: {
-  episode: Episode;
-  canManage: boolean;
-  submitting: boolean;
-  onUpdate: (body: UpdateEpisodeProgress) => void;
-}) {
-  return (
-    <li>
-      <EpisodeProgressPopover
-        episode={episode}
-        canManage={canManage}
-        submitting={submitting}
-        onUpdate={onUpdate}
-      >
-        {(triggerProps) => (
-          <Link
-            {...triggerProps}
-            to={getEpisodeLink(episode.id)}
-            className={classNames(
-              styles.epBtn,
-              episode.collection?.status === EpisodeCollectionStatus.Done
-                ? styles.epDone
-                : episode.airdate !== '' &&
-                    dayjs(episode.airdate).isValid() &&
-                    dayjs(episode.airdate).isAfter(dayjs(), 'day')
-                  ? styles.epUpcoming
-                  : styles.epAired,
-            )}
-            title={`ep.${episode.sort} ${episode.name || episode.nameCN}`}
-          >
-            {String(episode.sort).padStart(2, '0')}
-          </Link>
-        )}
-      </EpisodeProgressPopover>
-    </li>
-  );
 }
 
 /** 章节/曲目列表，对齐 PHP subject_box_prg */
@@ -144,13 +95,14 @@ function EpListSection({ subject, episodes }: { subject: Subject; episodes: Epis
   const renderEpGrid = (list: Episode[]) => (
     <ul className={styles.epGrid}>
       {list.map((ep) => (
-        <EpisodePopoverItem
-          key={ep.id}
-          episode={ep}
-          canManage={canManage}
-          submitting={submittingEpisodeID === ep.id}
-          onUpdate={(body) => void updateEpisode(ep, body)}
-        />
+        <li key={ep.id}>
+          <EpisodeButton
+            episode={ep}
+            canManage={canManage}
+            submitting={submittingEpisodeID === ep.id}
+            onUpdate={(body) => void updateEpisode(ep, body)}
+          />
+        </li>
       ))}
     </ul>
   );


### PR DESCRIPTION
## 改动内容

抽取首页进度管理器与条目详情页共用的章节按钮组件 `EpisodeButton`（Panda CSS），并按收藏状态显示样式，对齐 PHP 原版：

| 状态 | 样式 |
|---|---|
| 看过 (Done) | 深蓝实心白字 |
| 想看 (Wish) | 粉底粉字 |
| 抛弃 (Dropped) | 灰底白字 + 删除线 |
| 已放送未收藏 | 浅蓝底蓝字 |
| 未放送 | 浅灰底灰字 |

- 新增 `packages/website/src/components/EpisodeButton/`，首页 `PrgManager` 与条目详情页 `SubjectDetailBlocks` 共用，删除两处重复实现
- 按钮渲染为跳转章节页的 `Link`（对齐 PHP 原版），使用 `noStyle` 摆脱 `.bgm-link` 全局链接色干扰（避免非分层 less 覆盖 Panda layer 的优先级问题）
- 收藏状态优先于放送时间决定样式（对齐 PHP `sbtn` / `airStatus` 逻辑）
- 补充测试：章节按钮随收藏状态渲染（`data-episode-status` 断言）

## 验证

- `HomePage.spec`（11）+ `SubjectDetail.spec`（9）全部通过
- eslint / prettier / stylelint / `tsc --noEmit` / `pnpm website build` 通过
- 截图视觉验证四种状态样式渲染正确