### PR TITLE
feat(website): align collection panel with legacy site

### DIFF
--- a/packages/styled-system/styles.css
+++ b/packages/styled-system/styles.css
@@ -912,6 +912,18 @@
     padding: 0 10px;
 }
 
+  .bg_\#54b5df {
+    background: #54b5df;
+}
+
+  .p_2px_4px {
+    padding: 2px 4px;
+}
+
+  .bd_1px_solid_\#54b5df {
+    border: 1px solid #54b5df;
+}
+
   .m_5px_0 {
     margin: 5px 0;
 }
@@ -1328,12 +1340,16 @@
     gap: 1rem;
 }
 
-  .bdr_50px {
-    border-radius: 50px;
-}
-
   .bd-t_1px_solid_\#e8e3e3 {
     border-top: 1px solid #e8e3e3;
+}
+
+  .bdr_2px {
+    border-radius: 2px;
+}
+
+  .bdr_50px {
+    border-radius: 50px;
 }
 
   .gap_4px_0 {
@@ -1958,6 +1974,10 @@
     flex-basis: 75%;
 }
 
+  .fs_11px {
+    font-size: 11px;
+}
+
   .grid-tc_minmax\(0\,_7fr\)_minmax\(260px\,_3fr\) {
     grid-template-columns: minmax(0, 7fr) minmax(260px, 3fr);
 }
@@ -2004,10 +2024,6 @@
 
   .obj-f_cover {
     object-fit: cover;
-}
-
-  .fs_11px {
-    font-size: 11px;
 }
 
   .lh_140\% {
@@ -2627,6 +2643,26 @@
     margin-top: 10px;
 }
 
+  .ml_6px {
+    margin-left: 6px;
+}
+
+  .pt_10px {
+    padding-top: 10px;
+}
+
+  .top_0 {
+    top: var(--spacing-0);
+}
+
+  .left_6px {
+    left: 6px;
+}
+
+  .w_48px {
+    width: 48px;
+}
+
   .mb_23px {
     margin-bottom: 23px;
 }
@@ -2669,10 +2705,6 @@
 
   .h_48px {
     height: 48px;
-}
-
-  .w_48px {
-    width: 48px;
 }
 
   .max-w_100\% {
@@ -2895,6 +2927,10 @@
     padding: 0 14px;
 }
 
+  .disabled\:bg_\#fff:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    background: #fff;
+}
+
   .\[\&_tr\.even\]\:bg_\#f9f9f9 tr.even {
     background: #f9f9f9;
 }
@@ -3101,6 +3137,10 @@
 
   .\[\&_a\]\:bd-b_2px_solid_\#f09199 a {
     border-bottom: 2px solid #f09199;
+}
+
+  .disabled\:bd-c_\#e8e3e3:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    border-color: #e8e3e3;
 }
 
   .\[\&\:first-child\]\:bd-t_none:first-child {
@@ -3561,6 +3601,14 @@
 
   .\[\&_li\]\:fs_13px li {
     font-size: 13px;
+}
+
+  .disabled\:c_\#9f9b9b:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    color: #9f9b9b;
+}
+
+  .disabled\:cursor_default:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    cursor: default;
 }
 
   .\[\&_a\]\:fw_normal a {
@@ -4194,10 +4242,6 @@
     cursor: pointer;
 }
 
-  .disabled\:cursor_default:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
-    cursor: default;
-}
-
   .\[\&_img\]\:w_100\% img {
     width: 100%;
 }
@@ -4668,6 +4712,10 @@
 
   .hover\:bg_\#f09199:is(:hover, [data-hover]) {
     background: #f09199;
+}
+
+  .hover\:bg_\#54b5df:is(:hover, [data-hover]) {
+    background: #54b5df;
 }
 
   .hover\:bg_\#e7848e:is(:hover, [data-hover]) {

--- a/packages/website/src/pages/index/subject/[id]/SubjectDetail.spec.tsx
+++ b/packages/website/src/pages/index/subject/[id]/SubjectDetail.spec.tsx
@@ -51,6 +51,25 @@ describe('SubjectDetail', () => {
     });
   };
 
+  // 独立 SWR 缓存 + Suspense，用于依赖登录态数据（如 subject.interest）的用例，
+  // 避免前序测试已缓存同 key 的 subject home 数据
+  const renderSubjectData = async (data: SubjectHomeResponse) => {
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <Suspense fallback={null}>
+          <MemoryRouter>
+            <HelmetProvider>
+              <UserProvider>{children}</UserProvider>
+            </HelmetProvider>
+          </MemoryRouter>
+        </Suspense>
+      </SWRConfig>
+    );
+    await act(async () => {
+      render(<SubjectDetail data={data} />, { wrapper });
+    });
+  };
+
   it('should render all blocks', async () => {
     setup();
     await renderSubject();
@@ -281,5 +300,109 @@ describe('SubjectDetail', () => {
     await waitFor(() => {
       expect(patchedBody).toEqual({ type: 3 });
     });
+  });
+
+  it('should render collection details and progress manager when collected', async () => {
+    const progressData = {
+      ...homeData,
+      subject: {
+        ...homeData.subject,
+        interest: {
+          id: 1,
+          rate: 6,
+          type: CollectionType.Doing,
+          comment: '不错',
+          tags: [],
+          epStatus: 1,
+          volStatus: 0,
+          private: false,
+          updatedAt: 1775000000,
+        },
+      },
+    };
+    mockServer.use(
+      http.get('http://localhost:3000/p1/subjects/12/home', () => HttpResponse.json(progressData)),
+    );
+
+    await renderSubjectData(progressData);
+
+    // 已收藏：不再显示收藏按钮，改为状态文字 + 收藏时间
+    expect(screen.queryByRole('button', { name: '在看' })).not.toBeInTheDocument();
+    expect(await screen.findByText(/我在看这部作品/)).toBeInTheDocument();
+    // 收藏时间（页面中可能同时出现其他时间文本，取第一个）
+    expect(screen.getAllByText(/2026-\d+-\d+ \d+:\d+/)[0]).toBeInTheDocument();
+    // 我的评价与吐槽
+    expect(screen.getByText(/我的评价：/)).toBeInTheDocument();
+    expect(screen.getByText('不错')).toBeInTheDocument();
+    // 我的完成度
+    expect(screen.getByText('我的完成度')).toBeInTheDocument();
+    expect(screen.getByText('1/12')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '更新' })).toBeInTheDocument();
+  });
+
+  it('should update subject progress from collection panel', async () => {
+    const progressData = {
+      ...homeData,
+      subject: {
+        ...homeData.subject,
+        interest: {
+          id: 1,
+          rate: 0,
+          type: CollectionType.Doing,
+          comment: '',
+          tags: [],
+          epStatus: 1,
+          volStatus: 0,
+          private: false,
+          updatedAt: 1775000000,
+        },
+      },
+    };
+    let requestBody: unknown = null;
+    mockServer.use(
+      http.get('http://localhost:3000/p1/subjects/12/home', () => HttpResponse.json(progressData)),
+      http.patch('http://localhost:3000/p1/collections/subjects/12', async ({ request }) => {
+        requestBody = await request.json();
+        return HttpResponse.json({});
+      }),
+    );
+
+    await renderSubjectData(progressData);
+
+    const input = await screen.findByDisplayValue('1');
+    fireEvent.change(input, { target: { value: '2' } });
+    fireEvent.click(screen.getByRole('button', { name: '更新' }));
+
+    await waitFor(() => {
+      expect(requestBody).toEqual({ epStatus: 2 });
+    });
+  });
+
+  it('should hide progress manager for wish collection', async () => {
+    const progressData = {
+      ...homeData,
+      subject: {
+        ...homeData.subject,
+        interest: {
+          id: 1,
+          rate: 0,
+          type: CollectionType.Wish,
+          comment: '',
+          tags: [],
+          epStatus: 0,
+          volStatus: 0,
+          private: false,
+          updatedAt: 1775000000,
+        },
+      },
+    };
+    mockServer.use(
+      http.get('http://localhost:3000/p1/subjects/12/home', () => HttpResponse.json(progressData)),
+    );
+
+    await renderSubjectData(progressData);
+
+    expect(await screen.findByText(/我想看这部作品/)).toBeInTheDocument();
+    expect(screen.queryByText('我的完成度')).not.toBeInTheDocument();
   });
 });

--- a/packages/website/src/pages/index/subject/[id]/components/CollectionPanel.module.less
+++ b/packages/website/src/pages/index/subject/[id]/components/CollectionPanel.module.less
@@ -29,14 +29,12 @@
 }
 
 .interestDetails {
-  margin-top: 10px;
-  padding-top: 10px;
-  border-top: 1px solid @gray-10;
+  margin-bottom: 10px;
 }
 
 .interestNow {
   font-size: 13px;
-  margin: 0 0 8px;
+  margin: 0 0 4px;
 }
 
 .modifyBtn {

--- a/packages/website/src/pages/index/subject/[id]/components/CollectionPanel.tsx
+++ b/packages/website/src/pages/index/subject/[id]/components/CollectionPanel.tsx
@@ -1,18 +1,107 @@
 import { ok } from '@oazapfts/runtime';
+import dayjs from 'dayjs';
 import React, { useEffect, useState } from 'react';
 
 import { ozaClient } from '@bangumi/client';
-import type { Subject } from '@bangumi/client/client';
+import type { Subject, SubjectInterest, UpdateSubjectProgress } from '@bangumi/client/client';
 import { CollectionType, SubjectType } from '@bangumi/client/client';
 import { Button, toast, Typography } from '@bangumi/design';
+import { css } from '@bangumi/styled-system/css';
 import { getSubjectStatsLink } from '@bangumi/utils/pages';
 import { useSubjectHome } from '@bangumi/website/hooks/use-subject-home';
 import { useUser } from '@bangumi/website/hooks/use-user';
 
 import styles from './CollectionPanel.module.less';
-import { COLLECT_DESC } from './subject-common';
+import { COLLECT_DESC, makeDescriptiveTime } from './subject-common';
 
 const { Link } = Typography;
+
+const privateTag = css({ marginLeft: '6px', color: '#9f9b9b' });
+
+const interestTime = css({
+  margin: '0 0 8px',
+  color: '#9f9b9b',
+  fontSize: '12px',
+});
+
+/* 我的完成度，对齐 PHP block_prg_manager */
+const progressBlock = css({
+  marginTop: '10px',
+  paddingTop: '10px',
+  borderTop: '1px solid #e8e3e3',
+});
+
+const progressTitle = css({
+  margin: '0 0 6px',
+  fontSize: '13px',
+  fontWeight: 'normal',
+  color: '#595555',
+});
+
+const progressBar = css({
+  position: 'relative',
+  height: '18px',
+  overflow: 'hidden',
+  border: '1px solid #e8e3e3',
+  borderRadius: '3px',
+  background: '#f4f4f4',
+});
+
+const progressInner = css({
+  display: 'block',
+  height: '100%',
+  background: '#54b5df',
+});
+
+const progressText = css({
+  position: 'absolute',
+  top: '0',
+  left: '6px',
+  color: '#fff',
+  fontSize: '11px',
+  lineHeight: '18px',
+});
+
+const progressForm = css({
+  display: 'flex',
+  alignItems: 'center',
+  flexWrap: 'wrap',
+  gap: '8px',
+  marginTop: '8px',
+  fontSize: '12px',
+  color: '#9f9b9b',
+});
+
+const progressLabel = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '4px',
+});
+
+const progressInput = css({
+  width: '48px',
+  padding: '2px 4px',
+  border: '1px solid #e8e3e3',
+  borderRadius: '2px',
+  fontSize: '12px',
+});
+
+const progressUpdate = css({
+  border: '1px solid #54b5df',
+  borderRadius: '3px',
+  padding: '3px 12px',
+  background: '#fff',
+  color: '#54b5df',
+  cursor: 'pointer',
+  fontSize: '12px',
+  _hover: { background: '#54b5df', color: '#fff' },
+  _disabled: {
+    borderColor: '#e8e3e3',
+    color: '#9f9b9b',
+    cursor: 'default',
+    background: '#fff',
+  },
+});
 
 const COLLECT_OPTIONS: { type: CollectionType; label: string }[] = [
   { type: CollectionType.Wish, label: '想看' },
@@ -29,6 +118,13 @@ const RATING_CATEGORY: Record<SubjectType, string> = {
   [SubjectType.Game]: 'Game',
   [SubjectType.Real]: 'Real',
 };
+
+/** 支持进度管理的条目类型，对齐 PHP SubjectCore::$enable_progress_manager */
+const PROGRESS_MANAGE_TYPES: SubjectType[] = [
+  SubjectType.Book,
+  SubjectType.Anime,
+  SubjectType.Real,
+];
 
 function getRatingLabel(score: number): string {
   if (score >= 9) return '神作';
@@ -49,6 +145,22 @@ function getErrorMessage(error: unknown): string {
   return '操作失败，请稍后再试';
 }
 
+/** 进度百分比，对齐 PHP SubjectCore::GetProgress */
+function getProgressPercent(total: number, recent: number): number {
+  if (total <= 0) {
+    return 1;
+  }
+  if (recent > total) {
+    return 50;
+  }
+  const progress = Math.round((recent * 100) / total);
+  return progress === 0 ? 1 : progress;
+}
+
+function totalText(total: number): string {
+  return total === 0 ? '??' : String(total);
+}
+
 /** 可点击评分星星（1-10 分，每颗星 2 分） */
 function ClickableRate({ value, onChange }: { value: number; onChange: (value: number) => void }) {
   return (
@@ -64,6 +176,107 @@ function ClickableRate({ value, onChange }: { value: number; onChange: (value: n
           ★
         </button>
       ))}
+    </div>
+  );
+}
+
+/** 我的完成度，对齐 PHP block_prg_manager：进度条 + 章节/卷数输入 + 更新 */
+function ProgressManager({
+  subject,
+  interest,
+  mutate,
+}: {
+  subject: Subject;
+  interest: SubjectInterest;
+  mutate: () => Promise<unknown>;
+}) {
+  const isBook = subject.type === SubjectType.Book;
+  const [epValue, setEpValue] = useState(String(interest.epStatus));
+  const [volValue, setVolValue] = useState(String(interest.volStatus));
+  const [sending, setSending] = useState(false);
+  const percent = getProgressPercent(subject.eps, interest.epStatus);
+
+  const submit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    const ep = Number(epValue);
+    if (Number.isNaN(ep) || ep < 0) {
+      toast('请输入有效的章节进度', { type: 'error' });
+      return;
+    }
+    const body: UpdateSubjectProgress = { epStatus: ep };
+    if (isBook && subject.series) {
+      const vol = Number(volValue);
+      if (Number.isNaN(vol) || vol < 0) {
+        toast('请输入有效的卷数进度', { type: 'error' });
+        return;
+      }
+      body.volStatus = vol;
+    }
+    setSending(true);
+    try {
+      await ok(ozaClient.updateSubjectProgress(subject.id, body));
+      await mutate();
+    } catch (error) {
+      toast(getErrorMessage(error), { type: 'error' });
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <div className={progressBlock}>
+      <h4 className={progressTitle}>我的完成度</h4>
+      <div className={progressBar}>
+        <span className={progressInner} style={{ width: `${percent}%` }}>
+          <small className={progressText}>
+            {interest.epStatus}/{totalText(subject.eps)}
+          </small>
+        </span>
+      </div>
+      <form className={progressForm} onSubmit={(e) => void submit(e)}>
+        {isBook && (
+          <label className={progressLabel}>
+            Chap.
+            <input
+              className={progressInput}
+              type='number'
+              min={0}
+              value={epValue}
+              onChange={(e) => setEpValue(e.target.value)}
+            />
+            / {totalText(subject.eps)}
+          </label>
+        )}
+        {isBook && subject.series && (
+          <label className={progressLabel}>
+            Vol.
+            <input
+              className={progressInput}
+              type='number'
+              min={0}
+              value={volValue}
+              onChange={(e) => setVolValue(e.target.value)}
+            />
+            / {totalText(subject.volumes)}
+          </label>
+        )}
+        {!isBook && (
+          <label className={progressLabel}>
+            <input
+              className={progressInput}
+              type='number'
+              min={0}
+              value={epValue}
+              aria-label='章节进度'
+              onChange={(e) => setEpValue(e.target.value)}
+            />
+            / {totalText(subject.eps)}
+          </label>
+        )}
+        <button type='submit' className={progressUpdate} disabled={sending}>
+          更新
+        </button>
+      </form>
     </div>
   );
 }
@@ -131,49 +344,56 @@ const CollectionPanel: React.FC<{ subject: Subject }> = ({ subject }) => {
     <section className={styles.panel}>
       <h2 className={styles.panelTitle}>收藏盒</h2>
       <div className={styles.panelBody}>
-        {user && (
-          <div className={styles.collectButtons}>
-            {COLLECT_OPTIONS.map((option) => (
-              <button
-                key={option.type}
-                type='button'
-                className={`${styles.collectBtn} ${
-                  interest?.type === option.type ? styles.collectBtnActive : ''
-                }`}
-                aria-pressed={interest?.type === option.type}
-                disabled={sending}
-                onClick={() => void updateType(option.type)}
-              >
-                {option.label}
-              </button>
-            ))}
-          </div>
-        )}
-
-        {user && interest != null ? (
-          <div className={styles.interestDetails}>
-            <p className={styles.interestNow}>
-              我{COLLECT_DESC[interest.type]}这部作品
-              <button
-                type='button'
-                className={styles.modifyBtn}
-                onClick={() => setEditing(!editing)}
-                disabled={sending}
-              >
-                {editing ? '取消' : '修改'}
-              </button>
-            </p>
-            {!editing && interest.rate > 0 && (
-              <p className={styles.myRate}>
-                我的评价：
-                <ClickableRate value={interest.rate} onChange={() => undefined} />
+        {user &&
+          (interest != null ? (
+            <div className={styles.interestDetails}>
+              <p className={styles.interestNow}>
+                我{COLLECT_DESC[interest.type]}这部作品
+                {interest.private && <span className={privateTag}>[私密]</span>}
+                <button
+                  type='button'
+                  className={styles.modifyBtn}
+                  onClick={() => setEditing(!editing)}
+                  disabled={sending}
+                >
+                  {editing ? '取消' : '修改'}
+                </button>
               </p>
-            )}
-            {!editing && interest.comment != null && interest.comment !== '' && (
-              <p className={styles.myComment}>{interest.comment}</p>
-            )}
-          </div>
-        ) : null}
+              <p className={interestTime}>
+                {dayjs.unix(interest.updatedAt).format('YYYY-M-D HH:mm')}
+                <span> / {makeDescriptiveTime(interest.updatedAt)}</span>
+              </p>
+              {!editing && interest.rate > 0 && (
+                <p className={styles.myRate}>
+                  我的评价：
+                  <ClickableRate value={interest.rate} onChange={() => undefined} />
+                </p>
+              )}
+              {!editing && interest.comment !== '' && (
+                <p className={styles.myComment}>{interest.comment}</p>
+              )}
+              {!editing &&
+                interest.type !== CollectionType.Wish &&
+                PROGRESS_MANAGE_TYPES.includes(subject.type) && (
+                  <ProgressManager subject={subject} interest={interest} mutate={mutate} />
+                )}
+            </div>
+          ) : (
+            <div className={styles.collectButtons}>
+              {COLLECT_OPTIONS.map((option) => (
+                <button
+                  key={option.type}
+                  type='button'
+                  className={styles.collectBtn}
+                  aria-pressed={false}
+                  disabled={sending}
+                  onClick={() => void updateType(option.type)}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          ))}
 
         {user && editing && (
           <div className={styles.editForm}>


### PR DESCRIPTION
## 改动内容

条目页收藏盒对齐 PHP 原版（`panel_interest` / `block_prg_manager`）：

- **收藏状态二选一**：已收藏时显示「我在看这部作品 修改」+ 收藏时间（`updatedAt` 格式化 + 相对时间）；未收藏时才显示想看/看过/在看/搁置/抛弃五个按钮
- **我的评价**：非编辑态显示我的评分星星（`rate > 0` 时）
- **我的完成度**（新增，Panda CSS）：进度条（`epStatus/eps`，百分比对齐 PHP `GetProgress`）+ 章节/卷数输入框 + 更新按钮，调用 `updateSubjectProgress`；书籍条目含 Chap./Vol. 输入，对齐 `block_prg_manager`
- 新样式使用 Panda CSS（`CollectionPanel.module.less` 仅做存量样式调整）

**暂未实现**（需要后端支持，另行处理）：
- 删除收藏按钮（后端缺 `DELETE /collections/subjects/:id`）
- 好友评价（`SubjectHomeResponse` 缺 `friends_rate`）

## 验证

- `SubjectDetail.spec` 新增 3 个用例（已收藏渲染、进度更新、想看不显示完成度），12 个用例全部通过
- 全量相关测试 23 个通过；eslint / prettier / stylelint / `tsc --noEmit` / `pnpm website build` 通过
- Playwright 真实数据截图验证收藏盒布局（状态+时间+完成度+评分区）