### PR TITLE
feat(website): add blog entry page

### DIFF
--- a/packages/styled-system/styles.css
+++ b/packages/styled-system/styles.css
@@ -776,6 +776,18 @@
     background: #f97f77;
 }
 
+  .m_15px_0_10px {
+    margin: 15px 0 10px;
+}
+
+  .m_8px_0_0 {
+    margin: 8px 0 0;
+}
+
+  .p_10px_0 {
+    padding: 10px 0;
+}
+
   .m_15px_0 {
     margin: 15px 0;
 }
@@ -822,10 +834,6 @@
 
   .p_2px_5px {
     padding: 2px 5px;
-}
-
-  .m_8px_0_0 {
-    margin: 8px 0 0;
 }
 
   .p_6px_10px {
@@ -1140,10 +1148,6 @@
     background: #eee;
 }
 
-  .p_10px_0 {
-    padding: 10px 0;
-}
-
   .p_20px_0_40px {
     padding: 20px 0 40px;
 }
@@ -1246,6 +1250,10 @@
 
   .bg_\#aaa {
     background: #aaa;
+}
+
+  .p_15px_15px_10px {
+    padding: 15px 15px 10px;
 }
 
   .m_0_0_4px {
@@ -1426,10 +1434,6 @@
 
   .p_4px_6px {
     padding: 4px 6px;
-}
-
-  .p_15px_15px_10px {
-    padding: 15px 15px 10px;
 }
 
   .p_2px_8px_2px_5px {
@@ -2333,6 +2337,10 @@
     flex-shrink: 1;
 }
 
+  .lh_32px {
+    line-height: 32px;
+}
+
   .grid-tc_250px_minmax\(0\,_720px\) {
     grid-template-columns: 250px minmax(0, 720px);
 }
@@ -2650,6 +2658,14 @@
     grid-template-columns: repeat(10, 1fr);
 }
 
+  .flex-b_75\% {
+    flex-basis: 75%;
+}
+
+  .bx-sh_0_1px_4px_rgba\(0\,_0\,_0\,_0\.04\) {
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.04);
+}
+
   .grid-tc_repeat\(auto-fill\,_minmax\(290px\,_1fr\)\) {
     grid-template-columns: repeat(auto-fill, minmax(290px, 1fr));
 }
@@ -2672,10 +2688,6 @@
 
   .grid-tc_2fr_1fr {
     grid-template-columns: 2fr 1fr;
-}
-
-  .flex-b_75\% {
-    flex-basis: 75%;
 }
 
   .bx-sh_0_5px_10px_rgba\(0\,_0\,_0\,_0\.09\) {
@@ -2768,10 +2780,6 @@
 
   .lh_170\% {
     line-height: 170%;
-}
-
-  .bx-sh_0_1px_4px_rgba\(0\,_0\,_0\,_0\.04\) {
-    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.04);
 }
 
   .op_0\.3 {
@@ -4067,6 +4075,10 @@
     padding: 8px 0;
 }
 
+  .\[\&_\.bgm-avatar\]\:bd_none .bgm-avatar {
+    border: var(--borders-none);
+}
+
   .\[\&_button\]\:p_3px_8px button {
     padding: 3px 8px;
 }
@@ -4219,6 +4231,14 @@
     padding: 0 14px;
 }
 
+  .\[\&_button\]\:bd_none button {
+    border: var(--borders-none);
+}
+
+  .\[\&_button\]\:bg_none button {
+    background: none;
+}
+
   .\[\&\.collectBtnActive\]\:bg_\#54b5df.collectBtnActive {
     background: #54b5df;
 }
@@ -4305,10 +4325,6 @@
 
   .\[\&_p\]\:m_0_0_12px p {
     margin: 0 0 12px;
-}
-
-  .\[\&_\.bgm-avatar\]\:bd_none .bgm-avatar {
-    border: var(--borders-none);
 }
 
   .\[\&_h3\]\:m_0_0_4px h3 {
@@ -4653,6 +4669,10 @@
 
   .\[\&_a\]\:bd-b_2px_solid_\#f09199 a {
     border-bottom: 2px solid #f09199;
+}
+
+  .\[\&_\.blog-comment__box\]\:flex_1 .blog-comment__box {
+    flex: 1 1 0%;
 }
 
   .\[\&\:first-child\]\:bdr_4px_0_0_4px:first-child {
@@ -5123,6 +5143,10 @@
     font-weight: 600;
 }
 
+  .\[\&_\.bgm-link\]\:c_\#0084b4 .bgm-link {
+    color: #0084b4;
+}
+
   .\[\&_a\]\:c_\#1f1c1c a {
     color: #1f1c1c;
 }
@@ -5379,10 +5403,6 @@
     opacity: 0.55;
 }
 
-  .\[\&_\.bgm-link\]\:c_\#0084b4 .bgm-link {
-    color: #0084b4;
-}
-
   .\[\&_\>_li\]\:lh_1\.4 > li {
     line-height: 1.4;
 }
@@ -5581,6 +5601,74 @@
 
   .\[\&_li\]\:fs_13px li {
     font-size: 13px;
+}
+
+  .\[\&_\.comment-info\]\:flex-wrap_wrap .comment-info {
+    flex-wrap: wrap;
+}
+
+  .\[\&_\.blog-comment__main\]\:d_flex .blog-comment__main {
+    display: flex;
+}
+
+  .\[\&_\.blog-comment__main\]\:flex-d_column .blog-comment__main {
+    flex-direction: column;
+}
+
+  .\[\&_\.blog-comment__main\]\:ai_flex-start .blog-comment__main {
+    align-items: flex-start;
+}
+
+  .\[\&_\.blog-comment__main\]\:jc_space-between .blog-comment__main {
+    justify-content: space-between;
+}
+
+  .\[\&_\.blog-comment__tip\]\:fs_16px .blog-comment__tip {
+    font-size: 16px;
+}
+
+  .\[\&_\.blog-comment__tip\]\:lh_22px .blog-comment__tip {
+    line-height: 22px;
+}
+
+  .\[\&_\.blog-comment__tip\]\:d_flex .blog-comment__tip {
+    display: flex;
+}
+
+  .\[\&_\.blog-comment__tip\]\:ai_center .blog-comment__tip {
+    align-items: center;
+}
+
+  .\[\&_\.blog-comment__tip\]\:jc_space-between .blog-comment__tip {
+    justify-content: space-between;
+}
+
+  .\[\&_\.blog-comment__tip\]\:c_\#9f9b9b .blog-comment__tip {
+    color: #9f9b9b;
+}
+
+  .\[\&_\.blog-comment__content\]\:c_\#1f1c1c .blog-comment__content {
+    color: #1f1c1c;
+}
+
+  .\[\&_\.blog-comment__content\]\:lh_26px .blog-comment__content {
+    line-height: 26px;
+}
+
+  .\[\&_\.blog-comment__content--deleted\]\:c_\#595555 .blog-comment__content--deleted {
+    color: #595555;
+}
+
+  .\[\&_button\]\:c_\#9f9b9b button {
+    color: #9f9b9b;
+}
+
+  .\[\&_button\]\:fs_14px button {
+    font-size: 14px;
+}
+
+  .\[\&_button\]\:lh_20px button {
+    line-height: 20px;
 }
 
   .\[\&\.collectBtnActive\]\:c_\#fff.collectBtnActive {
@@ -6114,10 +6202,6 @@
     opacity: 1;
 }
 
-  .\[\&_\.comment-info\]\:flex-wrap_wrap .comment-info {
-    flex-wrap: wrap;
-}
-
   .\[\&_\.bgm-comment__main\]\:d_flex .bgm-comment__main {
     display: flex;
 }
@@ -6586,6 +6670,38 @@
     height: 100%;
 }
 
+  .\[\&_\.creator-info\,_\&_\.comment-info\]\:min-w_0 .creator-info,.\[\&_\.creator-info\,_\&_\.comment-info\]\:min-w_0 .comment-info {
+    min-width: var(--sizes-0);
+}
+
+  .\[\&_\>_\*\]\:max-w_100\% > * {
+    max-width: 100%;
+}
+
+  .\[\&\.blog-comment__header--reply\]\:ml_70px.blog-comment__header--reply {
+    margin-left: 70px;
+}
+
+  .\[\&_\.blog-comment__box\]\:ml_15px .blog-comment__box {
+    margin-left: 15px;
+}
+
+  .\[\&_\.blog-comment__box\]\:min-w_0 .blog-comment__box {
+    min-width: var(--sizes-0);
+}
+
+  .\[\&_\.blog-comment__main\]\:min-h_60px .blog-comment__main {
+    min-height: 60px;
+}
+
+  .\[\&_\.blog-comment__main\]\:w_100\% .blog-comment__main,.\[\&_\.blog-comment__tip\]\:w_100\% .blog-comment__tip {
+    width: 100%;
+}
+
+  .\[\&_\.blog-comment__content\]\:mt_12px .blog-comment__content {
+    margin-top: 12px;
+}
+
   .\[\&\:last-child\]\:bd-r-w_1px:last-child {
     border-right-width: 1px;
 }
@@ -6808,14 +6924,6 @@
 
   .\[\&_select\]\:w_100\% select {
     width: 100%;
-}
-
-  .\[\&_\.creator-info\,_\&_\.comment-info\]\:min-w_0 .creator-info,.\[\&_\.creator-info\,_\&_\.comment-info\]\:min-w_0 .comment-info {
-    min-width: var(--sizes-0);
-}
-
-  .\[\&_\>_\*\]\:max-w_100\% > * {
-    max-width: 100%;
 }
 
   .\[\&\.bgm-comment__header--reply\]\:ml_70px.bgm-comment__header--reply {
@@ -7158,6 +7266,10 @@
     overflow: hidden;
 }
 
+  .\[\&_\.blog-comment__tip\]\:\[\&_\.comment-info\]\:gap_8px .blog-comment__tip .comment-info {
+    gap: 8px;
+}
+
   .\[\&\[class\]\]\:\[\&_\>_div\]\:gap_4px[class] > div {
     gap: 4px;
 }
@@ -7446,6 +7558,34 @@
     white-space: nowrap;
 }
 
+  .\[\&_\.blog-comment__tip\]\:\[\&_\.creator-info\]\:d_flex .blog-comment__tip .creator-info {
+    display: flex;
+}
+
+  .\[\&_\.blog-comment__tip\]\:\[\&_\.creator-info\]\:ai_center .blog-comment__tip .creator-info {
+    align-items: center;
+}
+
+  .\[\&_\.blog-comment__tip\]\:\[\&_\.creator-info\]\:jc_space-between .blog-comment__tip .creator-info {
+    justify-content: space-between;
+}
+
+  .\[\&_\.blog-comment__tip\]\:\[\&_\.comment-info\]\:d_flex .blog-comment__tip .comment-info {
+    display: flex;
+}
+
+  .\[\&_\.blog-comment__tip\]\:\[\&_\.comment-info\]\:fs_14px .blog-comment__tip .comment-info {
+    font-size: 14px;
+}
+
+  .\[\&_\.blog-comment__tip\]\:\[\&_\.comment-info\]\:lh_20px .blog-comment__tip .comment-info {
+    line-height: 20px;
+}
+
+  .\[\&_button\]\:\[\&\:hover\]\:c_\#0084b4 button:hover {
+    color: #0084b4;
+}
+
   .\[\&\[class\]\]\:\[\&_\>_div\]\:jc_flex-start[class] > div {
     justify-content: flex-start;
 }
@@ -7672,6 +7812,10 @@
 
   .\[\&_a\]\:\[\&_\>_span\:last-child\]\:mt_4px a > span:last-child {
     margin-top: 4px;
+}
+
+  .\[\&\.blog-comment__header--reply\]\:\[\&_\.blog-comment__box\]\:ml_13px.blog-comment__header--reply .blog-comment__box {
+    margin-left: 13px;
 }
 
   .\[\&_p\]\:\[\&\:last-child\]\:mb_0 p:last-child {
@@ -7948,6 +8092,10 @@
 
   .\[\&_li\]\:\[\&_\>_a\]\:\[\&_span\]\:mt_4px li > a span {
     margin-top: 4px;
+}
+
+  .\[\&_\.blog-comment__tip\]\:\[\&_\.creator-info\]\:\[\&_\.bgm-link\,_\&_svg\]\:pr_12px .blog-comment__tip .creator-info .bgm-link,.\[\&_\.blog-comment__tip\]\:\[\&_\.creator-info\]\:\[\&_\.bgm-link\,_\&_svg\]\:pr_12px .blog-comment__tip .creator-info svg {
+    padding-right: 12px;
 }
 
   .bgm-form--compact > .\[\.bgm-form--compact_\>_\&\]\:\[\&\:not\(\:last-child\)\]\:\[\&\:\:after\]\:bottom_-1px:not(:last-child)::after {
@@ -8348,14 +8496,14 @@
     .\[\@media_\(max-width\:_640px\)\]\:p_10px_8px_24px {
       padding: 10px 8px 24px;
 }
+    .\[\@media_\(max-width\:_640px\)\]\:p_10px_5px {
+      padding: 10px 5px;
+}
     .\[\@media_\(max-width\:_640px\)\]\:p_0 {
       padding: var(--spacing-0);
 }
     .\[\@media_\(max-width\:_640px\)\]\:p_12px {
       padding: 12px;
-}
-    .\[\@media_\(max-width\:_640px\)\]\:p_10px_5px {
-      padding: 10px 5px;
 }
     .\[\@media_\(max-width\:_640px\)\]\:gap_2px {
       gap: 2px;
@@ -8654,6 +8802,12 @@
     .\[\@media_\(max-width\:_640px\)\]\:\[\&_button\]\:w_38px button {
       width: 38px;
 }
+    .\[\@media_\(max-width\:_640px\)\]\:\[\&_\.blog-comment__box\]\:ml_10px .blog-comment__box {
+      margin-left: 10px;
+}
+    .\[\@media_\(max-width\:_640px\)\]\:\[\&\.blog-comment__header--reply\]\:ml_55px.blog-comment__header--reply {
+      margin-left: 55px;
+}
     .\[\@media_\(max-width\:_640px\)\]\:\[\&_\.bgm-comment__box\]\:ml_10px .bgm-comment__box {
       margin-left: 10px;
 }
@@ -8662,6 +8816,9 @@
 }
     .\[\@media_\(max-width\:_640px\)\]\:\[\&_\.bgm-popover__content\]\:before\:d_none .bgm-popover__content::before,.\[\@media_\(max-width\:_640px\)\]\:\[\&_\.bgm-popover__content\]\:after\:d_none .bgm-popover__content::after,.\[\@media_\(max-width\:_640px\)\]\:\[\&_button\]\:\[\&_span\]\:d_none button span {
       display: none;
+}
+    .\[\@media_\(max-width\:_640px\)\]\:\[\&\.blog-comment__header--reply\]\:\[\&_\.blog-comment__box\]\:ml_13px.blog-comment__header--reply .blog-comment__box {
+      margin-left: 13px;
 }
     .\[\@media_\(max-width\:_640px\)\]\:\[\&\.bgm-comment__header--main-post\]\:\[\&_\.bgm-comment__box\]\:ml_12px.bgm-comment__header--main-post .bgm-comment__box {
       margin-left: 12px;

--- a/packages/website/src/components/PageRoutes/LegacyRedirect.spec.tsx
+++ b/packages/website/src/components/PageRoutes/LegacyRedirect.spec.tsx
@@ -23,7 +23,7 @@ it('redirects a registered legacy path to the legacy site', async () => {
   });
 });
 
-it.each(['/calendar', '/blog/42', '/subject/12/collections', '/subject/12/stats'])(
+it.each(['/calendar', '/subject/12/collections', '/subject/12/stats'])(
   'registers %s as a legacy route',
   (path) => {
     const matches = matchRoutes(pageRoutes, path);
@@ -35,7 +35,7 @@ it.each(['/calendar', '/blog/42', '/subject/12/collections', '/subject/12/stats'
   },
 );
 
-it.each(['/subject/topic/42', '/subject/ep/42'])(
+it.each(['/subject/topic/42', '/subject/ep/42', '/blog/42'])(
   'forwards %s to the new frontend instead of the legacy site',
   (path) => {
     const matches = matchRoutes(pageRoutes, path);

--- a/packages/website/src/hooks/use-blog.ts
+++ b/packages/website/src/hooks/use-blog.ts
@@ -1,0 +1,46 @@
+import { ok } from '@oazapfts/runtime';
+import type { KeyedMutator } from 'swr';
+import useSWR from 'swr';
+
+import { ozaClient } from '@bangumi/client';
+import type { BlogEntry, CommentBase, SlimSubject } from '@bangumi/client/client';
+
+/** 日志吐槽：主评论与其子回复 */
+export type BlogComment = CommentBase & { replies: CommentBase[] };
+
+export interface UseBlogEntryRet {
+  data: BlogEntry;
+  mutate: KeyedMutator<BlogEntry>;
+}
+
+export interface UseBlogCommentsRet {
+  data: BlogComment[];
+  mutate: KeyedMutator<BlogComment[]>;
+}
+
+function useBlogEntry(id: number): UseBlogEntryRet {
+  const { data, mutate } = useSWR(`/blog/${id}`, async () => ok(ozaClient.getBlogEntry(id)), {
+    suspense: true,
+  });
+  return { data, mutate };
+}
+
+function useBlogComments(id: number): UseBlogCommentsRet {
+  const { data, mutate } = useSWR(
+    `/blog/${id}/comments`,
+    async () => ok(ozaClient.getBlogComments(id)),
+    { suspense: true },
+  );
+  return { data, mutate };
+}
+
+/** 日志关联条目；请求失败时返回空列表，不影响日志主体展示 */
+function useBlogRelatedSubjects(id: number): { data: SlimSubject[] } {
+  const { data } = useSWR(`/blog/${id}/subjects`, async () =>
+    ok(ozaClient.getBlogRelatedSubjects(id)),
+  );
+  return { data: data ?? [] };
+}
+
+export default useBlogEntry;
+export { useBlogComments, useBlogRelatedSubjects };

--- a/packages/website/src/mocks/fixtures/p1/blogs/123-GET.json
+++ b/packages/website/src/mocks/fixtures/p1/blogs/123-GET.json
@@ -1,0 +1,30 @@
+{
+  "id": 123,
+  "type": 0,
+  "uid": 1,
+  "user": {
+    "id": 1,
+    "username": "sai",
+    "nickname": "Sai",
+    "avatar": {
+      "small": "https://lain.bgm.tv/pic/user/s/000/00/00/1.jpg",
+      "medium": "https://lain.bgm.tv/pic/user/m/000/00/00/1.jpg",
+      "large": "https://lain.bgm.tv/pic/user/l/000/00/00/1.jpg"
+    },
+    "sign": "",
+    "group": 1,
+    "joinedAt": 1262304000,
+    "isFriend": false
+  },
+  "title": "测试日志标题",
+  "icon": "",
+  "content": "这是日志正文，包含 [b]粗体[/b] 和 [url=https://bgm.tv]链接[/url]。\n第二段内容。",
+  "tags": ["吐槽", "测试"],
+  "views": 42,
+  "replies": 2,
+  "createdAt": 1786000000,
+  "updatedAt": 1786000000,
+  "noreply": 0,
+  "related": 0,
+  "public": true
+}

--- a/packages/website/src/mocks/fixtures/p1/blogs/123/comments-GET.json
+++ b/packages/website/src/mocks/fixtures/p1/blogs/123/comments-GET.json
@@ -1,0 +1,77 @@
+[
+  {
+    "id": 201,
+    "mainID": 123,
+    "creatorID": 1,
+    "relatedID": 0,
+    "createdAt": 1786000100,
+    "content": "第一条主评论",
+    "state": 0,
+    "user": {
+      "id": 1,
+      "username": "sai",
+      "nickname": "Sai",
+      "avatar": {
+        "small": "https://lain.bgm.tv/pic/user/s/000/00/00/1.jpg",
+        "medium": "https://lain.bgm.tv/pic/user/m/000/00/00/1.jpg",
+        "large": "https://lain.bgm.tv/pic/user/l/000/00/00/1.jpg"
+      },
+      "sign": "",
+      "group": 1,
+      "joinedAt": 1262304000,
+      "isFriend": false
+    },
+    "reactions": [],
+    "replies": [
+      {
+        "id": 202,
+        "mainID": 123,
+        "creatorID": 2,
+        "relatedID": 201,
+        "createdAt": 1786000200,
+        "content": "回复第一条评论",
+        "state": 0,
+        "user": {
+          "id": 2,
+          "username": "chobits",
+          "nickname": "Chobits",
+          "avatar": {
+            "small": "https://lain.bgm.tv/pic/user/s/000/00/00/2.jpg",
+            "medium": "https://lain.bgm.tv/pic/user/m/000/00/00/2.jpg",
+            "large": "https://lain.bgm.tv/pic/user/l/000/00/00/2.jpg"
+          },
+          "sign": "",
+          "group": 1,
+          "joinedAt": 1262304000,
+          "isFriend": false
+        },
+        "reactions": []
+      }
+    ]
+  },
+  {
+    "id": 203,
+    "mainID": 123,
+    "creatorID": 2,
+    "relatedID": 0,
+    "createdAt": 1786000300,
+    "content": "第二条主评论",
+    "state": 0,
+    "user": {
+      "id": 2,
+      "username": "chobits",
+      "nickname": "Chobits",
+      "avatar": {
+        "small": "https://lain.bgm.tv/pic/user/s/000/00/00/2.jpg",
+        "medium": "https://lain.bgm.tv/pic/user/m/000/00/00/2.jpg",
+        "large": "https://lain.bgm.tv/pic/user/l/000/00/00/2.jpg"
+      },
+      "sign": "",
+      "group": 1,
+      "joinedAt": 1262304000,
+      "isFriend": false
+    },
+    "reactions": [],
+    "replies": []
+  }
+]

--- a/packages/website/src/mocks/fixtures/p1/blogs/123/subjects-GET.json
+++ b/packages/website/src/mocks/fixtures/p1/blogs/123/subjects-GET.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": 501963,
+    "name": "Bangumi 测试条目",
+    "nameCN": "测试条目中文名",
+    "type": 2,
+    "images": {
+      "small": "https://lain.bgm.tv/pic/cover/s/50/19/501963.jpg",
+      "medium": "https://lain.bgm.tv/pic/cover/m/50/19/501963.jpg",
+      "large": "https://lain.bgm.tv/pic/cover/l/50/19/501963.jpg"
+    },
+    "info": "2024年10月",
+    "metaTags": [],
+    "rating": {
+      "rank": 100,
+      "count": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      "score": 7.5,
+      "total": 100
+    },
+    "locked": false,
+    "nsfw": false
+  }
+]

--- a/packages/website/src/mocks/handlers.ts
+++ b/packages/website/src/mocks/handlers.ts
@@ -43,6 +43,11 @@ export const handlers = [
   mockAPI('/p1/groups/-/posts/:postID/like', 'delete'),
   mockAPI('/p1/users/:username/indexes', 'get'),
   mockAPI('/p1/users/:username/blogs', 'get'),
+  mockAPI('/p1/blogs/:entryID', 'get'),
+  mockAPI('/p1/blogs/:entryID/comments', 'get'),
+  mockAPI('/p1/blogs/:entryID/subjects', 'get'),
+  mockAPI('/p1/blogs/:entryID/comments', 'post'),
+  mockAPI('/p1/blogs/-/comments/:commentID', 'delete'),
   mockAPI('/p1/users/:username/collections/subjects', 'get'),
   mockAPI('/p1/users/:username/timeline', 'get'),
 ];

--- a/packages/website/src/pages/index/blog/[id]/components/BlogCommentItem.tsx
+++ b/packages/website/src/pages/index/blog/[id]/components/BlogCommentItem.tsx
@@ -1,0 +1,223 @@
+import type { FC } from 'react';
+import React, { memo, useState } from 'react';
+
+import type { CommentBase, SlimUser } from '@bangumi/client/client';
+import { Avatar, Typography } from '@bangumi/design';
+import RichContent from '@bangumi/design/components/RichContent';
+import { css, cx } from '@bangumi/styled-system/css';
+import { getUserProfileLink } from '@bangumi/utils/pages';
+
+import { makeDescriptiveTime } from '../../../subject/[id]/components/subject-common';
+import BlogReplyForm from './BlogReplyForm';
+
+const { Link } = Typography;
+
+const commentTip = css({
+  overflowWrap: 'anywhere',
+  '& .creator-info, & .comment-info': {
+    minWidth: '0',
+  },
+  '& .comment-info': {
+    flexWrap: 'wrap',
+  },
+});
+
+const commentBody = css({
+  overflowWrap: 'anywhere',
+  minWidth: '0',
+  '& > *': {
+    maxWidth: '100%',
+  },
+});
+
+const commentHeader = css({
+  display: 'flex',
+  alignItems: 'flex-start',
+  padding: '15px 15px 10px',
+  borderBottom: '1px dotted #e8e3e3',
+  '&.blog-comment__header--reply': {
+    marginLeft: '70px',
+    '& .blog-comment__box': { marginLeft: '13px' },
+  },
+  '@media (max-width: 640px)': {
+    padding: '10px 5px',
+    '& .blog-comment__box': { marginLeft: '10px' },
+    '&.blog-comment__header--reply': {
+      marginLeft: '55px',
+      '& .blog-comment__box': { marginLeft: '13px' },
+    },
+  },
+  '& .blog-comment__box': {
+    marginLeft: '15px',
+    flex: '1',
+    // this trick is same to EditorForm
+    minWidth: '0',
+  },
+  '& .blog-comment__main': {
+    minHeight: '60px',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    width: '100%',
+  },
+  '& .blog-comment__tip': {
+    fontSize: '16px',
+    lineHeight: '22px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    color: '#9f9b9b',
+    width: '100%',
+    '& .creator-info': {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      '& .bgm-link, & svg': { paddingRight: '12px' },
+    },
+    '& .comment-info': {
+      display: 'flex',
+      fontSize: '14px',
+      lineHeight: '20px',
+      gap: '8px',
+    },
+  },
+  '& .blog-comment__content': {
+    color: '#1f1c1c',
+    lineHeight: '26px',
+    marginTop: '12px',
+  },
+  '& .blog-comment__content--deleted': {
+    color: '#595555',
+  },
+});
+
+const commentActions = css({
+  display: 'inline-flex',
+  gap: '12px',
+  '& button': {
+    padding: '0',
+    border: 'none',
+    background: 'none',
+    color: '#9f9b9b',
+    fontSize: '14px',
+    lineHeight: '20px',
+    cursor: 'pointer',
+    '&:hover': {
+      color: '#0084b4',
+    },
+  },
+});
+
+const replyEditor = css({
+  marginTop: '12px',
+});
+
+interface BlogCommentItemProps {
+  entryId: number;
+  /** 顶层评论携带子回复列表 */
+  comment: CommentBase & { replies?: CommentBase[] };
+  floor: string | number;
+  user?: Pick<SlimUser, 'id'>;
+  /** 删除评论的回调，调用方负责刷新评论列表 */
+  onDelete: (id: number) => void;
+  onCommentUpdate: () => Promise<unknown>;
+  /** 是否为子回复 */
+  isReply?: boolean;
+}
+
+const BlogCommentItem: FC<BlogCommentItemProps> = ({
+  entryId,
+  comment,
+  floor,
+  user,
+  onDelete,
+  onCommentUpdate,
+  isReply = false,
+}) => {
+  const isDeleted = comment.state === 6 || comment.state === 7;
+  const isAuthor = user?.id === comment.creatorID;
+  const [showReplyEditor, setShowReplyEditor] = useState(false);
+  const [replyContent, setReplyContent] = useState('');
+
+  const handleReplySuccess = async (id: number) => {
+    // 先隐藏回复框避免 scrollIntoView 后布局变化
+    setShowReplyEditor(false);
+    // 刷新评论列表
+    await onCommentUpdate();
+  };
+
+  const replies = 'replies' in comment ? comment.replies : undefined;
+
+  return (
+    <div>
+      <div
+        className={cx(commentHeader, isReply && 'blog-comment__header--reply')}
+        id={`post_${comment.id}`}
+      >
+        <Avatar src={comment.user?.avatar.medium ?? ''} size={isReply ? 'xsmall' : 'small'} />
+        <div className={cx('blog-comment__box', commentBody)}>
+          <div className='blog-comment__main'>
+            <span className={cx('blog-comment__tip', commentTip)}>
+              <div className='creator-info'>
+                <Link to={getUserProfileLink(comment.user?.username ?? '')}>
+                  {comment.user?.nickname ?? ''}
+                </Link>
+              </div>
+              <div className='comment-info'>
+                <span>#{floor}</span>
+                <span>-</span>
+                <span>{makeDescriptiveTime(comment.createdAt)}</span>
+                {!isDeleted && (
+                  <span className={commentActions}>
+                    <button type='button' onClick={() => setShowReplyEditor((v) => !v)}>
+                      回复
+                    </button>
+                    {isAuthor && (
+                      <button type='button' onClick={() => onDelete(comment.id)}>
+                        删除
+                      </button>
+                    )}
+                  </span>
+                )}
+              </div>
+            </span>
+            {isDeleted ? (
+              <div className='blog-comment__content--deleted'>内容已被删除</div>
+            ) : (
+              <RichContent bbcode={comment.content} classname='blog-comment__content' />
+            )}
+            {showReplyEditor && (
+              <div className={replyEditor}>
+                <BlogReplyForm
+                  autoFocus
+                  entryId={entryId}
+                  replyTo={comment.id}
+                  placeholder={`回复 @${comment.user?.nickname ?? ''}：`}
+                  content={replyContent}
+                  onChange={setReplyContent}
+                  onCancel={() => setShowReplyEditor(false)}
+                  onSuccess={handleReplySuccess}
+                />
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+      {replies?.map((reply, idx) => (
+        <BlogCommentItem
+          key={reply.id}
+          entryId={entryId}
+          comment={reply}
+          floor={`${floor}-${idx + 1}`}
+          user={user}
+          onDelete={onDelete}
+          onCommentUpdate={onCommentUpdate}
+          isReply
+        />
+      ))}
+    </div>
+  );
+};
+
+export default memo(BlogCommentItem);

--- a/packages/website/src/pages/index/blog/[id]/components/BlogComments.tsx
+++ b/packages/website/src/pages/index/blog/[id]/components/BlogComments.tsx
@@ -1,0 +1,101 @@
+import type { FC } from 'react';
+import React, { useState } from 'react';
+
+import { ozaClient } from '@bangumi/client';
+import { Avatar, toast } from '@bangumi/design';
+import { css } from '@bangumi/styled-system/css';
+import type { BlogComment } from '@bangumi/website/hooks/use-blog';
+import { useUser } from '@bangumi/website/hooks/use-user';
+
+import BlogCommentItem from './BlogCommentItem';
+import BlogReplyForm from './BlogReplyForm';
+
+const commentList = css({
+  borderTop: '1px solid #e8e3e3',
+});
+
+const empty = css({
+  margin: '0',
+  padding: '16px 10px',
+  borderTop: '1px solid #e8e3e3',
+  borderBottom: '1px dotted #e8e3e3',
+  color: '#9f9b9b',
+  fontSize: '13px',
+});
+
+const replyFormContainer = css({
+  display: 'flex',
+  alignItems: 'flex-start',
+  marginTop: '20px',
+});
+
+const replyForm = css({
+  flexBasis: '75%',
+  marginLeft: '10px',
+  '@media (max-width: 768px)': {
+    flexBasis: '100%',
+  },
+});
+
+interface BlogCommentsProps {
+  entryId: number;
+  comments: BlogComment[];
+  /** 刷新评论列表 */
+  onCommentUpdate: () => Promise<unknown>;
+}
+
+const BlogComments: FC<BlogCommentsProps> = ({ entryId, comments, onCommentUpdate }) => {
+  const { user } = useUser();
+  const [replyContent, setReplyContent] = useState('');
+
+  const handleDelete = async (id: number) => {
+    if (confirm('确认删除这条评论？')) {
+      const response = await ozaClient.deleteBlogComment(id);
+      if (response.status === 200) {
+        await onCommentUpdate();
+      } else {
+        toast(response.data.message, { type: 'error' });
+      }
+    }
+  };
+
+  const handleReplySuccess = async (id: number) => {
+    // 刷新评论列表
+    await onCommentUpdate();
+    setReplyContent('');
+  };
+
+  return (
+    <div>
+      <div className={commentList}>
+        {comments.length === 0 && <p className={empty}>还没有吐槽</p>}
+        {comments.map((comment, idx) => (
+          <BlogCommentItem
+            key={comment.id}
+            entryId={entryId}
+            comment={comment}
+            floor={idx + 1}
+            user={user}
+            onDelete={handleDelete}
+            onCommentUpdate={onCommentUpdate}
+          />
+        ))}
+      </div>
+      {user && (
+        <div className={replyFormContainer} id='replyForm'>
+          <Avatar src={user.avatar.large} size='small' />
+          <BlogReplyForm
+            entryId={entryId}
+            className={replyForm}
+            content={replyContent}
+            onChange={setReplyContent}
+            onSuccess={handleReplySuccess}
+            hideCancel
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default BlogComments;

--- a/packages/website/src/pages/index/blog/[id]/components/BlogReplyForm.tsx
+++ b/packages/website/src/pages/index/blog/[id]/components/BlogReplyForm.tsx
@@ -1,0 +1,89 @@
+import { Turnstile } from '@marsidev/react-turnstile';
+import React, { memo, useState } from 'react';
+
+import { ozaClient } from '@bangumi/client';
+import EditorForm from '@bangumi/design/components/EditorForm';
+
+interface BlogReplyFormProps {
+  entryId: number;
+  /** 最外层 className */
+  className?: string;
+  /**
+   * 回复的评论 ID，0 代表发送顶层评论
+   * @default 0
+   */
+  replyTo?: number;
+  placeholder?: string;
+  content?: string;
+  onChange?: (content: string) => void;
+  onCancel?: () => void;
+  /** 评论成功时的回调函数 */
+  onSuccess?: (id: number) => void;
+  autoFocus?: boolean;
+  /** 是否隐藏取消按钮 */
+  hideCancel?: boolean;
+}
+
+const BlogReplyForm = ({
+  entryId,
+  className,
+  replyTo = 0,
+  placeholder = '添加新吐槽...',
+  content = '',
+  onChange,
+  onCancel,
+  onSuccess,
+  autoFocus,
+  hideCancel = false,
+}: BlogReplyFormProps) => {
+  const [sending, setSending] = useState(false);
+  const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
+
+  const sendReply = async () => {
+    if (!content) return; // TODO: show validation message
+    if (sending) return; // TODO: disable button instead
+    setSending(true);
+    try {
+      const response = await ozaClient.createBlogComment(entryId, {
+        content,
+        replyTo,
+        turnstileToken: turnstileToken ?? '',
+      });
+      if (response.status === 200) {
+        onSuccess?.(response.data.id);
+      }
+      // TODO: handle error
+    } catch (e: unknown) {
+      setSending(false);
+      throw e;
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <EditorForm
+      autoFocus={autoFocus}
+      className={className}
+      hideCancel={hideCancel}
+      onCancel={onCancel}
+      placeholder={placeholder}
+      value={content}
+      // TODO: use loading state
+      confirmText={sending ? '...' : undefined}
+      onChange={onChange}
+      onConfirm={sendReply}
+      submitExtra={
+        <Turnstile
+          options={{ theme: 'light', size: 'invisible', action: 'post_reply' }}
+          siteKey={import.meta.env.VITE_TURNSTILE_SITE_KEY}
+          onSuccess={setTurnstileToken}
+          onError={() => setTurnstileToken(null)}
+          onExpire={() => setTurnstileToken(null)}
+        />
+      }
+    />
+  );
+};
+
+export default memo(BlogReplyForm);

--- a/packages/website/src/pages/index/blog/[id]/components/RelatedSubjects.tsx
+++ b/packages/website/src/pages/index/blog/[id]/components/RelatedSubjects.tsx
@@ -1,0 +1,106 @@
+import type { FC } from 'react';
+import React from 'react';
+
+import type { SlimSubject } from '@bangumi/client/client';
+import { Rate, Typography } from '@bangumi/design';
+import { css } from '@bangumi/styled-system/css';
+import { getSubjectLink } from '@bangumi/utils/pages';
+
+const { Link } = Typography;
+
+const section = css({
+  marginBottom: '20px',
+});
+
+const subtitle = css({
+  margin: '0 0 8px',
+  fontSize: '16px',
+  fontWeight: 'bold',
+  lineHeight: '22px',
+  color: '#595555',
+});
+
+const cardList = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '10px',
+});
+
+const subjectCard = css({
+  display: 'flex',
+  minWidth: '0',
+  padding: '10px',
+  border: '1px solid #e8e3e3',
+  borderRadius: '6px',
+  boxShadow: '0 1px 4px rgba(0, 0, 0, 0.04)',
+  boxSizing: 'border-box',
+});
+
+const coverLink = css({
+  flex: '0 0 48px',
+  height: '48px',
+  marginRight: '10px',
+});
+
+const cover = css({
+  width: '48px',
+  height: '48px',
+  borderRadius: '4px',
+  objectFit: 'cover',
+});
+
+const subjectCardContent = css({
+  display: 'flex',
+  minWidth: '0',
+  flexDirection: 'column',
+  alignItems: 'flex-start',
+});
+
+const subjectName = css({
+  maxWidth: '100%',
+  overflow: 'hidden',
+  color: '#595555',
+  fontSize: '13px',
+  textOverflow: 'ellipsis',
+});
+
+const subjectNameCN = css({
+  maxWidth: '100%',
+  overflow: 'hidden',
+  color: '#9f9b9b',
+  fontSize: '12px',
+  textOverflow: 'ellipsis',
+});
+
+/** 日志页右侧栏：关联条目列表 */
+const RelatedSubjects: FC<{ subjects: SlimSubject[] }> = ({ subjects }) => {
+  return (
+    <section className={section}>
+      <h2 className={subtitle}>关联条目</h2>
+      <div className={cardList}>
+        {subjects.map((subject) => (
+          <div key={subject.id} className={subjectCard}>
+            {subject.images?.small && (
+              <Link to={getSubjectLink(subject.id)} noStyle className={coverLink}>
+                <img src={subject.images.small} alt='' className={cover} />
+              </Link>
+            )}
+            <div className={subjectCardContent}>
+              <Link to={getSubjectLink(subject.id)} className={subjectName}>
+                {subject.name}
+              </Link>
+              {subject.nameCN && subject.nameCN !== subject.name && (
+                <Link to={getSubjectLink(subject.id)} className={subjectNameCN}>
+                  {subject.nameCN}
+                </Link>
+              )}
+              {subject.rating?.score > 0 && <Rate value={subject.rating.score} />}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default RelatedSubjects;

--- a/packages/website/src/pages/index/blog/[id]/index.spec.tsx
+++ b/packages/website/src/pages/index/blog/[id]/index.spec.tsx
@@ -1,0 +1,88 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { PropsWithChildren } from 'react';
+import React, { Suspense } from 'react';
+import { HelmetProvider } from 'react-helmet-async';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { SWRConfig } from 'swr';
+
+import { UserProvider } from '@bangumi/website/hooks/use-user';
+import { server as mockServer } from '@bangumi/website/mocks/server';
+
+import BlogEntryPage from '.';
+
+describe('BlogEntryPage', () => {
+  const renderPage = async () => {
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <Suspense fallback={null}>
+          <MemoryRouter initialEntries={['/blog/123']}>
+            <HelmetProvider>
+              <UserProvider>
+                <Routes>
+                  <Route path='blog/:id' element={children} />
+                </Routes>
+              </UserProvider>
+            </HelmetProvider>
+          </MemoryRouter>
+        </Suspense>
+      </SWRConfig>
+    );
+    await act(async () => {
+      render(<BlogEntryPage />, { wrapper });
+    });
+    await screen.findByText('测试日志标题');
+  };
+
+  it('should render entry, comments and related subjects', async () => {
+    await renderPage();
+
+    // 作者信息（作者行与评论作者均指向用户主页）
+    const saiLinks = screen.getAllByRole('link', { name: 'Sai' });
+    expect(saiLinks.length).toBeGreaterThan(0);
+    expect(saiLinks.every((link) => link.getAttribute('href') === '/user/sai')).toBe(true);
+    expect(screen.getByRole('link', { name: '日志' })).toHaveAttribute('href', '/user/sai/blog');
+
+    // 标题
+    expect(screen.getByRole('heading', { name: '测试日志标题' })).toBeInTheDocument();
+
+    // 正文（BBCode 渲染）
+    expect(screen.getByText(/这是日志正文/)).toBeInTheDocument();
+    expect(screen.getByText('粗体')).toBeInTheDocument();
+
+    // 标签
+    expect(screen.getByText('#吐槽')).toBeInTheDocument();
+
+    // 评论列表：主评论 + 子回复
+    expect(screen.getByText('第一条主评论')).toBeInTheDocument();
+    expect(screen.getByText('回复第一条评论')).toBeInTheDocument();
+    expect(screen.getByText('第二条主评论')).toBeInTheDocument();
+
+    // 关联条目（普通 SWR 异步加载，需等待）
+    const relatedSubjectLink = await screen.findByRole('link', { name: 'Bangumi 测试条目' });
+    expect(relatedSubjectLink).toHaveAttribute('href', '/subject/501963');
+  });
+
+  it('should post a new comment', async () => {
+    let postedBody: unknown;
+    mockServer.use(
+      http.post('http://localhost:3000/p1/blogs/123/comments', async ({ request }) => {
+        postedBody = await request.json();
+        return HttpResponse.json({ id: 999 });
+      }),
+    );
+
+    await renderPage();
+
+    const textarea = await screen.findByPlaceholderText('添加新吐槽...');
+    fireEvent.change(textarea, { target: { value: '新的吐槽内容' } });
+    fireEvent.click(screen.getByRole('button', { name: '写好了' }));
+
+    await waitFor(() => expect(postedBody).not.toBeUndefined());
+    expect(postedBody).toMatchObject({
+      content: '新的吐槽内容',
+      replyTo: 0,
+      turnstileToken: '',
+    });
+  });
+});

--- a/packages/website/src/pages/index/blog/[id]/index.tsx
+++ b/packages/website/src/pages/index/blog/[id]/index.tsx
@@ -1,0 +1,152 @@
+import dayjs from 'dayjs';
+import type { FC } from 'react';
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+import { Avatar, Layout, Typography } from '@bangumi/design';
+import RichContent from '@bangumi/design/components/RichContent';
+import { css } from '@bangumi/styled-system/css';
+import { getUserBlogsPageLink, getUserProfileLink } from '@bangumi/utils/pages';
+import Helmet from '@bangumi/website/components/Helmet';
+import PageContainer from '@bangumi/website/components/PageContainer';
+import useBlogEntry, {
+  useBlogComments,
+  useBlogRelatedSubjects,
+} from '@bangumi/website/hooks/use-blog';
+
+import BlogComments from './components/BlogComments';
+import RelatedSubjects from './components/RelatedSubjects';
+
+const { Link } = Typography;
+
+const entryContainer = css({
+  marginBottom: '20px',
+});
+
+const authorRow = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '8px',
+  fontSize: '14px',
+  lineHeight: '20px',
+  color: '#9f9b9b',
+  '& .bgm-avatar': {
+    border: 'none',
+  },
+  '& .bgm-link': {
+    color: '#0084b4',
+  },
+});
+
+const entryHeader = css({
+  margin: '15px 0 10px',
+});
+
+const entryTitle = css({
+  margin: '0',
+  fontSize: '24px',
+  fontWeight: 'bold',
+  lineHeight: '32px',
+  color: '#1f1c1c',
+});
+
+const entryMeta = css({
+  display: 'flex',
+  flexWrap: 'wrap',
+  alignItems: 'center',
+  gap: '8px',
+  margin: '8px 0 0',
+  fontSize: '13px',
+  lineHeight: '18px',
+  color: '#9f9b9b',
+});
+
+const entryTags = css({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '8px',
+  margin: '8px 0 0',
+  fontSize: '13px',
+  lineHeight: '18px',
+  '& .bgm-link': {
+    color: '#0084b4',
+  },
+});
+
+const entryContent = css({
+  padding: '10px 0',
+});
+
+/** 对齐 PHP 原版 readTimeCount：按正文去标记后字数估算阅读时间 */
+function getReadTime(content: string): string {
+  const text = content.replace(/\[[^\]]+\]/g, '');
+  const minutes = Math.ceil(text.length / 400);
+  return `${minutes} 分钟阅读`;
+}
+
+const BlogEntryPage: FC = () => {
+  const { id } = useParams();
+  if (!id || Number.isNaN(Number(id))) {
+    throw new Error('BUG: blog entry id is required');
+  }
+  const entryId = Number(id);
+
+  const { data: entry } = useBlogEntry(entryId);
+  const { data: comments, mutate: mutateComments } = useBlogComments(entryId);
+  const { data: relatedSubjects } = useBlogRelatedSubjects(entryId);
+
+  return (
+    <>
+      <Helmet title={entry.title} />
+      <PageContainer>
+        <Layout
+          type='alpha'
+          leftChildren={
+            <article className={entryContainer}>
+              <div className={authorRow}>
+                <Avatar src={entry.user.avatar.medium} size='small' />
+                <Link to={getUserProfileLink(entry.user.username)}>{entry.user.nickname}</Link>
+                <span>·</span>
+                <Link to={getUserBlogsPageLink(entry.user.username)}>日志</Link>
+              </div>
+              <header className={entryHeader}>
+                <h1 className={entryTitle}>{entry.title}</h1>
+                <div className={entryMeta}>
+                  <span>{dayjs(entry.createdAt * 1000).format('YYYY-M-D HH:mm')}</span>
+                  <span>·</span>
+                  <span>{getReadTime(entry.content)}</span>
+                  <span>·</span>
+                  <span>{entry.views} 次浏览</span>
+                  <span>·</span>
+                  <span>{entry.replies} 条回复</span>
+                </div>
+                {entry.tags.length > 0 && (
+                  <div className={entryTags}>
+                    {entry.tags.map((tag) => (
+                      <Link key={tag} to={getUserBlogsPageLink(entry.user.username)}>
+                        #{tag}
+                      </Link>
+                    ))}
+                  </div>
+                )}
+              </header>
+              <div className={entryContent}>
+                <RichContent bbcode={entry.content} />
+              </div>
+              <BlogComments
+                entryId={entry.id}
+                comments={comments}
+                onCommentUpdate={mutateComments}
+              />
+            </article>
+          }
+          rightChildren={
+            relatedSubjects.length > 0 ? <RelatedSubjects subjects={relatedSubjects} /> : undefined
+          }
+        />
+      </PageContainer>
+    </>
+  );
+};
+
+export default BlogEntryPage;

--- a/packages/website/src/routes.tsx
+++ b/packages/website/src/routes.tsx
@@ -58,6 +58,7 @@ const WikiUploadImg = lazy(async () => import('./pages/index/subject/[id]/wiki/u
 const Login = lazy(async () => import('./pages/login'));
 const UserHome = lazy(async () => import('./pages/index/user/[username]'));
 const UserCollections = lazy(async () => import('./pages/index/user/collections/[username]'));
+const BlogEntry = lazy(async () => import('./pages/index/blog/[id]'));
 
 const userCollectionTypes = ['anime', 'book', 'music', 'game', 'real'] as const;
 
@@ -68,7 +69,6 @@ const legacyPagePaths = [
     `${type}/chart`,
     `${type}/tag/*`,
   ]),
-  'blog/:id',
   'calendar',
   'index',
   'index/:id',
@@ -120,6 +120,7 @@ export const pageRoutes: RouteObject[] = [
       { path: 'goodies', element: <Goodies /> },
       { path: 'ep/:id', element: <Episode /> },
       { path: 'ep/:id/edit', element: <EpisodeEdit /> },
+      { path: 'blog/:id', element: <BlogEntry /> },
       { path: 'notifications', element: <Notifications /> },
       ...userCollectionTypes.map((type) => ({
         path: type,


### PR DESCRIPTION
## 变更内容

实现日志详情页 `/blog/:id`（从旧站重定向改为站内页面），对齐 PHP 原版 `block_entry_view`：

- **日志主体**：作者行（头像 + 昵称 + 日志链接）、标题、元信息（时间 · 阅读时间 · 浏览数 · 回复数）、标签、BBCode 正文（RichContent）
- **评论吐槽箱**：主评论 + 子回复嵌套（楼层 `#1`/`#1-1` + 相对时间 + 回复/删除），本人评论可删除，支持回复指定评论（replyTo）
- **发评论表单**：复用 `EditorForm` + `Turnstile`，调 `createBlogComment`
- **右侧栏**：关联条目卡片（`getBlogRelatedSubjects`），无关联条目时不显示
- 阅读时间对齐 PHP `readTimeCount`（正文去标记字数 / 400）

复用小组主题页的 `PageContainer` / `Layout` / `Avatar` / `Helmet` / `RichContent` / `EditorForm` / `Turnstile` / SWR suspense hook 模式；`Topic.Comment` 因硬编码小组 API（点赞/删除/回复）未直接复用，评论组件为自定义实现。

日志编辑/删除因后端无对应 API（仅 `GET /p1/blogs/:id`）未实现。

## 测试

- 新增 `BlogEntryPage.spec.tsx`：渲染（标题/作者/正文 BBCode/评论/关联条目）+ 发评论（POST body 断言）
- 更新 `LegacyRedirect.spec.tsx`：`/blog/:id` 从 legacy 路由改为站内路由
- 新增 MSW handlers 与 fixtures（`/p1/blogs/:id`、`/p1/blogs/:id/comments`、`/p1/blogs/:id/subjects`）
- 验证：eslint / prettier / type-check / build 通过，139 个单元测试通过；截图对比真实后端 `/blog/273601` 与 PHP 原版