### PR TITLE
refactor(website): load channel sections independently

### DIFF
--- a/packages/website/src/hooks/use-channel.ts
+++ b/packages/website/src/hooks/use-channel.ts
@@ -10,56 +10,90 @@ import type {
   TrendingSubject,
 } from '@bangumi/client/client';
 import { useUser } from '@bangumi/website/hooks/use-user';
-import type { ChannelConfig } from '@bangumi/website/pages/index/channel/config';
 
-export interface ChannelData {
-  subjects: TrendingSubject[];
-  topics: ChannelSubjectTopic[];
-  blogs: SlimBlogEntry[];
-  tags: SubjectTag[];
-  friendActivities: FriendSubjectCollectionActivity[];
-  showFriendActivities: boolean;
+/**
+ * 频道页各区块的数据请求相互独立，某个接口较慢或失败时只影响对应区块，
+ * 不会拖慢或拖垮整个页面加载。
+ */
+
+/** 请求失败时返回空数组，区块按空数据降级渲染 */
+async function fetchList<T>(fetch: () => Promise<T[]>): Promise<T[]> {
+  try {
+    return await fetch();
+  } catch {
+    return [];
+  }
 }
 
-export function useChannel(config: ChannelConfig): ChannelData {
-  const { user, isLoading: isUserLoading } = useUser();
+export function useTrendingSubjects(type: number): TrendingSubject[] {
   const { data } = useSWR(
-    ['channel', config.type],
-    async () => {
-      const [subjects, topics, blogs, tags] = await Promise.all([
-        ok(ozaClient.getTrendingSubjects(config.type, { limit: 15, offset: 0 })),
-        ok(
-          ozaClient.getTrendingSubjectTopics({
-            $type: config.type,
-            limit: 20,
-            offset: 0,
-          }),
-        ),
-        ok(ozaClient.getChannelBlogs(config.type, { limit: 6, offset: 0 })),
-        ok(ozaClient.getChannelTags(config.type, { limit: 30, offset: 0 })),
-      ]);
-
-      return {
-        subjects: subjects.data,
-        topics: topics.data,
-        blogs: blogs.data,
-        tags: tags.data,
-      };
-    },
+    ['channel', type, 'trending-subjects'],
+    async () =>
+      fetchList(
+        async () => (await ok(ozaClient.getTrendingSubjects(type, { limit: 15, offset: 0 }))).data,
+      ),
     { suspense: true },
   );
+  return data;
+}
 
-  const { data: friendActivities } = useSWR(
-    user ? ['channel-friend-activities', config.type, user.id] : null,
-    async () => ok(ozaClient.getFriendsSubjectCollections(config.type, { limit: 10, offset: 0 })),
+export function useTrendingSubjectTopics(type: number): ChannelSubjectTopic[] {
+  const { data } = useSWR(
+    ['channel', type, 'trending-topics'],
+    async () =>
+      fetchList(
+        async () =>
+          (
+            await ok(
+              ozaClient.getTrendingSubjectTopics({
+                $type: type,
+                limit: 20,
+                offset: 0,
+              }),
+            )
+          ).data,
+      ),
+    { suspense: true },
   );
+  return data;
+}
 
+export function useChannelBlogs(type: number): SlimBlogEntry[] {
+  const { data } = useSWR(
+    ['channel', type, 'blogs'],
+    async () =>
+      fetchList(
+        async () => (await ok(ozaClient.getChannelBlogs(type, { limit: 6, offset: 0 }))).data,
+      ),
+    { suspense: true },
+  );
+  return data;
+}
+
+export function useChannelTags(type: number): SubjectTag[] {
+  const { data } = useSWR(
+    ['channel', type, 'tags'],
+    async () =>
+      fetchList(
+        async () => (await ok(ozaClient.getChannelTags(type, { limit: 30, offset: 0 }))).data,
+      ),
+    { suspense: true },
+  );
+  return data;
+}
+
+export function useFriendActivities(type: number): {
+  friendActivities: FriendSubjectCollectionActivity[];
+  showFriendActivities: boolean;
+} {
+  const { user, isLoading: isUserLoading } = useUser();
+  const { data } = useSWR(
+    user ? ['channel-friend-activities', type, user.id] : null,
+    async () =>
+      (await ok(ozaClient.getFriendsSubjectCollections(type, { limit: 10, offset: 0 }))).data,
+  );
   return {
-    subjects: data?.subjects ?? [],
-    topics: data?.topics ?? [],
-    blogs: data?.blogs ?? [],
-    tags: data?.tags ?? [],
-    friendActivities: friendActivities?.data ?? [],
-    showFriendActivities: !isUserLoading && Boolean(user) && friendActivities !== undefined,
+    friendActivities: data ?? [],
+    showFriendActivities: !isUserLoading && Boolean(user) && data !== undefined,
   };
 }

--- a/packages/website/src/pages/index/channel/index.tsx
+++ b/packages/website/src/pages/index/channel/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import { Link } from 'react-router-dom';
 
 import type {
@@ -20,7 +20,13 @@ import {
 import { withErrorBoundary } from '@bangumi/website/components/ErrorBoundary';
 import Helmet from '@bangumi/website/components/Helmet';
 import PageContainer from '@bangumi/website/components/PageContainer';
-import { useChannel } from '@bangumi/website/hooks/use-channel';
+import {
+  useChannelBlogs,
+  useChannelTags,
+  useFriendActivities,
+  useTrendingSubjects,
+  useTrendingSubjectTopics,
+} from '@bangumi/website/hooks/use-channel';
 
 import type { ChannelConfig, ChannelKey } from './config';
 import { CHANNEL_CONFIGS } from './config';
@@ -681,13 +687,13 @@ function ChannelBlogs({ blogs, config }: { blogs: SlimBlogEntry[]; config: Chann
 }
 
 function ChannelSidebar({
-  tags,
-  blogs,
   config,
+  blogSection,
+  tagSection,
 }: {
-  tags: SubjectTag[];
-  blogs: SlimBlogEntry[];
   config: ChannelConfig;
+  blogSection: React.ReactNode;
+  tagSection: React.ReactNode;
 }) {
   return (
     <aside className={sidebar}>
@@ -714,31 +720,64 @@ function ChannelSidebar({
         </nav>
       </section>
 
-      <ChannelBlogs blogs={blogs} config={config} />
+      {blogSection}
 
-      {tags.length > 0 && (
-        <section className={sidePanel}>
-          <h2>
-            标签汇总
-            <small>
-              <Link to={`/${config.key}/tag`}>more</Link>
-            </small>
-          </h2>
-          <div className={tagCloud}>
-            {tags.map((tag) => (
-              <Link
-                key={tag.name}
-                to={`/${config.key}/tag/${encodeURIComponent(tag.name)}`}
-                className={TAG_LEVEL_STYLES[getTagLevel(tag.count, tags)]}
-                title={`${tag.count.toLocaleString()} 个条目`}
-              >
-                {tag.name}
-              </Link>
-            ))}
-          </div>
-        </section>
-      )}
+      {tagSection}
     </aside>
+  );
+}
+
+function ChannelTags({ tags, config }: { tags: SubjectTag[]; config: ChannelConfig }) {
+  if (tags.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className={sidePanel}>
+      <h2>
+        标签汇总
+        <small>
+          <Link to={`/${config.key}/tag`}>more</Link>
+        </small>
+      </h2>
+      <div className={tagCloud}>
+        {tags.map((tag) => (
+          <Link
+            key={tag.name}
+            to={`/${config.key}/tag/${encodeURIComponent(tag.name)}`}
+            className={TAG_LEVEL_STYLES[getTagLevel(tag.count, tags)]}
+            title={`${tag.count.toLocaleString()} 个条目`}
+          >
+            {tag.name}
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+/** 频道页整体框架：页头 + 主列 + 侧栏 */
+function ChannelFrame({
+  config,
+  main,
+  sidebar,
+}: {
+  config: ChannelConfig;
+  main: React.ReactNode;
+  sidebar: React.ReactNode;
+}) {
+  return (
+    <PageContainer as='main' className={page}>
+      <header className={pageHeader}>
+        <h1>
+          <span>{config.title}</span>频道
+        </h1>
+      </header>
+      <div className={columns}>
+        <div className={mainColumn}>{main}</div>
+        {sidebar}
+      </div>
+    </PageContainer>
   );
 }
 
@@ -759,14 +798,10 @@ export function ChannelPageContent({
   data: ChannelPageData;
 }) {
   return (
-    <PageContainer as='main' className={page}>
-      <header className={pageHeader}>
-        <h1>
-          <span>{config.title}</span>频道
-        </h1>
-      </header>
-      <div className={columns}>
-        <div className={mainColumn}>
+    <ChannelFrame
+      config={config}
+      main={
+        <>
           <TrendingSubjects subjects={data.subjects} config={config} />
           {data.showFriendActivities && (
             <>
@@ -779,21 +814,94 @@ export function ChannelPageContent({
           )}
           <div className={divider} />
           <TopicList topics={data.topics} config={config} />
-        </div>
-        <ChannelSidebar tags={data.tags} blogs={data.blogs} config={config} />
-      </div>
-    </PageContainer>
+        </>
+      }
+      sidebar={
+        <ChannelSidebar
+          config={config}
+          blogSection={<ChannelBlogs blogs={data.blogs} config={config} />}
+          tagSection={<ChannelTags tags={data.tags} config={config} />}
+        />
+      }
+    />
   );
+}
+
+/** 各区块独立数据加载：某个接口慢只阻塞自身，不影响其他区块 */
+function TrendingSubjectsSection({ config }: { config: ChannelConfig }) {
+  const subjects = useTrendingSubjects(config.type);
+  return <TrendingSubjects subjects={subjects} config={config} />;
+}
+
+function TopicListSection({ config }: { config: ChannelConfig }) {
+  const topics = useTrendingSubjectTopics(config.type);
+  return <TopicList topics={topics} config={config} />;
+}
+
+function FriendActivitySection({ config }: { config: ChannelConfig }) {
+  const { friendActivities, showFriendActivities } = useFriendActivities(config.type);
+  if (!showFriendActivities) {
+    return null;
+  }
+
+  return (
+    <>
+      <div className={divider} />
+      <section className={section}>
+        <h2 className={sectionTitle}>好友动态</h2>
+        <FriendActivityList activities={friendActivities} config={config} />
+      </section>
+    </>
+  );
+}
+
+function BlogSection({ config }: { config: ChannelConfig }) {
+  const blogs = useChannelBlogs(config.type);
+  return <ChannelBlogs blogs={blogs} config={config} />;
+}
+
+function TagSection({ config }: { config: ChannelConfig }) {
+  const tags = useChannelTags(config.type);
+  return <ChannelTags tags={tags} config={config} />;
 }
 
 function ChannelIndex({ channel }: { channel: ChannelKey }) {
   const config = CHANNEL_CONFIGS[channel];
-  const data = useChannel(config);
 
   return (
     <>
       <Helmet title={config.title} />
-      <ChannelPageContent config={config} data={data} />
+      <ChannelFrame
+        config={config}
+        main={
+          <>
+            <Suspense fallback={null}>
+              <TrendingSubjectsSection config={config} />
+            </Suspense>
+            <Suspense fallback={null}>
+              <FriendActivitySection config={config} />
+            </Suspense>
+            <Suspense fallback={null}>
+              <TopicListSection config={config} />
+            </Suspense>
+          </>
+        }
+        sidebar={
+          <ChannelSidebar
+            config={config}
+            blogSection={
+              <Suspense fallback={null}>
+                <BlogSection config={config} />
+              </Suspense>
+            }
+            tagSection={
+              <Suspense fallback={null}>
+                <TagSection config={config} />
+              </Suspense>
+            }
+          />
+        }
+      />
     </>
   );
 }


### PR DESCRIPTION
## 变更内容

修复频道页（`/anime`、`/book`、`/music`、`/game`、`/real`）单个慢请求拖垮整页加载的问题。

**原实现**：`useChannel` 用 `suspense: true` + `Promise.all` 并发请求 4 个接口（注目条目 / 最新讨论 / 频道日志 / 标签），任何一个接口慢（实测 `channels/:type/tags` 504 超时）都会让整个页面停在空白加载态，且 suspense 错误冒泡会导致整页报错。

**改动**：

- `use-channel.ts`：拆分为 5 个独立 hook（`useTrendingSubjects` / `useTrendingSubjectTopics` / `useChannelBlogs` / `useChannelTags` 各自 suspense，`useFriendActivities` 非 suspense），每个 hook 带 `fetchList` 错误兜底（失败返回空数组）
- `channel/index.tsx`：各区块独立 `<Suspense>` 边界（fallback 为 null），接口慢只阻塞对应区块，失败区块按空数据优雅降级（如标签区块隐藏）；提取 `ChannelFrame` 布局与各 Section 数据组件
- `ChannelPageContent` 保持 `config + data` 接口不变，渲染测试不受影响

**验证**：139 个单元测试通过（channel 7 个），eslint / prettier / type-check / build 通过；真实后端截图确认 tags 接口 504 时页面正常渲染、其他区块正常、慢区块独立渐进出现。