### PR TITLE
fix(website): unify routed page widths

### DIFF
--- a/packages/styled-system/styles.css
+++ b/packages/styled-system/styles.css
@@ -712,6 +712,10 @@
     margin: 0 0 12px;
 }
 
+  .p_15px_15px_32px {
+    padding: 15px 15px 32px;
+}
+
   .p_0_0_10px {
     padding: 0 0 10px;
 }
@@ -788,6 +792,10 @@
     padding: 10px 0;
 }
 
+  .p_10px_15px_24px {
+    padding: 10px 15px 24px;
+}
+
   .m_15px_0 {
     margin: 15px 0;
 }
@@ -848,24 +856,12 @@
     margin: 0 0 8px;
 }
 
-  .p_10px_30px_32px {
-    padding: 10px 30px 32px;
+  .p_6px_5px_18px {
+    padding: 6px 5px 18px;
 }
 
-  .p_6px_5px_22px {
-    padding: 6px 5px 22px;
-}
-
-  .m_3px_0_0 {
-    margin: 3px 0 0;
-}
-
-  .m_14px_0_0 {
-    margin: 14px 0 0;
-}
-
-  .m_12px_0_0 {
-    margin: 12px 0 0;
+  .m_10px_0_0 {
+    margin: 10px 0 0;
 }
 
   .bd_0 {
@@ -892,8 +888,8 @@
     padding: 8px 0 14px;
 }
 
-  .p_32px_30px_48px {
-    padding: 32px 30px 48px;
+  .p_32px_15px_48px {
+    padding: 32px 15px 48px;
 }
 
   .m_8px_0_24px {
@@ -1072,6 +1068,10 @@
     padding: 8px 5px;
 }
 
+  .m_3px_0_0 {
+    margin: 3px 0 0;
+}
+
   .bd_1px_solid_\#eee {
     border: 1px solid #eee;
 }
@@ -1122,10 +1122,6 @@
 
   .bd_1px_solid_\#e8e8e8 {
     border: 1px solid #e8e8e8;
-}
-
-  .p_10px_30px_30px {
-    padding: 10px 30px 30px;
 }
 
   .p_2px {
@@ -1280,10 +1276,6 @@
     background: #f3f1f1;
 }
 
-  .m_10px_0_0 {
-    margin: 10px 0 0;
-}
-
   .bg_\#9f9b9b {
     background: #9f9b9b;
 }
@@ -1310,10 +1302,6 @@
 
   .p_0_5px_0_10px {
     padding: 0 5px 0 10px;
-}
-
-  .p_10px_15px_24px {
-    padding: 10px 15px 24px;
 }
 
   .p_0_18px_0_10px {
@@ -1632,10 +1620,6 @@
     gap: 28px;
 }
 
-  .gap_18px {
-    gap: 18px;
-}
-
   .flex_0_0_auto {
     flex: 0 0 auto;
 }
@@ -1774,6 +1758,10 @@
 
   .gap_16px_10px {
     gap: 16px 10px;
+}
+
+  .gap_18px {
+    gap: 18px;
 }
 
   .gap_10px_4px {
@@ -2237,8 +2225,8 @@
     display: grid;
 }
 
-  .grid-tc_minmax\(0\,_700px\)_280px {
-    grid-template-columns: minmax(0, 700px) 280px;
+  .grid-tc_minmax\(0\,_1fr\)_280px {
+    grid-template-columns: minmax(0, 1fr) 280px;
 }
 
   .ai_start {
@@ -2341,8 +2329,8 @@
     line-height: 32px;
 }
 
-  .grid-tc_250px_minmax\(0\,_720px\) {
-    grid-template-columns: 250px minmax(0, 720px);
+  .grid-tc_250px_minmax\(0\,_1fr\) {
+    grid-template-columns: 250px minmax(0, 1fr);
 }
 
   .ai_flex-start {
@@ -2401,8 +2389,16 @@
     display: inline;
 }
 
-  .grid-tc_minmax\(0\,_1fr\)_280px {
-    grid-template-columns: minmax(0, 1fr) 280px;
+  .fs_22px {
+    font-size: 22px;
+}
+
+  .fs_inherit {
+    font-size: inherit;
+}
+
+  .fw_inherit {
+    font-weight: inherit;
 }
 
   .lh_1\.75 {
@@ -2423,10 +2419,6 @@
 
   .font-style_italic {
     font-style: italic;
-}
-
-  .fs_22px {
-    font-size: 22px;
 }
 
   .jc_flex-end {
@@ -2540,10 +2532,6 @@
 
   .lh_25px {
     line-height: 25px;
-}
-
-  .grid-tc_250px_minmax\(0\,_1fr\) {
-    grid-template-columns: 250px minmax(0, 1fr);
 }
 
   .grid-tc_minmax\(220px\,_1fr\)_minmax\(260px\,_1\.15fr\) {
@@ -3119,8 +3107,8 @@
     width: 150px;
 }
 
-  .max-w_760px {
-    max-width: 760px;
+  .max-w_700px {
+    max-width: 700px;
 }
 
   .mb_32px {
@@ -3141,18 +3129,6 @@
 
   .mb_10px {
     margin-bottom: 10px;
-}
-
-  .max-w_1060px {
-    max-width: 1060px;
-}
-
-  .pt_15px {
-    padding-top: 15px;
-}
-
-  .pb_32px {
-    padding-bottom: 32px;
 }
 
   .pt_5px {
@@ -3263,16 +3239,12 @@
     margin-right: 4px;
 }
 
-  .max-w_1000px {
-    max-width: 1000px;
+  .pr_15px {
+    padding-right: 15px;
 }
 
-  .mr_auto {
-    margin-right: auto;
-}
-
-  .pb_30px {
-    padding-bottom: 30px;
+  .pl_15px {
+    padding-left: 15px;
 }
 
   .min-w_max-content {
@@ -3323,6 +3295,10 @@
     margin-bottom: 5px;
 }
 
+  .pt_15px {
+    padding-top: 15px;
+}
+
   .ml_6px {
     margin-left: 6px;
 }
@@ -3331,28 +3307,12 @@
     padding-top: 8px;
 }
 
-  .max-w_1040px {
-    max-width: 1040px;
-}
-
-  .pr_30px {
-    padding-right: 30px;
-}
-
-  .pl_30px {
-    padding-left: 30px;
-}
-
   .w_max-content {
     width: max-content;
 }
 
   .min-w_100\% {
     min-width: 100%;
-}
-
-  .mt_8px {
-    margin-top: 8px;
 }
 
   .mt_18px {
@@ -3477,6 +3437,10 @@
 
   .min-h_120px {
     min-height: 120px;
+}
+
+  .mt_8px {
+    margin-top: 8px;
 }
 
   .min-h_42px {
@@ -3797,14 +3761,6 @@
 
   .mb_4px {
     margin-bottom: 4px;
-}
-
-  .pr_15px {
-    padding-right: 15px;
-}
-
-  .pl_15px {
-    padding-left: 15px;
 }
 
   .w_255px {
@@ -5281,22 +5237,6 @@
 
   .\[\&_a\]\:fw_inherit a {
     font-weight: inherit;
-}
-
-  .\[\&_h1\]\:c_\#1f1c1c h1 {
-    color: #1f1c1c;
-}
-
-  .\[\&_h1\]\:fs_22px h1 {
-    font-size: 22px;
-}
-
-  .\[\&_h1\]\:fw_400 h1 {
-    font-weight: 400;
-}
-
-  .\[\&_h1\]\:ov-wrap_anywhere h1 {
-    overflow-wrap: anywhere;
 }
 
   .\[\&_h2\]\:fs_18px h2 {
@@ -7478,18 +7418,6 @@
     white-space: nowrap;
 }
 
-  .\[\&_h1\]\:\[\&_\>_span\]\:c_\#f09199 h1 > span {
-    color: #f09199;
-}
-
-  .\[\&_h1\]\:\[\&_\>_span\]\:fs_16px h1 > span {
-    font-size: 16px;
-}
-
-  .\[\&_h1\]\:\[\&_\>_span\]\:fw_600 h1 > span {
-    font-weight: 600;
-}
-
   .\[\&_li\]\:\[\&_a\]\:d_grid li a {
     display: grid;
 }
@@ -8163,9 +8091,6 @@
     .\[\@media_\(max-width\:_1024px\)\]\:grid-tc_repeat\(6\,_minmax\(0\,_1fr\)\) {
       grid-template-columns: repeat(6, minmax(0, 1fr));
 }
-    .\[\@media_\(max-width\:_1024px\)\]\:max-w_820px {
-      max-width: 820px;
-}
     .\[\@media_\(max-width\:_1024px\)\]\:w_calc\(100\%_-_40px\) {
       width: calc(100% - 40px);
 }
@@ -8177,18 +8102,6 @@
 }
     .\[\&\.bgm-layout--alpha\]\:\[\&_\.bgm-layout__right\]\:\[\@media_\(max-width\:_1024px\)\]\:d_none.bgm-layout--alpha .bgm-layout__right {
       display: none;
-}
-}
-
-  @media (max-width: 1000px) {
-    .\[\@media_\(max-width\:_1000px\)\]\:grid-tc_minmax\(200px\,_250px\)_minmax\(0\,_720px\) {
-      grid-template-columns: minmax(200px, 250px) minmax(0, 720px);
-}
-    .\[\@media_\(max-width\:_1000px\)\]\:pr_15px {
-      padding-right: 15px;
-}
-    .\[\@media_\(max-width\:_1000px\)\]\:pl_15px {
-      padding-left: 15px;
 }
 }
 
@@ -8460,20 +8373,17 @@
     .\[\@media_\(max-width\:_640px\)\]\:p_1px_3px {
       padding: 1px 3px;
 }
+    .\[\@media_\(max-width\:_640px\)\]\:p_14px_15px_24px {
+      padding: 14px 15px 24px;
+}
     .\[\@media_\(max-width\:_640px\)\]\:p_8px_6px {
       padding: 8px 6px;
-}
-    .\[\@media_\(max-width\:_640px\)\]\:p_0_5px_24px {
-      padding: 0 5px 24px;
 }
     .\[\@media_\(max-width\:_640px\)\]\:m_10px_0 {
       margin: 10px 0;
 }
     .\[\@media_\(max-width\:_640px\)\]\:p_0_5px_10px {
       padding: 0 5px 10px;
-}
-    .\[\@media_\(max-width\:_640px\)\]\:p_8px_10px_24px {
-      padding: 8px 10px 24px;
 }
     .\[\@media_\(max-width\:_640px\)\]\:m_12px_0 {
       margin: 12px 0;
@@ -8492,9 +8402,6 @@
 }
     .\[\@media_\(max-width\:_640px\)\]\:p_5px_10px_0 {
       padding: 5px 10px 0;
-}
-    .\[\@media_\(max-width\:_640px\)\]\:p_10px_8px_24px {
-      padding: 10px 8px 24px;
 }
     .\[\@media_\(max-width\:_640px\)\]\:p_10px_5px {
       padding: 10px 5px;
@@ -8559,6 +8466,9 @@
     .\[\@media_\(max-width\:_640px\)\]\:fs_18px {
       font-size: 18px;
 }
+    .\[\@media_\(max-width\:_640px\)\]\:fs_19px {
+      font-size: 19px;
+}
     .\[\@media_\(max-width\:_640px\)\]\:fs_20px {
       font-size: 20px;
 }
@@ -8619,23 +8529,11 @@
     .\[\@media_\(max-width\:_640px\)\]\:pl_16px {
       padding-left: 16px;
 }
-    .\[\@media_\(max-width\:_640px\)\]\:pt_14px {
-      padding-top: 14px;
-}
-    .\[\@media_\(max-width\:_640px\)\]\:pb_24px {
-      padding-bottom: 24px;
-}
     .\[\@media_\(max-width\:_640px\)\]\:pb_8px {
       padding-bottom: 8px;
 }
     .\[\@media_\(max-width\:_640px\)\]\:ml_40px {
       margin-left: 40px;
-}
-    .\[\@media_\(max-width\:_640px\)\]\:pr_10px {
-      padding-right: 10px;
-}
-    .\[\@media_\(max-width\:_640px\)\]\:pl_10px {
-      padding-left: 10px;
 }
     .\[\@media_\(max-width\:_640px\)\]\:mt_0 {
       margin-top: var(--spacing-0);
@@ -8645,6 +8543,12 @@
 }
     .\[\@media_\(max-width\:_640px\)\]\:mb_10px {
       margin-bottom: 10px;
+}
+    .\[\@media_\(max-width\:_640px\)\]\:pr_10px {
+      padding-right: 10px;
+}
+    .\[\@media_\(max-width\:_640px\)\]\:pl_10px {
+      padding-left: 10px;
 }
     .\[\@media_\(max-width\:_640px\)\]\:pr_2px {
       padding-right: 2px;
@@ -8756,9 +8660,6 @@
 }
     .\[\@media_\(max-width\:_640px\)\]\:\[\&_time\]\:d_block time,.\[\@media_\(max-width\:_640px\)\]\:\[\&_small\]\:d_block small {
       display: block;
-}
-    .\[\@media_\(max-width\:_640px\)\]\:\[\&_h1\]\:fs_19px h1 {
-      font-size: 19px;
 }
     .\[\@media_\(max-width\:_640px\)\]\:\[\&_\>_span\]\:d_none > span {
       display: none;

--- a/packages/website/src/pages/index/about/copyright.tsx
+++ b/packages/website/src/pages/index/about/copyright.tsx
@@ -4,7 +4,7 @@ import Helmet from '@bangumi/website/components/Helmet';
 import PageContainer from '@bangumi/website/components/PageContainer';
 
 import {
-  aboutContainer,
+  aboutContent,
   AboutNav,
   aboutParagraph,
   aboutSection,
@@ -15,38 +15,40 @@ import {
 const Copyright: React.FC = () => (
   <>
     <Helmet title='版权声明' />
-    <PageContainer className={aboutContainer}>
-      <AboutNav />
-      <h1 className={aboutTitle}>版权声明</h1>
-      <section className={aboutSection}>
-        <h2 className={aboutSectionTitle}>用户发布的内容</h2>
-        <p className={aboutParagraph}>
-          用户在 Bangumi
-          发布的内容（包括但不限于日志、小组话题与回复、条目吐槽、图片等）著作权归发布者本人所有，发布者对其发布内容负相应责任。
-        </p>
-        <p className={aboutParagraph}>
-          Bangumi
-          仅为用户提供内容存储与展示服务，不参与用户内容的创作，也不对用户发布内容的真实性、合法性作出保证。
-        </p>
-      </section>
-      <section className={aboutSection}>
-        <h2 className={aboutSectionTitle}>站方内容</h2>
-        <p className={aboutParagraph}>
-          本站自身的页面、文字与设计等站方内容，未经许可不得擅自复制、转载或用于商业用途。
-        </p>
-      </section>
-      <section className={aboutSection}>
-        <h2 className={aboutSectionTitle}>转载与引用</h2>
-        <p className={aboutParagraph}>
-          转载本站内容时请注明出处与原作者；在符合著作权保护的前提下，欢迎对本站内容进行合理引用。
-        </p>
-      </section>
-      <section className={aboutSection}>
-        <h2 className={aboutSectionTitle}>侵权处理</h2>
-        <p className={aboutParagraph}>
-          如果您认为本站内容侵犯了您的合法权益，请通过站务途径与我们联系，我们会在核实后尽快处理。
-        </p>
-      </section>
+    <PageContainer as='main'>
+      <div className={aboutContent}>
+        <AboutNav />
+        <h1 className={aboutTitle}>版权声明</h1>
+        <section className={aboutSection}>
+          <h2 className={aboutSectionTitle}>用户发布的内容</h2>
+          <p className={aboutParagraph}>
+            用户在 Bangumi
+            发布的内容（包括但不限于日志、小组话题与回复、条目吐槽、图片等）著作权归发布者本人所有，发布者对其发布内容负相应责任。
+          </p>
+          <p className={aboutParagraph}>
+            Bangumi
+            仅为用户提供内容存储与展示服务，不参与用户内容的创作，也不对用户发布内容的真实性、合法性作出保证。
+          </p>
+        </section>
+        <section className={aboutSection}>
+          <h2 className={aboutSectionTitle}>站方内容</h2>
+          <p className={aboutParagraph}>
+            本站自身的页面、文字与设计等站方内容，未经许可不得擅自复制、转载或用于商业用途。
+          </p>
+        </section>
+        <section className={aboutSection}>
+          <h2 className={aboutSectionTitle}>转载与引用</h2>
+          <p className={aboutParagraph}>
+            转载本站内容时请注明出处与原作者；在符合著作权保护的前提下，欢迎对本站内容进行合理引用。
+          </p>
+        </section>
+        <section className={aboutSection}>
+          <h2 className={aboutSectionTitle}>侵权处理</h2>
+          <p className={aboutParagraph}>
+            如果您认为本站内容侵犯了您的合法权益，请通过站务途径与我们联系，我们会在核实后尽快处理。
+          </p>
+        </section>
+      </div>
     </PageContainer>
   </>
 );

--- a/packages/website/src/pages/index/about/guideline.tsx
+++ b/packages/website/src/pages/index/about/guideline.tsx
@@ -4,7 +4,7 @@ import Helmet from '@bangumi/website/components/Helmet';
 import PageContainer from '@bangumi/website/components/PageContainer';
 
 import {
-  aboutContainer,
+  aboutContent,
   aboutList,
   aboutListItem,
   AboutNav,
@@ -15,28 +15,30 @@ import {
 const Guideline: React.FC = () => (
   <>
     <Helmet title='社区指导原则' />
-    <PageContainer className={aboutContainer}>
-      <AboutNav />
-      <h1 className={aboutTitle}>社区指导原则</h1>
-      <p className={aboutParagraph}>
-        Bangumi 是一个开放的社区，为了让大家在这里愉快地交流和分享，请所有用户共同遵守以下原则：
-      </p>
-      <ol className={aboutList}>
-        <li className={aboutListItem}>
-          友善交流：尊重每一位用户，不进行人身攻击、引战或恶意骚扰，理性表达不同观点。
-        </li>
-        <li className={aboutListItem}>
-          尊重版权：不要在站内上传或分享侵犯他人版权的资源，转载他人内容时注明出处。
-        </li>
-        <li className={aboutListItem}>
-          条目编辑规范：编辑条目时应如实填写信息并遵循现有规范，不要恶意修改、删除他人的编辑成果。
-        </li>
-        <li className={aboutListItem}>
-          拒绝广告与刷屏：不要发布商业广告、垃圾信息，也不要重复刷屏影响他人浏览。
-        </li>
-        <li className={aboutListItem}>保护隐私：未经本人同意，不要公开他人的个人隐私信息。</li>
-        <li className={aboutListItem}>遵守法律法规：不发布违反法律法规及公序良俗的内容。</li>
-      </ol>
+    <PageContainer as='main'>
+      <div className={aboutContent}>
+        <AboutNav />
+        <h1 className={aboutTitle}>社区指导原则</h1>
+        <p className={aboutParagraph}>
+          Bangumi 是一个开放的社区，为了让大家在这里愉快地交流和分享，请所有用户共同遵守以下原则：
+        </p>
+        <ol className={aboutList}>
+          <li className={aboutListItem}>
+            友善交流：尊重每一位用户，不进行人身攻击、引战或恶意骚扰，理性表达不同观点。
+          </li>
+          <li className={aboutListItem}>
+            尊重版权：不要在站内上传或分享侵犯他人版权的资源，转载他人内容时注明出处。
+          </li>
+          <li className={aboutListItem}>
+            条目编辑规范：编辑条目时应如实填写信息并遵循现有规范，不要恶意修改、删除他人的编辑成果。
+          </li>
+          <li className={aboutListItem}>
+            拒绝广告与刷屏：不要发布商业广告、垃圾信息，也不要重复刷屏影响他人浏览。
+          </li>
+          <li className={aboutListItem}>保护隐私：未经本人同意，不要公开他人的个人隐私信息。</li>
+          <li className={aboutListItem}>遵守法律法规：不发布违反法律法规及公序良俗的内容。</li>
+        </ol>
+      </div>
     </PageContainer>
   </>
 );

--- a/packages/website/src/pages/index/about/index.tsx
+++ b/packages/website/src/pages/index/about/index.tsx
@@ -18,7 +18,7 @@ const ABOUT_NAV_ITEMS: AboutNavItem[] = [
   { to: '/about/link2us', label: '链接我们' },
 ];
 
-export const aboutContainer = css({ maxWidth: '760px', margin: '0 auto' });
+export const aboutContent = css({ maxWidth: '700px', margin: '0 auto' });
 
 const nav = css({
   display: 'flex',
@@ -95,32 +95,35 @@ export const AboutNav: React.FC = () => (
 const About: React.FC = () => (
   <>
     <Helmet title='关于本站' />
-    <PageContainer className={aboutContainer}>
-      <AboutNav />
-      <h1 className={aboutTitle}>关于本站</h1>
-      <p className={aboutParagraph}>
-        Bangumi（番组计划）是一个以 ACG（动画、漫画、游戏）为主题的综合性社区网站，创立于 2008 年。
-        在这里，你可以记录自己看过、读过、玩过的作品，也可以和同好一起交流讨论，分享自己的见闻与感想。
-      </p>
-      <section className={aboutSection}>
-        <h2 className={aboutSectionTitle}>核心功能</h2>
-        <ul className={aboutList}>
-          <li className={aboutListItem}>
-            条目资料库：收录动画、漫画、游戏、音乐等 ACG
-            条目，以及人物、角色与声优信息，并支持社区成员共同编辑补充。
-          </li>
-          <li className={aboutListItem}>
-            收藏管理：通过「想看 / 在看 / 看过」等方式记录追番、阅读与游玩进度，随时回顾自己的 ACG
-            历程。
-          </li>
-          <li className={aboutListItem}>
-            兴趣小组：围绕作品、类型或话题创建和加入小组，和同好分享心得、组织活动。
-          </li>
-          <li className={aboutListItem}>
-            日志与吐槽：撰写日志记录长篇感想，也可以在条目和章节下随手记录吐槽。
-          </li>
-        </ul>
-      </section>
+    <PageContainer as='main'>
+      <div className={aboutContent}>
+        <AboutNav />
+        <h1 className={aboutTitle}>关于本站</h1>
+        <p className={aboutParagraph}>
+          Bangumi（番组计划）是一个以 ACG（动画、漫画、游戏）为主题的综合性社区网站，创立于 2008
+          年。
+          在这里，你可以记录自己看过、读过、玩过的作品，也可以和同好一起交流讨论，分享自己的见闻与感想。
+        </p>
+        <section className={aboutSection}>
+          <h2 className={aboutSectionTitle}>核心功能</h2>
+          <ul className={aboutList}>
+            <li className={aboutListItem}>
+              条目资料库：收录动画、漫画、游戏、音乐等 ACG
+              条目，以及人物、角色与声优信息，并支持社区成员共同编辑补充。
+            </li>
+            <li className={aboutListItem}>
+              收藏管理：通过「想看 / 在看 / 看过」等方式记录追番、阅读与游玩进度，随时回顾自己的 ACG
+              历程。
+            </li>
+            <li className={aboutListItem}>
+              兴趣小组：围绕作品、类型或话题创建和加入小组，和同好分享心得、组织活动。
+            </li>
+            <li className={aboutListItem}>
+              日志与吐槽：撰写日志记录长篇感想，也可以在条目和章节下随手记录吐槽。
+            </li>
+          </ul>
+        </section>
+      </div>
     </PageContainer>
   </>
 );

--- a/packages/website/src/pages/index/about/link2us.tsx
+++ b/packages/website/src/pages/index/about/link2us.tsx
@@ -4,7 +4,7 @@ import Helmet from '@bangumi/website/components/Helmet';
 import PageContainer from '@bangumi/website/components/PageContainer';
 
 import {
-  aboutContainer,
+  aboutContent,
   aboutList,
   aboutListItem,
   AboutNav,
@@ -18,35 +18,37 @@ import {
 const Link2Us: React.FC = () => (
   <>
     <Helmet title='链接我们' />
-    <PageContainer className={aboutContainer}>
-      <AboutNav />
-      <h1 className={aboutTitle}>链接我们</h1>
-      <section className={aboutSection}>
-        <h2 className={aboutSectionTitle}>申请条件</h2>
-        <ul className={aboutList}>
-          <li className={aboutListItem}>网站内容与 ACG（动画、漫画、游戏）相关；</li>
-          <li className={aboutListItem}>内容健康，无恶意程序与违规信息；</li>
-          <li className={aboutListItem}>已添加指向 Bangumi 的链接。</li>
-        </ul>
-      </section>
-      <section className={aboutSection}>
-        <h2 className={aboutSectionTitle}>申请方式</h2>
-        <p className={aboutParagraph}>
-          满足条件的站点，请到站务论坛发布申请帖，附上站点名称、地址与一句简介：
-        </p>
-        <p className={aboutParagraph}>
-          <a className={inlineLink} href='https://bgm.tv/group/issues'>
-            https://bgm.tv/group/issues
-          </a>
-        </p>
-      </section>
-      <section className={aboutSection}>
-        <h2 className={aboutSectionTitle}>审核说明</h2>
-        <p className={aboutParagraph}>
-          我们会在核实站点信息后尽快处理申请。由于精力有限，暂时只接受与 ACG
-          相关的站点申请，敬请谅解。
-        </p>
-      </section>
+    <PageContainer as='main'>
+      <div className={aboutContent}>
+        <AboutNav />
+        <h1 className={aboutTitle}>链接我们</h1>
+        <section className={aboutSection}>
+          <h2 className={aboutSectionTitle}>申请条件</h2>
+          <ul className={aboutList}>
+            <li className={aboutListItem}>网站内容与 ACG（动画、漫画、游戏）相关；</li>
+            <li className={aboutListItem}>内容健康，无恶意程序与违规信息；</li>
+            <li className={aboutListItem}>已添加指向 Bangumi 的链接。</li>
+          </ul>
+        </section>
+        <section className={aboutSection}>
+          <h2 className={aboutSectionTitle}>申请方式</h2>
+          <p className={aboutParagraph}>
+            满足条件的站点，请到站务论坛发布申请帖，附上站点名称、地址与一句简介：
+          </p>
+          <p className={aboutParagraph}>
+            <a className={inlineLink} href='https://bgm.tv/group/issues'>
+              https://bgm.tv/group/issues
+            </a>
+          </p>
+        </section>
+        <section className={aboutSection}>
+          <h2 className={aboutSectionTitle}>审核说明</h2>
+          <p className={aboutParagraph}>
+            我们会在核实站点信息后尽快处理申请。由于精力有限，暂时只接受与 ACG
+            相关的站点申请，敬请谅解。
+          </p>
+        </section>
+      </div>
     </PageContainer>
   </>
 );

--- a/packages/website/src/pages/index/channel/index.spec.tsx
+++ b/packages/website/src/pages/index/channel/index.spec.tsx
@@ -81,6 +81,7 @@ describe('ChannelPageContent', () => {
   it('renders all channel data sections', () => {
     renderPage(<ChannelPageContent config={CHANNEL_CONFIGS.anime} data={createData()} />);
 
+    expect(document.querySelector('main')?.className).toContain('max-w_1260px');
     expect(screen.getAllByText('尼古喵喵')).toHaveLength(2);
     expect(screen.getByRole('heading', { name: '好友动态' })).toBeInTheDocument();
     expect(screen.getByText('七月新番第一话短评合集')).toBeInTheDocument();

--- a/packages/website/src/pages/index/channel/index.tsx
+++ b/packages/website/src/pages/index/channel/index.tsx
@@ -32,15 +32,9 @@ import type { ChannelConfig, ChannelKey } from './config';
 import { CHANNEL_CONFIGS } from './config';
 
 const page = css({
-  maxWidth: '1060px',
-  paddingTop: '15px',
-  paddingBottom: '32px',
-  '@media (max-width: 1024px)': {
-    maxWidth: '820px',
-  },
+  padding: '15px 15px 32px',
   '@media (max-width: 640px)': {
-    paddingTop: '14px',
-    paddingBottom: '24px',
+    padding: '14px 15px 24px',
   },
 });
 
@@ -65,7 +59,7 @@ const pageHeader = css({
 
 const columns = css({
   display: 'grid',
-  gridTemplateColumns: 'minmax(0, 700px) 280px',
+  gridTemplateColumns: 'minmax(0, 1fr) 280px',
   gap: '15px',
   alignItems: 'start',
   '@media (max-width: 1024px)': {

--- a/packages/website/src/pages/index/character/[id]/CharacterDetail.spec.tsx
+++ b/packages/website/src/pages/index/character/[id]/CharacterDetail.spec.tsx
@@ -57,6 +57,8 @@ describe('CharacterDetail', () => {
 
     // header 标题（出演区同名条目重复出现）
     expect((await screen.findAllByText('ヤニねこ')).length).toBeGreaterThan(0);
+    expect(document.querySelector('main')?.className).toContain('max-w_1260px');
+    expect(document.querySelector('main')?.className).toContain('p_10px_15px_24px');
     // 信息框
     expect(await screen.findByText(/简体中文名/)).toBeInTheDocument();
     // 推荐目录

--- a/packages/website/src/pages/index/character/[id]/CharacterDetail.tsx
+++ b/packages/website/src/pages/index/character/[id]/CharacterDetail.tsx
@@ -22,6 +22,7 @@ import {
   getSubjectLink,
   getUserProfileLink,
 } from '@bangumi/utils/pages';
+import PageContainer from '@bangumi/website/components/PageContainer';
 import { makeDescriptiveTime } from '@bangumi/website/components/TimelineDescription';
 import type {
   CharacterComment,
@@ -31,41 +32,19 @@ import { useCharacterHome } from '@bangumi/website/hooks/use-character-home';
 import { useUser } from '@bangumi/website/hooks/use-user';
 
 const page = css({
-  width: '100%',
-  maxWidth: '1000px',
-  marginRight: 'auto',
-  marginLeft: 'auto',
-  boxSizing: 'border-box',
   display: 'grid',
-  gridTemplateColumns: '250px minmax(0, 720px)',
+  gridTemplateColumns: '250px minmax(0, 1fr)',
   alignItems: 'flex-start',
-  gap: '15px',
-  paddingBottom: '30px',
-  '@media (max-width: 1000px)': {
-    paddingRight: '15px',
-    paddingLeft: '15px',
-    gridTemplateColumns: 'minmax(200px, 250px) minmax(0, 720px)',
-  },
+  gap: '20px',
+  padding: '10px 15px 24px',
   '@media (max-width: 640px)': {
     display: 'block',
-    padding: '0 5px 24px',
   },
 });
 
 const headerInner = css({
-  width: '100%',
-  maxWidth: '1000px',
-  marginRight: 'auto',
-  marginLeft: 'auto',
-  boxSizing: 'border-box',
-  '@media (max-width: 1000px)': {
-    paddingRight: '15px',
-    paddingLeft: '15px',
-  },
-  '@media (max-width: 640px)': {
-    paddingRight: '10px',
-    paddingLeft: '10px',
-  },
+  paddingRight: '15px',
+  paddingLeft: '15px',
 });
 
 const name = css({
@@ -96,23 +75,12 @@ const tabsBar = css({
 });
 
 const tabsInner = css({
-  width: '100%',
-  maxWidth: '1000px',
-  marginRight: 'auto',
-  marginLeft: 'auto',
-  boxSizing: 'border-box',
+  paddingRight: '15px',
+  paddingLeft: '15px',
   overflowX: 'auto',
   scrollbarWidth: 'none',
   '&::-webkit-scrollbar': {
     display: 'none',
-  },
-  '@media (max-width: 1000px)': {
-    paddingRight: '15px',
-    paddingLeft: '15px',
-  },
-  '@media (max-width: 640px)': {
-    paddingRight: '10px',
-    paddingLeft: '10px',
   },
 });
 
@@ -643,16 +611,16 @@ function CharacterHeader({ character }: { character: Character }) {
 
   return (
     <header>
-      <div className={headerInner}>
+      <PageContainer gutterOnly className={headerInner}>
         <h1 className={name}>
           <Link to={baseLink} title={character.nameCN}>
             {character.name}
           </Link>
           {character.nameCN !== '' && <small>{character.nameCN}</small>}
         </h1>
-      </div>
+      </PageContainer>
       <nav className={tabsBar} aria-label='角色导航'>
-        <div className={tabsInner}>
+        <PageContainer gutterOnly className={tabsInner}>
           <ul className={tabList}>
             {tabs.map((tab) => (
               <li key={tab.to}>
@@ -673,7 +641,7 @@ function CharacterHeader({ character }: { character: Character }) {
               </li>
             )}
           </ul>
-        </div>
+        </PageContainer>
       </nav>
     </header>
   );
@@ -936,7 +904,7 @@ export default function CharacterDetail({ data }: { data: CharacterHomeResponse 
   return (
     <>
       <CharacterHeader character={character} />
-      <main className={page}>
+      <PageContainer as='main' className={page}>
         <aside className={sidebar}>
           <CharacterInfobox character={character} />
           <IndexPanel indexes={data.indexes} total={data.indexTotal} />
@@ -953,7 +921,7 @@ export default function CharacterDetail({ data }: { data: CharacterHomeResponse 
           <RelationsSection relations={data.relations} />
           <CommentsSection comments={data.comments} />
         </div>
-      </main>
+      </PageContainer>
     </>
   );
 }

--- a/packages/website/src/pages/index/ep/[id]/EpisodeDetail.spec.tsx
+++ b/packages/website/src/pages/index/ep/[id]/EpisodeDetail.spec.tsx
@@ -13,6 +13,15 @@ import { renderPage } from '@bangumi/website/utils/test-utils';
 
 import EpisodePage from '.';
 
+vi.mock('@bangumi/website/hooks/use-user', async () => ({
+  ...(await vi.importActual<typeof import('@bangumi/website/hooks/use-user')>(
+    '@bangumi/website/hooks/use-user',
+  )),
+  useUser: () => ({
+    user: { permissions: { subjectWikiEdit: true } },
+  }),
+}));
+
 vi.mock('react-router-dom', async () => {
   return {
     __esModule: true,
@@ -58,10 +67,22 @@ describe('EpisodeDetail', () => {
     const activeTab = screen.getByRole('link', { name: '章节' });
     expect(activeTab.className).toContain('p_10px_10px_9px');
     expect(activeTab.className).toContain('c_#f09199');
+    expect(document.querySelector('main')?.className).toContain('max-w_1260px');
+    expect(document.querySelector('main')?.className).toContain('p_10px_15px_24px');
 
     // 主栏：章节 label、名称与简介
-    expect(screen.getByRole('heading', { name: /EP\.1 燃えよ狂犬/ })).toBeInTheDocument();
+    const episodeHeading = screen.getByRole('heading', { name: /EP\.1 燃えよ狂犬/ });
+    expect(episodeHeading).toBeInTheDocument();
+    const editLink = screen.getByRole('link', { name: '[修改]' });
+    expect(editLink).toHaveAttribute('href', '/ep/1704816/edit');
+    expect(episodeHeading).toContainElement(editLink);
+    const patchLink = screen.getByRole('link', { name: '[提供修改建议]' });
+    expect(patchLink).toHaveAttribute('href', 'https://patch.bgm38.tv/edit/episode/1704816');
+    expect(patchLink).toHaveAttribute('target', '_blank');
+    expect(patchLink).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(episodeHeading).toContainElement(patchLink);
     expect(screen.getAllByText('燃烧吧，狂犬').length).toBeGreaterThan(0);
+    expect(screen.getByText('时长:00:23:40 / 首播:2026-07-04')).toBeInTheDocument();
     expect(screen.getByText(/ルーデウスと結ばれたものの/)).toBeInTheDocument();
 
     // 吐槽箱：评论作者与内容

--- a/packages/website/src/pages/index/ep/[id]/EpisodeDetail.tsx
+++ b/packages/website/src/pages/index/ep/[id]/EpisodeDetail.tsx
@@ -24,20 +24,12 @@ import type { EpisodePageData } from '@bangumi/website/hooks/use-episode-page';
 import { useUser } from '@bangumi/website/hooks/use-user';
 
 const page = css({
-  maxWidth: '1040px',
-  padding: '10px 30px 32px',
-  '@media (max-width: 640px)': {
-    padding: '8px 10px 24px',
-  },
+  padding: '10px 15px 24px',
 });
 
 const headerInner = css({
-  paddingRight: '30px',
-  paddingLeft: '30px',
-  '@media (max-width: 640px)': {
-    paddingRight: '10px',
-    paddingLeft: '10px',
-  },
+  paddingRight: '15px',
+  paddingLeft: '15px',
 });
 
 const subjectTitle = css({
@@ -140,52 +132,53 @@ const sidebar = css({
 });
 
 const episodeInfo = css({
-  padding: '6px 5px 22px',
+  padding: '6px 5px 18px',
   borderBottom: '1px solid #e8e3e3',
-  '& h1': {
-    margin: '0',
-    color: '#1f1c1c',
-    fontSize: '22px',
-    fontWeight: '400',
-    lineHeight: '1.4',
-    overflowWrap: 'anywhere',
-    '& > span': {
-      color: '#f09199',
-      fontSize: '16px',
-      fontWeight: '600',
-    },
-  },
   '@media (max-width: 640px)': {
     paddingRight: '2px',
     paddingLeft: '2px',
-    '& h1': {
-      fontSize: '19px',
-    },
   },
 });
 
+const episodeTitle = css({
+  margin: '0',
+  color: '#595555',
+  fontSize: '22px',
+  fontWeight: '400',
+  lineHeight: '1.4',
+  overflowWrap: 'anywhere',
+  '@media (max-width: 640px)': {
+    fontSize: '19px',
+  },
+});
+
+const episodeLabelStyle = css({
+  color: '#f09199',
+  fontSize: 'inherit',
+  fontWeight: 'inherit',
+});
+
 const episodeNameCN = css({
-  margin: '3px 0 0',
+  margin: '2px 0 0',
   color: '#9f9b9b',
   fontSize: '14px',
 });
 
-const editLink = css({
-  display: 'inline-block',
-  marginTop: '8px',
+const editLinks = css({
+  marginLeft: '8px',
   fontSize: '13px',
+  fontWeight: '400',
+  whiteSpace: 'nowrap',
 });
 
 const episodeMeta = css({
-  display: 'flex',
-  margin: '14px 0 0',
+  margin: '10px 0 0',
   color: '#9f9b9b',
   fontSize: '12px',
-  gap: '18px',
 });
 
 const description = css({
-  margin: '12px 0 0',
+  margin: '8px 0 0',
   color: '#595555',
   fontSize: '14px',
   lineHeight: '1.75',
@@ -193,7 +186,7 @@ const description = css({
 });
 
 const emptyDescription = css({
-  margin: '12px 0 0',
+  margin: '8px 0 0',
   color: '#9f9b9b',
   fontSize: '14px',
   lineHeight: '1.75',
@@ -723,18 +716,27 @@ export default function EpisodeDetail({ data }: { data: EpisodePageData }) {
         <div className={columns}>
           <div className={mainColumn}>
             <section className={episodeInfo}>
-              <h1>
-                <span>{episodeLabel(episode)}</span> {episode.name}
+              <h1 className={episodeTitle}>
+                <span className={episodeLabelStyle}>{episodeLabel(episode)}</span> {episode.name}
+                <small className={editLinks}>
+                  {user?.permissions?.subjectWikiEdit && (
+                    <Link to={`/ep/${episode.id}/edit`}>[修改]</Link>
+                  )}
+                  <Link
+                    to={`https://patch.bgm38.tv/edit/episode/${episode.id}`}
+                    isExternal
+                    target='_blank'
+                    rel='noopener noreferrer'
+                  >
+                    [提供修改建议]
+                  </Link>
+                </small>
               </h1>
-              {user?.permissions?.subjectWikiEdit && (
-                <Link to={`/ep/${episode.id}/edit`} className={editLink}>
-                  编辑章节
-                </Link>
-              )}
               {episode.nameCN && <p className={episodeNameCN}>{episode.nameCN}</p>}
               <p className={episodeMeta}>
-                {episode.duration && <span>时长 {episode.duration}</span>}
-                {episode.airdate && <span>首播 {episode.airdate}</span>}
+                {episode.duration && <>时长:{episode.duration}</>}
+                {episode.duration && episode.airdate && ' / '}
+                {episode.airdate && <>首播:{episode.airdate}</>}
               </p>
               {episode.desc ? (
                 <p className={description}>{episode.desc}</p>

--- a/packages/website/src/pages/index/ep/[id]/edit.spec.tsx
+++ b/packages/website/src/pages/index/ep/[id]/edit.spec.tsx
@@ -41,6 +41,7 @@ describe('EpisodeEditPage', () => {
     });
 
     const name = await screen.findByLabelText('原名');
+    expect(document.querySelector('main')?.className).toContain('max-w_1260px');
     expect(name).toHaveValue('燃えよ狂犬');
     expect(screen.getByLabelText('中文名')).toHaveValue('燃烧吧，狂犬');
 

--- a/packages/website/src/pages/index/ep/[id]/edit.tsx
+++ b/packages/website/src/pages/index/ep/[id]/edit.tsx
@@ -11,15 +11,16 @@ import { Button, Form, Input, toast, Typography } from '@bangumi/design';
 import { css } from '@bangumi/styled-system/css';
 import { withErrorBoundary } from '@bangumi/website/components/ErrorBoundary';
 import Helmet from '@bangumi/website/components/Helmet';
+import PageContainer from '@bangumi/website/components/PageContainer';
 
 const page = css({
-  maxWidth: '760px',
-  margin: '0 auto',
-  padding: '32px 30px 48px',
+  padding: '32px 15px 48px',
   '@media (max-width: 768px)': {
     padding: '24px 16px 36px',
   },
 });
+
+const content = css({ maxWidth: '700px', margin: '0 auto' });
 
 const title = css({
   margin: '8px 0 24px',
@@ -159,92 +160,99 @@ function EpisodeEditPage() {
   };
 
   return (
-    <main className={page}>
+    <PageContainer as='main' className={page}>
       <Helmet title={`编辑章节 ${episode.ep} - ${episode.name}`} />
-      <Typography.Text type='secondary'>正在编辑章节 #{episode.id}</Typography.Text>
-      <h1 className={title}>编辑章节</h1>
-      <Form labelWidth={92} className={form} onSubmit={handleSubmit(onSubmit, onInvalid)}>
-        <Form.Item label='原名'>
-          <Input
-            aria-label='原名'
-            wrapperClass={input}
-            {...register('name', { required: '请填写章节原名' })}
-          />
-        </Form.Item>
-        <Form.Item label='中文名'>
-          <Input aria-label='中文名' wrapperClass={input} {...register('nameCN')} />
-        </Form.Item>
-        <Form.Item label='类型'>
-          <select
-            aria-label='类型'
-            className={select}
-            {...register('type', { valueAsNumber: true })}
-          >
-            {episodeTypes.map((type) => (
-              <option key={type.value} value={type.value}>
-                {type.label}
-              </option>
-            ))}
-          </select>
-        </Form.Item>
-        <Form.Item label='章节编号'>
-          <Input
-            type='number'
-            aria-label='章节编号'
-            step='0.1'
-            wrapperClass={numberInput}
-            {...register('ep', { required: '请填写章节编号', valueAsNumber: true })}
-          />
-        </Form.Item>
-        <Form.Item label='碟号'>
-          <Input
-            type='number'
-            aria-label='碟号'
-            min='0'
-            step='1'
-            wrapperClass={numberInput}
-            {...register('disc', {
-              setValueAs: (value) => (value === '' ? undefined : Number(value)),
-            })}
-          />
-        </Form.Item>
-        <Form.Item label='时长'>
-          <Input
-            aria-label='时长'
-            placeholder='例如 24:53'
-            wrapperClass={input}
-            {...register('duration')}
-          />
-        </Form.Item>
-        <Form.Item label='首播日期'>
-          <Input type='date' aria-label='首播日期' wrapperClass={dateInput} {...register('date')} />
-        </Form.Item>
-        <Form.Item label='简介'>
-          <textarea aria-label='简介' className={textarea} rows={8} {...register('summary')} />
-        </Form.Item>
-        <Form.Item label='编辑摘要'>
-          <Input
-            aria-label='编辑摘要'
-            wrapperClass={input}
-            {...register('commitMessage', { required: '请填写编辑摘要' })}
-          />
-        </Form.Item>
-        <div className={actions}>
-          <Button
-            type='plain'
-            onClick={() => {
-              void navigate(`/ep/${episodeID}`);
-            }}
-            disabled={submitting}
-          >
-            取消
-          </Button>
-          <Button htmlType='submit' color='blue' disabled={submitting}>
-            {submitting ? '提交中...' : '提交修改'}
-          </Button>
-        </div>
-      </Form>
-    </main>
+      <div className={content}>
+        <Typography.Text type='secondary'>正在编辑章节 #{episode.id}</Typography.Text>
+        <h1 className={title}>编辑章节</h1>
+        <Form labelWidth={92} className={form} onSubmit={handleSubmit(onSubmit, onInvalid)}>
+          <Form.Item label='原名'>
+            <Input
+              aria-label='原名'
+              wrapperClass={input}
+              {...register('name', { required: '请填写章节原名' })}
+            />
+          </Form.Item>
+          <Form.Item label='中文名'>
+            <Input aria-label='中文名' wrapperClass={input} {...register('nameCN')} />
+          </Form.Item>
+          <Form.Item label='类型'>
+            <select
+              aria-label='类型'
+              className={select}
+              {...register('type', { valueAsNumber: true })}
+            >
+              {episodeTypes.map((type) => (
+                <option key={type.value} value={type.value}>
+                  {type.label}
+                </option>
+              ))}
+            </select>
+          </Form.Item>
+          <Form.Item label='章节编号'>
+            <Input
+              type='number'
+              aria-label='章节编号'
+              step='0.1'
+              wrapperClass={numberInput}
+              {...register('ep', { required: '请填写章节编号', valueAsNumber: true })}
+            />
+          </Form.Item>
+          <Form.Item label='碟号'>
+            <Input
+              type='number'
+              aria-label='碟号'
+              min='0'
+              step='1'
+              wrapperClass={numberInput}
+              {...register('disc', {
+                setValueAs: (value) => (value === '' ? undefined : Number(value)),
+              })}
+            />
+          </Form.Item>
+          <Form.Item label='时长'>
+            <Input
+              aria-label='时长'
+              placeholder='例如 24:53'
+              wrapperClass={input}
+              {...register('duration')}
+            />
+          </Form.Item>
+          <Form.Item label='首播日期'>
+            <Input
+              type='date'
+              aria-label='首播日期'
+              wrapperClass={dateInput}
+              {...register('date')}
+            />
+          </Form.Item>
+          <Form.Item label='简介'>
+            <textarea aria-label='简介' className={textarea} rows={8} {...register('summary')} />
+          </Form.Item>
+          <Form.Item label='编辑摘要'>
+            <Input
+              aria-label='编辑摘要'
+              wrapperClass={input}
+              {...register('commitMessage', { required: '请填写编辑摘要' })}
+            />
+          </Form.Item>
+          <div className={actions}>
+            <Button
+              type='plain'
+              onClick={() => {
+                void navigate(`/ep/${episodeID}`);
+              }}
+              disabled={submitting}
+            >
+              取消
+            </Button>
+            <Button htmlType='submit' color='blue' disabled={submitting}>
+              {submitting ? '提交中...' : '提交修改'}
+            </Button>
+          </div>
+        </Form>
+      </div>
+    </PageContainer>
   );
 }
 

--- a/packages/website/src/pages/index/person/[id]/PersonDetail.spec.tsx
+++ b/packages/website/src/pages/index/person/[id]/PersonDetail.spec.tsx
@@ -73,6 +73,8 @@ describe('PersonDetail', () => {
       'href',
       '/person/21884/works',
     );
+    expect(document.querySelector('main')?.className).toContain('max-w_1260px');
+    expect(document.querySelector('main')?.className).toContain('p_10px_15px_24px');
 
     // 左栏：infobox 与收藏者
     // span 内的文本被拆分成多个 text node，用函数匹配器

--- a/packages/website/src/pages/index/person/[id]/PersonDetail.tsx
+++ b/packages/website/src/pages/index/person/[id]/PersonDetail.tsx
@@ -25,21 +25,14 @@ import type { PersonHomeData } from '@bangumi/website/hooks/use-person-home';
 import PersonLayout from './components/PersonLayout';
 
 const page = css({
-  padding: '10px 30px 30px',
-  '@media (max-width: 640px)': {
-    padding: '10px 8px 24px',
-  },
+  padding: '10px 15px 24px',
 });
 
 const header = css({ margin: '0' });
 
 const headerInner = css({
-  paddingRight: '30px',
-  paddingLeft: '30px',
-  '@media (max-width: 640px)': {
-    paddingRight: '8px',
-    paddingLeft: '8px',
-  },
+  paddingRight: '15px',
+  paddingLeft: '15px',
 });
 
 const name = css({


### PR DESCRIPTION
## Summary

- align episode, person, character, and channel page shells with the subject page 1260px container and 15px gutter
- keep About and episode edit content readable with an inner narrow column while using the shared outer page width
- align the episode header with the legacy page, including inline edit and patch suggestion links
- regenerate committed Panda CSS and add layout regression assertions

## Verification

- `pnpm test --run packages/website/src/pages/index/ep/[id]/EpisodeDetail.spec.tsx packages/website/src/pages/index/ep/[id]/edit.spec.tsx packages/website/src/pages/index/person/[id]/PersonDetail.spec.tsx packages/website/src/pages/index/character/[id]/CharacterDetail.spec.tsx packages/website/src/pages/index/channel/index.spec.tsx`
- `pnpm lint`
- `pnpm lint:style`
- `pnpm type-check`
- `pnpm prettier:check`
- `pnpm build`
- Playwright fixture screenshots for subject, episode desktop/mobile, person, channel, and About pages

## Conflict check

- fetched the latest `origin/master` before commit
- branch was based directly on current `origin/master`; `git merge-tree` reported no conflicts