### PR TITLE
feat(website): add subject topic pages

### DIFF
--- a/packages/design/components/Topic/Comment.tsx
+++ b/packages/design/components/Topic/Comment.tsx
@@ -2,7 +2,6 @@ import type { FC } from 'react';
 import React, { memo, useCallback, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
-import { ozaClient } from '@bangumi/client';
 import type { Reply, ReplyBase, SlimUser } from '@bangumi/client/topic';
 import { State } from '@bangumi/client/topic';
 import { OriginalPoster, TopicClosed, TopicReopen, TopicSilent } from '@bangumi/icons';
@@ -17,6 +16,8 @@ import CommentActions from './CommentActions';
 import CommentInfo from './CommentInfo';
 import Reactions from './Reactions';
 import ReplyForm from './ReplyForm';
+import type { TopicApi } from './topic-api';
+import { groupTopicApi } from './topic-api';
 
 // 昵称/签名/内容可能包含长文本或 URL，允许换行避免移动端水平溢出；
 // tip 是 flex 容器，内部 flex 项默认 min-width: auto 不收缩，需显式允许收缩；
@@ -140,6 +141,8 @@ export type CommentProps = ((ReplyBase & { isReply: true }) | (Reply & { isReply
   isMainPost?: boolean;
   /** 主题帖的回复总数，用于在主题帖底部展示回复数 */
   replyCount?: number;
+  /** 话题操作实现，默认小组话题 */
+  api?: TopicApi;
 };
 
 const Link = Typography.Link;
@@ -195,6 +198,7 @@ const Comment: FC<CommentProps> = ({
   onCommentUpdate,
   isMainPost = false,
   replyCount,
+  api = groupTopicApi,
   ...props
 }) => {
   const isReply = props.isReply;
@@ -266,7 +270,7 @@ const Comment: FC<CommentProps> = ({
 
   const handleDeleteReply = async () => {
     if (confirm('确认删除这条回复？')) {
-      const response = await ozaClient.deleteGroupPost(props.id);
+      const response = await api.deletePost(props.id);
       if (response.status === 200) {
         onCommentUpdate();
       } else {
@@ -306,6 +310,7 @@ const Comment: FC<CommentProps> = ({
                       reactions={props.reactions}
                       user={user}
                       onReacted={onCommentUpdate}
+                      api={api}
                     />
                   </>
                 )}
@@ -318,6 +323,7 @@ const Comment: FC<CommentProps> = ({
                 postId={props.id}
                 user={user}
                 onReacted={onCommentUpdate}
+                api={api}
               />
             )}
             {isMainPost && replyCount != null && (
@@ -332,6 +338,7 @@ const Comment: FC<CommentProps> = ({
                 autoFocus
                 topicId={topicId}
                 replyTo={props.id}
+                api={api}
                 placeholder={`回复 @${creator?.nickname ?? ''}：`}
                 content={replyContent}
                 onChange={setReplyContent}

--- a/packages/design/components/Topic/CommentActions.tsx
+++ b/packages/design/components/Topic/CommentActions.tsx
@@ -7,6 +7,8 @@ import { css, cx } from '@bangumi/styled-system/css';
 import Button from '../../components/Button';
 import Popover from '../Popover';
 import { ReactionMenu } from './Reactions';
+import type { TopicApi } from './topic-api';
+import { groupTopicApi } from './topic-api';
 
 const commentActions = css({
   display: 'flex',
@@ -49,6 +51,8 @@ export interface CommentActionsProps {
   reactions?: Reaction[];
   user?: Pick<SlimUser, 'id'>;
   onReacted?: () => Promise<unknown>;
+  /** 话题操作实现，默认小组话题 */
+  api?: TopicApi;
 }
 
 const CommentActions = ({
@@ -61,6 +65,7 @@ const CommentActions = ({
   reactions,
   user,
   onReacted,
+  api = groupTopicApi,
 }: CommentActionsProps) => {
   return (
     <div className={cx('bgm-comment-actions', commentActions)}>
@@ -71,7 +76,13 @@ const CommentActions = ({
       {user && onReacted && (
         <Popover
           content={
-            <ReactionMenu reactions={reactions} postId={id} user={user} onReacted={onReacted} />
+            <ReactionMenu
+              reactions={reactions}
+              postId={id}
+              user={user}
+              onReacted={onReacted}
+              api={api}
+            />
           }
         >
           <Button type='plain' size='small' title='贴贴'>
@@ -85,7 +96,7 @@ const CommentActions = ({
             {isAuthor && (
               <>
                 {editable && (
-                  <Button.Link type='text' size='small' to={`/group/reply/${id}/edit`}>
+                  <Button.Link type='text' size='small' to={api.replyEditPath(id)}>
                     编辑
                   </Button.Link>
                 )}

--- a/packages/design/components/Topic/Reactions.tsx
+++ b/packages/design/components/Topic/Reactions.tsx
@@ -1,10 +1,12 @@
 import type { FC } from 'react';
 import React, { useCallback, useState } from 'react';
 
-import { ozaClient } from '@bangumi/client';
 import type { Reaction, SlimUser } from '@bangumi/client/topic';
 import { css, cx } from '@bangumi/styled-system/css';
 import { ALLOWED_REACTIONS, getReactionEmojiUrl } from '@bangumi/utils';
+
+import type { TopicApi } from './topic-api';
+import { groupTopicApi } from './topic-api';
 
 export interface ReactionsProps {
   reactions?: Reaction[];
@@ -12,6 +14,8 @@ export interface ReactionsProps {
   user?: Pick<SlimUser, 'id'>;
   /** 点赞/取消点赞成功后的回调，用于刷新数据 */
   onReacted: () => Promise<unknown>;
+  /** 话题操作实现，默认小组话题 */
+  api?: TopicApi;
 }
 
 const container = css({
@@ -86,6 +90,7 @@ function useReactionToggle(
   postId: number,
   user: ReactionsProps['user'],
   onReacted: ReactionsProps['onReacted'],
+  api: NonNullable<ReactionsProps['api']>,
 ) {
   const [pending, setPending] = useState<number | null>(null);
 
@@ -106,8 +111,8 @@ function useReactionToggle(
       setPending(value);
       try {
         const response = isSelected(reactions, value)
-          ? await ozaClient.unlikeGroupPost(postId)
-          : await ozaClient.likeGroupPost(postId, { value });
+          ? await api.unlikePost(postId)
+          : await api.likePost(postId, value);
         if (response.status === 200) {
           await onReacted();
         }
@@ -115,15 +120,21 @@ function useReactionToggle(
         setPending(null);
       }
     },
-    [user, pending, postId, isSelected, onReacted],
+    [user, pending, postId, isSelected, onReacted, api],
   );
 
   return { pending, isSelected, toggle };
 }
 
 /** 评论内容下方的 reactions 列表，点击切换点赞状态 */
-const Reactions: FC<ReactionsProps> = ({ reactions = [], postId, user, onReacted }) => {
-  const { pending, isSelected, toggle } = useReactionToggle(postId, user, onReacted);
+const Reactions: FC<ReactionsProps> = ({
+  reactions = [],
+  postId,
+  user,
+  onReacted,
+  api = groupTopicApi,
+}) => {
+  const { pending, isSelected, toggle } = useReactionToggle(postId, user, onReacted, api);
 
   if (reactions.length === 0) {
     return null;
@@ -157,8 +168,14 @@ const Reactions: FC<ReactionsProps> = ({ reactions = [], postId, user, onReacted
 };
 
 /** 反应选择菜单，供操作区"贴贴"按钮使用 */
-export const ReactionMenu: FC<ReactionsProps> = ({ reactions = [], postId, user, onReacted }) => {
-  const { pending, isSelected, toggle } = useReactionToggle(postId, user, onReacted);
+export const ReactionMenu: FC<ReactionsProps> = ({
+  reactions = [],
+  postId,
+  user,
+  onReacted,
+  api = groupTopicApi,
+}) => {
+  const { pending, isSelected, toggle } = useReactionToggle(postId, user, onReacted, api);
 
   return (
     <div className={menu}>

--- a/packages/design/components/Topic/ReplyForm.tsx
+++ b/packages/design/components/Topic/ReplyForm.tsx
@@ -1,10 +1,10 @@
 import { Turnstile } from '@marsidev/react-turnstile';
 import React, { memo, useState } from 'react';
 
-import { ozaClient } from '@bangumi/client';
-
 import type { EditorFormProps } from '../../components/EditorForm';
 import EditorForm from '../../components/EditorForm';
+import type { TopicApi } from './topic-api';
+import { groupTopicApi } from './topic-api';
 
 interface ReplyFormProps extends EditorFormProps {
   topicId: number;
@@ -19,6 +19,8 @@ interface ReplyFormProps extends EditorFormProps {
   onCancel?: () => void;
   /** 回复成功时的回调函数 */
   onSuccess?: (id: number) => void;
+  /** 话题操作实现，默认小组话题 */
+  api?: TopicApi;
 }
 
 const ReplyForm = ({
@@ -29,6 +31,7 @@ const ReplyForm = ({
   onChange,
   onCancel,
   onSuccess,
+  api = groupTopicApi,
   ...props
 }: ReplyFormProps) => {
   const [sending, setSending] = useState(false);
@@ -39,7 +42,7 @@ const ReplyForm = ({
     if (sending) return; // TODO: disable button instead
     setSending(true);
     try {
-      const response = await ozaClient.createGroupReply(topicId, {
+      const response = await api.createReply(topicId, {
         content,
         replyTo,
         turnstileToken: turnstileToken ?? '',

--- a/packages/design/components/Topic/topic-api.ts
+++ b/packages/design/components/Topic/topic-api.ts
@@ -1,0 +1,38 @@
+import { ozaClient } from '@bangumi/client';
+import type { CreateReply, ErrorResponse, TurnstileToken } from '@bangumi/client/client';
+
+/** 话题相关操作的统一返回，客户端只关心 200 与错误信息 */
+type TopicApiResult<T> =
+  | {
+      status: 200;
+      data: T;
+    }
+  | {
+      status: 429 | 500;
+      data: ErrorResponse;
+    };
+
+/**
+ * 话题页面所需的回复/删除/点赞操作，group 与 subject 话题分别提供实现。
+ * blog、episode 等同样具备"评论列表 + 回复表单"的页面日后可复用该接口。
+ */
+export interface TopicApi {
+  createReply: (
+    topicId: number,
+    body: CreateReply & TurnstileToken,
+  ) => Promise<TopicApiResult<{ id: number }>>;
+  deletePost: (postId: number) => Promise<TopicApiResult<{}>>;
+  likePost: (postId: number, value: number) => Promise<TopicApiResult<{}>>;
+  unlikePost: (postId: number) => Promise<TopicApiResult<{}>>;
+  /** 回复编辑页面路径 */
+  replyEditPath: (postId: number) => string;
+}
+
+/** 小组话题默认实现 */
+export const groupTopicApi: TopicApi = {
+  createReply: async (topicId, body) => ozaClient.createGroupReply(topicId, body),
+  deletePost: async (postId) => ozaClient.deleteGroupPost(postId),
+  likePost: async (postId, value) => ozaClient.likeGroupPost(postId, { value }),
+  unlikePost: async (postId) => ozaClient.unlikeGroupPost(postId),
+  replyEditPath: (postId) => `/group/reply/${postId}/edit`,
+};

--- a/packages/styled-system/styles.css
+++ b/packages/styled-system/styles.css
@@ -1976,6 +1976,14 @@
     font-weight: var(--font-weights-bold);
 }
 
+  .ai_flex-start {
+    align-items: flex-start;
+}
+
+  .flex-b_75\% {
+    flex-basis: 75%;
+}
+
   .jc_center {
     justify-content: center;
 }
@@ -2333,10 +2341,6 @@
     grid-template-columns: 250px minmax(0, 1fr);
 }
 
-  .ai_flex-start {
-    align-items: flex-start;
-}
-
   .lh_1\.3 {
     line-height: 1.3;
 }
@@ -2646,10 +2650,6 @@
     grid-template-columns: repeat(10, 1fr);
 }
 
-  .flex-b_75\% {
-    flex-basis: 75%;
-}
-
   .bx-sh_0_1px_4px_rgba\(0\,_0\,_0\,_0\.04\) {
     box-shadow: 0 1px 4px rgba(0, 0, 0, 0.04);
 }
@@ -2897,6 +2897,18 @@
 
   .w_100\% {
     width: 100%;
+}
+
+  .mt_10px {
+    margin-top: 10px;
+}
+
+  .mt_20px {
+    margin-top: 20px;
+}
+
+  .ml_10px {
+    margin-left: 10px;
 }
 
   .min-w_24px {
@@ -3255,10 +3267,6 @@
     border-bottom-color: #f09199;
 }
 
-  .mt_10px {
-    margin-top: 10px;
-}
-
   .w_240px {
     width: 240px;
 }
@@ -3389,10 +3397,6 @@
 
   .min-h_32px {
     min-height: 32px;
-}
-
-  .ml_10px {
-    margin-left: 10px;
 }
 
   .w_60px {
@@ -3593,10 +3597,6 @@
 
   .pb_0\! {
     padding-bottom: var(--spacing-0) !important;
-}
-
-  .mt_20px {
-    margin-top: 20px;
 }
 
   .min-h_78px {
@@ -8166,6 +8166,9 @@
     .\[\@media_\(max-width\:_768px\)\]\:gap_10px {
       gap: 10px;
 }
+    .\[\@media_\(max-width\:_768px\)\]\:flex-b_100\% {
+      flex-basis: 100%;
+}
     .\[\@media_\(max-width\:_768px\)\]\:grid-tc_minmax\(0\,_1fr\) {
       grid-template-columns: minmax(0, 1fr);
 }
@@ -8201,9 +8204,6 @@
 }
     .\[\@media_\(max-width\:_768px\)\]\:fs_14px {
       font-size: 14px;
-}
-    .\[\@media_\(max-width\:_768px\)\]\:flex-b_100\% {
-      flex-basis: 100%;
 }
     .\[\@media_\(max-width\:_768px\)\]\:pt_0 {
       padding-top: var(--spacing-0);

--- a/packages/website/src/components/TopicPage.tsx
+++ b/packages/website/src/components/TopicPage.tsx
@@ -1,0 +1,138 @@
+import type { ReactNode } from 'react';
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import type { Reply } from '@bangumi/client/client';
+import { Avatar, Layout, Topic } from '@bangumi/design';
+import ReplyForm from '@bangumi/design/components/Topic/ReplyForm';
+import type { TopicApi } from '@bangumi/design/components/Topic/topic-api';
+import { css } from '@bangumi/styled-system/css';
+import Helmet from '@bangumi/website/components/Helmet';
+import { useUser } from '@bangumi/website/hooks/use-user';
+
+const { Comment } = Topic;
+
+const replies = css({
+  marginTop: '10px',
+});
+
+const replyFormContainer = css({
+  display: 'flex',
+  alignItems: 'flex-start',
+  marginTop: '20px',
+});
+
+const replyForm = css({
+  flexBasis: '75%',
+  marginLeft: '10px',
+  '@media (max-width: 768px)': {
+    flexBasis: '100%',
+  },
+});
+
+interface TopicPageProps<T> {
+  topic: T & {
+    id: number;
+    title: string;
+    creatorID: number;
+    replyCount: number;
+    state: number;
+    replies: Reply[];
+  };
+  /** 刷新话题数据（回复/删除/点赞后调用） */
+  mutate: () => Promise<unknown>;
+  /** 回复/删除/点赞等操作实现 */
+  api: TopicApi;
+  /** 顶部导航（小组/条目上下文） */
+  header: ReactNode;
+  /** 右侧栏内容（小组信息/条目信息），可为空 */
+  sideContent?: ReactNode;
+}
+
+/**
+ * 话题详情页骨架：帖子与回复列表 + 回复表单 + 侧栏。
+ * 小组话题与条目讨论共用，顶部导航与右侧栏通过 props 注入。
+ */
+const TopicPage = <T extends { id: number }>({
+  topic,
+  mutate,
+  api,
+  header,
+  sideContent,
+}: TopicPageProps<T>) => {
+  const { user } = useUser();
+  const navigate = useNavigate();
+  const originalPosterId = topic.creatorID;
+  const isClosed = topic.state === 1;
+
+  const [replyContent, setReplyContent] = useState('');
+
+  // 首次渲染时评论列表可能还没加载完，浏览器无法定位，所以需要在评论加载完后再滚动到指定位置
+  useEffect(() => {
+    const anchor = window.location.hash.slice(1);
+    document.getElementById(anchor)?.scrollIntoView(true);
+  }, [topic]);
+
+  const handleReplySuccess = async (id: number) => {
+    navigate(`#post_${id}`);
+    // 刷新评论列表
+    await mutate();
+    setReplyContent('');
+  };
+
+  const startReply = () => {
+    const replyForm = document.getElementById('replyForm');
+    replyForm?.scrollIntoView(true);
+    replyForm?.querySelector('textarea')?.focus();
+  };
+
+  return (
+    <>
+      <Helmet title={topic.title} />
+      {header}
+      <Layout
+        type='alpha'
+        leftChildren={
+          <>
+            {/* Topic Comments */}
+            <div className={replies}>
+              {topic.replies.map((comment: Reply, idx: number) => (
+                <Comment
+                  topicId={topic.id}
+                  key={comment.id}
+                  isReply={false}
+                  isMainPost={idx === 0}
+                  replyCount={topic.replyCount}
+                  floor={idx + 1}
+                  originalPosterId={originalPosterId}
+                  user={user}
+                  onCommentUpdate={mutate}
+                  api={api}
+                  {...comment}
+                />
+              ))}
+              {/* Reply BBCode Editor */}
+              {!isClosed && user && (
+                <div className={replyFormContainer} id='replyForm'>
+                  <Avatar src={user.avatar.large} size='small' />
+                  <ReplyForm
+                    topicId={topic.id}
+                    className={replyForm}
+                    content={replyContent}
+                    onChange={setReplyContent}
+                    onSuccess={handleReplySuccess}
+                    hideCancel
+                    api={api}
+                  />
+                </div>
+              )}
+            </div>
+          </>
+        }
+        rightChildren={sideContent}
+      />
+    </>
+  );
+};
+
+export default TopicPage;

--- a/packages/website/src/hooks/use-subject-post.ts
+++ b/packages/website/src/hooks/use-subject-post.ts
@@ -1,0 +1,23 @@
+import { ok } from '@oazapfts/runtime';
+import type { KeyedMutator } from 'swr';
+import useSWR from 'swr';
+
+import { ozaClient } from '@bangumi/client';
+
+export interface UseSubjectPostRet {
+  data: ozaClient.Post;
+  mutate: KeyedMutator<ozaClient.Post>;
+}
+
+function useSubjectPost(id: number): UseSubjectPostRet {
+  const { data, mutate } = useSWR(
+    `/subject/post/${id}`,
+    async () => ok(ozaClient.getSubjectPost(id)),
+    {
+      suspense: true,
+    },
+  );
+  return { data, mutate };
+}
+
+export default useSubjectPost;

--- a/packages/website/src/hooks/use-subject-topic.ts
+++ b/packages/website/src/hooks/use-subject-topic.ts
@@ -1,0 +1,24 @@
+import { ok } from '@oazapfts/runtime';
+import type { KeyedMutator } from 'swr';
+import useSWR from 'swr';
+
+import { ozaClient } from '@bangumi/client';
+import type { SubjectTopic } from '@bangumi/client/client';
+
+export interface UseSubjectTopicRet {
+  data: SubjectTopic;
+  mutate: KeyedMutator<SubjectTopic>;
+}
+
+function useSubjectTopic(id: number): UseSubjectTopicRet {
+  const { data, mutate } = useSWR(
+    `/subject/topic/${id}`,
+    async () => ok(ozaClient.getSubjectTopic(id)),
+    {
+      suspense: true,
+    },
+  );
+  return { data, mutate };
+}
+
+export default useSubjectTopic;

--- a/packages/website/src/mocks/fixtures/p1/subjects/-/posts/2-GET.json
+++ b/packages/website/src/mocks/fixtures/p1/subjects/-/posts/2-GET.json
@@ -1,0 +1,32 @@
+{
+  "id": 2,
+  "creatorID": 382951,
+  "creator": {
+    "id": 382951,
+    "username": "382951",
+    "nickname": "树洞酱",
+    "avatar": {
+      "large": "https://lain.bgm.tv/pic/user/l/000/38/29/382951.jpg",
+      "medium": "https://lain.bgm.tv/pic/user/m/000/38/29/382951.jpg",
+      "small": "https://lain.bgm.tv/pic/user/s/000/38/29/382951.jpg"
+    },
+    "group": 10,
+    "sign": "",
+    "joinedAt": 1500000000,
+    "isFriend": false
+  },
+  "createdAt": 1774100000,
+  "content": "回复内容",
+  "state": 0,
+  "topic": {
+    "id": 202,
+    "title": "热门讨论标题",
+    "creatorID": 382951,
+    "parentID": 12,
+    "replyCount": 8,
+    "createdAt": 1774000000,
+    "updatedAt": 1774500000,
+    "state": 0,
+    "display": 1
+  }
+}

--- a/packages/website/src/mocks/fixtures/p1/subjects/-/topics/202-GET.json
+++ b/packages/website/src/mocks/fixtures/p1/subjects/-/topics/202-GET.json
@@ -1,0 +1,96 @@
+{
+  "id": 202,
+  "title": "热门讨论标题",
+  "creatorID": 382951,
+  "parentID": 12,
+  "replyCount": 8,
+  "createdAt": 1774000000,
+  "updatedAt": 1774500000,
+  "state": 0,
+  "display": 1,
+  "subject": {
+    "id": 12,
+    "type": 2,
+    "name": "Test Anime",
+    "nameCN": "测试动画",
+    "images": {
+      "large": "https://lain.bgm.tv/pic/cover/l/00/00/12.jpg",
+      "common": "https://lain.bgm.tv/pic/cover/c/00/00/12.jpg",
+      "medium": "https://lain.bgm.tv/pic/cover/m/00/00/12.jpg",
+      "small": "https://lain.bgm.tv/pic/cover/s/00/00/12.jpg",
+      "grid": "https://lain.bgm.tv/pic/cover/g/00/00/12.jpg"
+    },
+    "info": "",
+    "locked": false,
+    "metaTags": [],
+    "nsfw": false,
+    "rating": {
+      "rank": 100,
+      "total": 1234,
+      "count": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      "score": 8.1
+    }
+  },
+  "replies": [
+    {
+      "id": 1,
+      "creatorID": 382951,
+      "createdAt": 1774000000,
+      "content": "楼主内容 [b]加粗[/b]",
+      "state": 0,
+      "replies": [],
+      "creator": {
+        "id": 382951,
+        "username": "382951",
+        "nickname": "树洞酱",
+        "avatar": {
+          "large": "https://lain.bgm.tv/pic/user/l/000/38/29/382951.jpg",
+          "medium": "https://lain.bgm.tv/pic/user/m/000/38/29/382951.jpg",
+          "small": "https://lain.bgm.tv/pic/user/s/000/38/29/382951.jpg"
+        },
+        "group": 10,
+        "sign": "",
+        "joinedAt": 1500000000,
+        "isFriend": false
+      },
+      "reactions": []
+    },
+    {
+      "id": 2,
+      "creatorID": 1001,
+      "createdAt": 1774100000,
+      "content": "回复内容",
+      "state": 0,
+      "replies": [],
+      "creator": {
+        "id": 1001,
+        "username": "friend-a",
+        "nickname": "好友甲",
+        "avatar": {
+          "large": "https://lain.bgm.tv/pic/user/l/000/00/10/1001.jpg",
+          "medium": "https://lain.bgm.tv/pic/user/m/000/00/10/1001.jpg",
+          "small": "https://lain.bgm.tv/pic/user/s/000/00/10/1001.jpg"
+        },
+        "group": 10,
+        "sign": "",
+        "joinedAt": 1500000000,
+        "isFriend": false
+      },
+      "reactions": []
+    }
+  ],
+  "creator": {
+    "id": 382951,
+    "username": "382951",
+    "nickname": "树洞酱",
+    "avatar": {
+      "large": "https://lain.bgm.tv/pic/user/l/000/38/29/382951.jpg",
+      "medium": "https://lain.bgm.tv/pic/user/m/000/38/29/382951.jpg",
+      "small": "https://lain.bgm.tv/pic/user/s/000/38/29/382951.jpg"
+    },
+    "group": 10,
+    "sign": "",
+    "joinedAt": 1500000000,
+    "isFriend": false
+  }
+}

--- a/packages/website/src/mocks/handlers.ts
+++ b/packages/website/src/mocks/handlers.ts
@@ -39,6 +39,8 @@ export const handlers = [
   mockAPI('/p1/groups', 'get'),
   mockAPI('/p1/groups/-/topics', 'get'),
   mockAPI('/p1/groups/-/topics/:topicID', 'get'),
+  mockAPI('/p1/subjects/-/topics/:topicID', 'get'),
+  mockAPI('/p1/subjects/-/posts/:postID', 'get'),
   mockAPI('/p1/groups/-/posts/:postID/like', 'put'),
   mockAPI('/p1/groups/-/posts/:postID/like', 'delete'),
   mockAPI('/p1/users/:username/indexes', 'get'),

--- a/packages/website/src/pages/index/group/components/TopicForm.tsx
+++ b/packages/website/src/pages/index/group/components/TopicForm.tsx
@@ -7,19 +7,30 @@ import { ozaClient } from '@bangumi/client';
 import { EditorForm, Form, Input, toast } from '@bangumi/design';
 import { css } from '@bangumi/styled-system/css';
 import TurnstileCaptcha from '@bangumi/website/components/TurnstileCaptcha';
-import type { UseGroupTopicRet } from '@bangumi/website/hooks/use-group-topic';
 
 interface FormData {
   title: string;
   content: string;
 }
 
-export interface TopicFormProps {
+/** 可编辑话题数据，编辑表单只需要 id/title/content */
+export interface EditableTopic {
+  id: number;
+  title: string;
+  content?: string;
+}
+
+export interface TopicFormProps<T extends EditableTopic = EditableTopic> {
   quickPost?: boolean;
   /** 小组 slug name，指定此参数时为发表话题 */
   groupName?: string;
   /** 话题，指定此参数时为修改话题 */
-  topic?: UseGroupTopicRet;
+  topic?: {
+    data: T;
+    mutate: (data: T) => Promise<unknown>;
+  };
+  /** 话题类型，决定修改时调用的 API 与跳转 URL，默认小组话题 */
+  topicKind?: 'group' | 'subject';
 }
 
 /**
@@ -53,7 +64,12 @@ const quickPostForm = css({
   },
 });
 
-const TopicForm = ({ quickPost = false, groupName, topic }: TopicFormProps) => {
+const TopicForm = <T extends EditableTopic = EditableTopic>({
+  quickPost = false,
+  groupName,
+  topic,
+  topicKind = 'group',
+}: TopicFormProps<T>) => {
   if ((!!groupName && !!topic) || (!groupName && !topic)) {
     throw Error('Invalid usage: should specify either groupName or topic');
   }
@@ -79,10 +95,13 @@ const TopicForm = ({ quickPost = false, groupName, topic }: TopicFormProps) => {
   };
 
   const editTopic = async (data: FormData, id: number) => {
-    const response = await ozaClient.editGroupTopic(id, data);
+    const response =
+      topicKind === 'subject'
+        ? await ozaClient.updateSubjectTopic(id, data)
+        : await ozaClient.editGroupTopic(id, data);
     if (response.status === 200) {
       topic?.mutate({ ...topic.data, ...data });
-      navigate(`/group/topic/${id}`);
+      navigate(topicKind === 'subject' ? `/subject/topic/${id}` : `/group/topic/${id}`);
     } else {
       console.error(response);
       toast(response.data.message);
@@ -103,7 +122,7 @@ const TopicForm = ({ quickPost = false, groupName, topic }: TopicFormProps) => {
     toast(Object.values(errors).map((field) => field.message)[0]!);
   };
 
-  const FormInput = ({ quickPost = false }: TopicFormProps) => (
+  const FormInput = ({ quickPost = false }: { quickPost?: boolean }) => (
     <Input
       rounded
       placeholder={quickPost ? '给新帖取一个标题' : '取个标题…'}
@@ -111,7 +130,7 @@ const TopicForm = ({ quickPost = false, groupName, topic }: TopicFormProps) => {
     />
   );
 
-  const FormEditor = ({ quickPost = false }: TopicFormProps) => (
+  const FormEditor = ({ quickPost = false }: { quickPost?: boolean }) => (
     <Controller
       name='content'
       control={control}

--- a/packages/website/src/pages/index/group/topic/[id]/index.tsx
+++ b/packages/website/src/pages/index/group/topic/[id]/index.tsx
@@ -1,116 +1,31 @@
-import type { Reply } from 'packages/client/client';
 import type { FC } from 'react';
-import React, { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import React from 'react';
+import { useParams } from 'react-router-dom';
 
-import { Avatar, Layout, Topic } from '@bangumi/design';
-import ReplyForm from '@bangumi/design/components/Topic/ReplyForm';
-import { css } from '@bangumi/styled-system/css';
-import Helmet from '@bangumi/website/components/Helmet';
+import { groupTopicApi } from '@bangumi/design/components/Topic/topic-api';
+import TopicPage from '@bangumi/website/components/TopicPage';
 import useGroupTopic from '@bangumi/website/hooks/use-group-topic';
-import { useUser } from '@bangumi/website/hooks/use-user';
 
 import GroupInfo from '../../components/GroupInfo';
 import GroupTopicHeader from './components/GroupTopicHeader';
 
-const { Comment } = Topic;
-
-const replies = css({
-  marginTop: '10px',
-});
-
-const replyFormContainer = css({
-  display: 'flex',
-  alignItems: 'flex-start',
-  marginTop: '20px',
-});
-
-const replyForm = css({
-  flexBasis: '75%',
-  marginLeft: '10px',
-  '@media (max-width: 768px)': {
-    flexBasis: '100%',
-  },
-});
-
-const TopicPage: FC = () => {
+const GroupTopicPage: FC = () => {
   const { id } = useParams();
   if (!id || Number.isNaN(Number(id))) {
     throw new Error('BUG: topic id is required');
   }
 
   const { data: topic, mutate } = useGroupTopic(Number(id));
-  const { user } = useUser();
-  const originalPosterId = topic.creatorID;
-  const isClosed = topic.state === 1;
-
-  const [replyContent, setReplyContent] = useState('');
-
-  const navigate = useNavigate();
-
-  // 首次渲染时评论列表可能还没加载完，浏览器无法定位，所以需要在评论加载完后再滚动到指定位置
-  useEffect(() => {
-    const anchor = window.location.hash.slice(1);
-    document.getElementById(anchor)?.scrollIntoView(true);
-  }, [topic]);
-
-  const handleReplySuccess = async (id: number) => {
-    navigate(`#post_${id}`);
-    // 刷新评论列表
-    await mutate();
-    setReplyContent('');
-  };
-
-  const startReply = () => {
-    const replyForm = document.getElementById('replyForm');
-    replyForm?.scrollIntoView(true);
-    replyForm?.querySelector('textarea')?.focus();
-  };
 
   return (
-    <>
-      <Helmet title={topic.title} />
-      <GroupTopicHeader title={topic.title} group={topic.group} />
-      <Layout
-        type='alpha'
-        leftChildren={
-          <>
-            {/* Topic Comments */}
-            <div className={replies}>
-              {topic.replies.map((comment: Reply, idx: number) => (
-                <Comment
-                  topicId={topic.id}
-                  key={comment.id}
-                  isReply={false}
-                  isMainPost={idx === 0}
-                  replyCount={topic.replyCount}
-                  floor={idx + 1}
-                  originalPosterId={originalPosterId}
-                  user={user}
-                  onCommentUpdate={mutate}
-                  {...comment}
-                />
-              ))}
-              {/* Reply BBCode Editor */}
-              {!isClosed && user && (
-                <div className={replyFormContainer} id='replyForm'>
-                  <Avatar src={user.avatar.large} size='small' />
-                  <ReplyForm
-                    topicId={topic.id}
-                    className={replyForm}
-                    content={replyContent}
-                    onChange={setReplyContent}
-                    onSuccess={handleReplySuccess}
-                    hideCancel
-                  />
-                </div>
-              )}
-            </div>
-          </>
-        }
-        rightChildren={<GroupInfo group={topic.group} />}
-      />
-    </>
+    <TopicPage
+      topic={topic}
+      mutate={mutate}
+      api={groupTopicApi}
+      header={<GroupTopicHeader title={topic.title} group={topic.group} />}
+      sideContent={<GroupInfo group={topic.group} />}
+    />
   );
 };
-export default TopicPage;
+
+export default GroupTopicPage;

--- a/packages/website/src/pages/index/subject/[id]/components/SubjectSummaryCard.tsx
+++ b/packages/website/src/pages/index/subject/[id]/components/SubjectSummaryCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import type { Subject } from '@bangumi/client/client';
+import type { SlimSubject } from '@bangumi/client/client';
 import { Typography } from '@bangumi/design';
 import { css } from '@bangumi/styled-system/css';
 import { getSubjectLink } from '@bangumi/utils/pages';
@@ -51,7 +51,7 @@ const returnLink = css({
 });
 
 /** 条目子页侧栏卡片：封面 + 名称 + 返回条目，供章节/关联等子页复用 */
-function SubjectSummaryCard({ subject }: { subject: Subject }) {
+function SubjectSummaryCard({ subject }: { subject: SlimSubject }) {
   return (
     <aside className={subjectCard}>
       {subject.images?.small && (

--- a/packages/website/src/pages/index/subject/reply/[id].tsx
+++ b/packages/website/src/pages/index/subject/reply/[id].tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+
+import ErrorBoundary from '@bangumi/website/components/ErrorBoundary';
+import PageContainer from '@bangumi/website/components/PageContainer';
+
+const SubjectReplyPage = () => (
+  <ErrorBoundary fallback={{ 404: <>数据库中没有查询到指定话题，话题可能正在审核或已被删除。</> }}>
+    <PageContainer>
+      <Outlet />
+    </PageContainer>
+  </ErrorBoundary>
+);
+
+export default SubjectReplyPage;

--- a/packages/website/src/pages/index/subject/reply/[id]/edit.spec.tsx
+++ b/packages/website/src/pages/index/subject/reply/[id]/edit.spec.tsx
@@ -1,0 +1,52 @@
+import { act, render, screen } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { PropsWithChildren } from 'react';
+import React, { Suspense } from 'react';
+import { HelmetProvider } from 'react-helmet-async';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { UserProvider } from '@bangumi/website/hooks/use-user';
+import subjectPostFixture from '@bangumi/website/mocks/fixtures/p1/subjects/-/posts/2-GET.json';
+import { server as mockServer } from '@bangumi/website/mocks/server';
+
+import EditReplyPage from './edit';
+
+describe('SubjectReplyEditPage', () => {
+  const renderPage = async () => {
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <MemoryRouter initialEntries={['/subject/reply/2/edit']}>
+        <HelmetProvider>
+          <UserProvider>
+            <Routes>
+              <Route path='subject/reply/:id/edit' element={children} />
+            </Routes>
+          </UserProvider>
+        </HelmetProvider>
+      </MemoryRouter>
+    );
+    mockServer.use(
+      http.get('http://localhost:3000/p1/subjects/-/posts/2', () =>
+        HttpResponse.json(subjectPostFixture),
+      ),
+    );
+    await act(async () => {
+      render(
+        <Suspense fallback={null}>
+          <EditReplyPage />
+        </Suspense>,
+        { wrapper },
+      );
+    });
+  };
+
+  it('渲染回复内容与所属话题链接', async () => {
+    await renderPage();
+
+    expect(await screen.findByText(/修改主题/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '热门讨论标题' })).toHaveAttribute(
+      'href',
+      '/subject/topic/202',
+    );
+    expect(screen.getByDisplayValue('回复内容')).toBeInTheDocument();
+  });
+});

--- a/packages/website/src/pages/index/subject/reply/[id]/edit.tsx
+++ b/packages/website/src/pages/index/subject/reply/[id]/edit.tsx
@@ -1,0 +1,116 @@
+import React, { useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useSWRConfig } from 'swr';
+
+import { ozaClient } from '@bangumi/client';
+import type { SubjectTopic } from '@bangumi/client/client';
+import { EditorForm, toast, Typography } from '@bangumi/design';
+import { css } from '@bangumi/styled-system/css';
+import Helmet from '@bangumi/website/components/Helmet';
+import { OperationNeedLoginError } from '@bangumi/website/error';
+import useSubjectPost from '@bangumi/website/hooks/use-subject-post';
+import { useUser } from '@bangumi/website/hooks/use-user';
+
+const form = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1rem',
+});
+
+const tipText = css({
+  display: 'block',
+  marginBottom: '10px',
+});
+
+const topicLink = css({
+  padding: '0 10px',
+});
+
+const EditReplyPage = () => {
+  const { id } = useParams();
+  if (!id || Number.isNaN(parseInt(id))) {
+    throw new Error('参数错误：post ID');
+  }
+  const postId = parseInt(id);
+
+  const { user, isLoading } = useUser();
+  if (isLoading) {
+    return null;
+  }
+  if (!user) {
+    throw OperationNeedLoginError;
+  }
+
+  const { data, mutate } = useSubjectPost(postId);
+  if (data.creatorID !== user.id) {
+    throw new Error('抱歉，你只能修改自己发表的帖子。');
+  }
+
+  const { mutate: mutateTopic } = useSWRConfig();
+  const navigate = useNavigate();
+
+  const [sending, setSending] = useState(false);
+  const [content, setContent] = useState(data.content);
+
+  const handleSubmit = async (content: string) => {
+    if (!content) {
+      toast('请填写回复内容', { type: 'error' });
+      return;
+    }
+    setSending(true);
+    const response = await ozaClient.editSubjectPost(postId, { content });
+    if (response.status === 200) {
+      const topicPath = `/subject/topic/${data.topic.id}`;
+      // 确保再次回到此页面时内容是最新的，不需要向后端请求数据，因此将 revalidate 设置为 false
+      mutate({ ...data, content }, { revalidate: false });
+      // 乐观更新回复内容
+      await mutateTopic(topicPath, (topic?: SubjectTopic) => {
+        if (!topic) {
+          return topic;
+        }
+        const reply = topic.replies.find((reply) => reply.id === postId);
+        if (reply) {
+          reply.content = content;
+        }
+        return topic;
+      });
+      navigate(topicPath);
+    } else {
+      console.error(response);
+      toast(response.data.message, { type: 'error' });
+    }
+    setSending(false);
+  };
+
+  return (
+    <>
+      <Helmet title={`修改主题“${data.topic.title}”的回复`} />
+      <Typography.Text type='secondary' className={tipText}>
+        修改主题
+        <Typography.Link
+          to={`/subject/topic/${data.topic.id}`}
+          fontWeight='bold'
+          className={topicLink}
+        >
+          {data.topic.title}
+        </Typography.Link>
+        的回复
+      </Typography.Text>
+      <div className={form}>
+        <EditorForm
+          placeholder='回复内容…'
+          hideCancel
+          value={content}
+          onChange={setContent}
+          onConfirm={handleSubmit}
+          // TODO: use loading state
+          confirmText={sending ? '...' : undefined}
+          rows={15}
+        />
+      </div>
+      {/* TODO: add right column */}
+    </>
+  );
+};
+
+export default EditReplyPage;

--- a/packages/website/src/pages/index/subject/topic/[id].tsx
+++ b/packages/website/src/pages/index/subject/topic/[id].tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+
+import { withErrorBoundary } from '@bangumi/website/components/ErrorBoundary';
+import PageContainer from '@bangumi/website/components/PageContainer';
+
+const SubjectTopicPage = () => (
+  <PageContainer>
+    <Outlet />
+  </PageContainer>
+);
+
+export default withErrorBoundary(SubjectTopicPage, { 404: <>Topic Not found</> });

--- a/packages/website/src/pages/index/subject/topic/[id]/components/SubjectTopicHeader.tsx
+++ b/packages/website/src/pages/index/subject/topic/[id]/components/SubjectTopicHeader.tsx
@@ -1,0 +1,58 @@
+import type { FC } from 'react';
+import React, { memo } from 'react';
+
+import type { SlimSubject } from '@bangumi/client/client';
+import { Avatar, Typography } from '@bangumi/design';
+import { css } from '@bangumi/styled-system/css';
+import { getSubjectBoardLink, getSubjectLink } from '@bangumi/utils/pages';
+
+interface Header {
+  title: string;
+  subject: SlimSubject;
+}
+
+const Link = Typography.Link;
+
+const subjectTopicHeader = css({
+  marginBottom: '0',
+});
+
+const navBar = css({
+  fontSize: '16px',
+  lineHeight: '22px',
+  display: 'flex',
+  alignItems: 'center',
+  color: '#9f9b9b',
+  '& a': {
+    paddingLeft: '10px',
+  },
+  '& .bgm-avatar': {
+    paddingRight: '10px',
+    border: 'none',
+  },
+});
+
+const topicTitle = css({
+  marginTop: '4px',
+  marginBottom: '5px',
+  fontSize: '24px',
+  lineHeight: '34px',
+  fontWeight: '600',
+  color: '#1f1c1c',
+});
+
+const SubjectTopicHeader: FC<Header> = ({ title, subject }) => {
+  return (
+    <div className={subjectTopicHeader}>
+      <div className={navBar}>
+        <Avatar src={subject.images?.small ?? ''} size='xsmall' />
+        <Link to={getSubjectLink(subject.id)}>{subject.nameCN || subject.name}</Link>
+        <span>»</span>
+        <Link to={getSubjectBoardLink(subject.id)}>讨论区</Link>
+      </div>
+      <h1 className={topicTitle}>{title}</h1>
+    </div>
+  );
+};
+
+export default memo(SubjectTopicHeader);

--- a/packages/website/src/pages/index/subject/topic/[id]/edit.tsx
+++ b/packages/website/src/pages/index/subject/topic/[id]/edit.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+import { Typography } from '@bangumi/design';
+import { css } from '@bangumi/styled-system/css';
+import Helmet from '@bangumi/website/components/Helmet';
+import useSubjectTopic from '@bangumi/website/hooks/use-subject-topic';
+import TopicForm from '@bangumi/website/pages/index/group/components/TopicForm';
+
+const form = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1rem',
+});
+
+const tipText = css({
+  display: 'block',
+  marginBottom: '10px',
+});
+
+const topicLink = css({
+  padding: '0 10px',
+});
+
+const EditTopicPage = () => {
+  const { id } = useParams();
+  if (!id || Number.isNaN(Number(id))) {
+    throw new Error('BUG: topic id is required');
+  }
+
+  const { data, mutate } = useSubjectTopic(Number(id));
+
+  return (
+    <>
+      <Helmet title={`修改主题“${data.title}”`} />
+      <Typography.Text type='secondary' className={tipText}>
+        修改主题
+        <Typography.Link to={`/subject/topic/${data.id}`} fontWeight='bold' className={topicLink}>
+          {data.title}
+        </Typography.Link>
+      </Typography.Text>
+      <div className={form}>
+        <TopicForm topic={{ data, mutate }} topicKind='subject' />
+      </div>
+      {/* TODO: add right column */}
+    </>
+  );
+};
+
+export default EditTopicPage;

--- a/packages/website/src/pages/index/subject/topic/[id]/index.spec.tsx
+++ b/packages/website/src/pages/index/subject/topic/[id]/index.spec.tsx
@@ -1,0 +1,73 @@
+import { act, render, screen } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { PropsWithChildren } from 'react';
+import React, { Suspense } from 'react';
+import { HelmetProvider } from 'react-helmet-async';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { UserProvider } from '@bangumi/website/hooks/use-user';
+import subjectTopicFixture from '@bangumi/website/mocks/fixtures/p1/subjects/-/topics/202-GET.json';
+import { server as mockServer } from '@bangumi/website/mocks/server';
+
+import SubjectTopicPage from './index';
+
+describe('SubjectTopicPage', () => {
+  const renderPage = async () => {
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <MemoryRouter initialEntries={['/subject/topic/202']}>
+        <HelmetProvider>
+          <UserProvider>
+            <Routes>
+              <Route path='subject/topic/:id' element={children} />
+            </Routes>
+          </UserProvider>
+        </HelmetProvider>
+      </MemoryRouter>
+    );
+    mockServer.use(
+      http.get('http://localhost:3000/p1/subjects/-/topics/202', () =>
+        HttpResponse.json(subjectTopicFixture),
+      ),
+    );
+    await act(async () => {
+      render(
+        <Suspense fallback={null}>
+          <SubjectTopicPage />
+        </Suspense>,
+        { wrapper },
+      );
+    });
+  };
+
+  it('渲染话题标题、楼主内容与回复', async () => {
+    await renderPage();
+
+    expect(await screen.findByRole('heading', { name: '热门讨论标题' })).toBeInTheDocument();
+    expect(screen.getByText('树洞酱')).toBeInTheDocument();
+    expect(screen.getByText(/楼主内容/)).toBeInTheDocument();
+    expect(screen.getByText('加粗')).toBeInTheDocument();
+    expect(screen.getByText('回复内容')).toBeInTheDocument();
+  });
+
+  it('顶部导航指向条目与讨论区，右侧展示条目卡片', async () => {
+    await renderPage();
+
+    expect(await screen.findByRole('link', { name: '测试动画' })).toHaveAttribute(
+      'href',
+      '/subject/12',
+    );
+    expect(screen.getByRole('link', { name: '讨论区' })).toHaveAttribute(
+      'href',
+      '/subject/12/board',
+    );
+    // 右侧条目卡片
+    expect(screen.getByRole('link', { name: '返回条目' })).toHaveAttribute('href', '/subject/12');
+  });
+
+  it('登录用户可看到回复表单', async () => {
+    await renderPage();
+
+    expect(await screen.findByText('热门讨论标题')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('添加新回复...')).toBeInTheDocument();
+  });
+});

--- a/packages/website/src/pages/index/subject/topic/[id]/index.tsx
+++ b/packages/website/src/pages/index/subject/topic/[id]/index.tsx
@@ -1,0 +1,31 @@
+import type { FC } from 'react';
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+import TopicPage from '@bangumi/website/components/TopicPage';
+import useSubjectTopic from '@bangumi/website/hooks/use-subject-topic';
+
+import SubjectSummaryCard from '../../[id]/components/SubjectSummaryCard';
+import { subjectTopicApi } from '../topic-api';
+import SubjectTopicHeader from './components/SubjectTopicHeader';
+
+const SubjectTopicPage: FC = () => {
+  const { id } = useParams();
+  if (!id || Number.isNaN(Number(id))) {
+    throw new Error('BUG: topic id is required');
+  }
+
+  const { data: topic, mutate } = useSubjectTopic(Number(id));
+
+  return (
+    <TopicPage
+      topic={topic}
+      mutate={mutate}
+      api={subjectTopicApi}
+      header={<SubjectTopicHeader title={topic.title} subject={topic.subject} />}
+      sideContent={<SubjectSummaryCard subject={topic.subject} />}
+    />
+  );
+};
+
+export default SubjectTopicPage;

--- a/packages/website/src/pages/index/subject/topic/topic-api.ts
+++ b/packages/website/src/pages/index/subject/topic/topic-api.ts
@@ -1,0 +1,11 @@
+import { ozaClient } from '@bangumi/client';
+import type { TopicApi } from '@bangumi/design/components/Topic/topic-api';
+
+/** 条目讨论话题操作实现 */
+export const subjectTopicApi: TopicApi = {
+  createReply: async (topicId, body) => ozaClient.createSubjectReply(topicId, body),
+  deletePost: async (postId) => ozaClient.deleteSubjectPost(postId),
+  likePost: async (postId, value) => ozaClient.likeSubjectPost(postId, { value }),
+  unlikePost: async (postId) => ozaClient.unlikeSubjectPost(postId),
+  replyEditPath: (postId) => `/subject/reply/${postId}/edit`,
+};

--- a/packages/website/src/routes.tsx
+++ b/packages/website/src/routes.tsx
@@ -46,6 +46,11 @@ const SubjectBoard = lazy(async () => import('./pages/index/subject/[id]/board')
 const SubjectComments = lazy(async () => import('./pages/index/subject/[id]/comments'));
 const SubjectReviews = lazy(async () => import('./pages/index/subject/[id]/reviews'));
 const SubjectSearch = lazy(async () => import('./pages/index/subject_search/[keyword]'));
+const SubjectTopic = lazy(async () => import('./pages/index/subject/topic/[id]'));
+const SubjectTopicEdit = lazy(async () => import('./pages/index/subject/topic/[id]/edit'));
+const SubjectTopicHome = lazy(async () => import('./pages/index/subject/topic/[id]/index'));
+const SubjectReply = lazy(async () => import('./pages/index/subject/reply/[id]'));
+const SubjectReplyEdit = lazy(async () => import('./pages/index/subject/reply/[id]/edit'));
 const Person = lazy(async () => import('./pages/index/person/[id]'));
 const PersonVoice = lazy(async () => import('./pages/index/person/[id]/voice'));
 const PersonWorks = lazy(async () => import('./pages/index/person/[id]/works'));
@@ -89,12 +94,6 @@ const EpisodeRedirect: React.FC = () => {
   return <Navigate to={`/ep/${id}`} replace />;
 };
 
-/** 旧版条目讨论区话题 URL 转发到新版 /group/topic/:id */
-const TopicRedirect: React.FC = () => {
-  const { id } = useParams();
-  return <Navigate to={`/group/topic/${id}`} replace />;
-};
-
 export const pageRoutes: RouteObject[] = [
   {
     path: '/',
@@ -102,7 +101,19 @@ export const pageRoutes: RouteObject[] = [
     children: [
       ...legacyPagePaths.map((path) => ({ path, element: <LegacyRedirect /> })),
       { path: 'subject/ep/:id', element: <EpisodeRedirect /> },
-      { path: 'subject/topic/:id', element: <TopicRedirect /> },
+      {
+        path: 'subject/topic/:id',
+        element: <SubjectTopic />,
+        children: [
+          { path: 'edit', element: <SubjectTopicEdit /> },
+          { path: '', element: <SubjectTopicHome /> },
+        ],
+      },
+      {
+        path: 'subject/reply/:id',
+        element: <SubjectReply />,
+        children: [{ path: 'edit', element: <SubjectReplyEdit /> }],
+      },
       { path: '*', element: <MatchAll /> },
       { path: '', element: <HomeIndex /> },
       {


### PR DESCRIPTION
## 背景

首页「热门条目讨论」与条目讨论区的链接生成 `/subject/topic/:id`，但此前该 URL 在路由中被 `TopicRedirect` 重定向到 `/group/topic/:id`。本次为 subject topic 提供独立页面，不再跳转到 group topic。

## 改动

### 架构

- 新增通用 `TopicPage` 骨架组件（`packages/website/src/components/TopicPage.tsx`）：帖子/回复列表 + 回复表单 + 侧栏，`header` 与 `sideContent` 以 slot 注入
- 新增 `TopicApi` 接口（`packages/design/components/Topic/topic-api.ts`）：统一回复/删除/点赞/回复编辑路径，`groupTopicApi` 与 `subjectTopicApi` 分别实现；`Comment`/`Reactions`/`ReplyForm`/`CommentActions` 由原先的 `topicKind` 标志改为通过 `api` prop 注入
- `GroupTopic` 页面同步重构为使用通用骨架，消除两套重复的页面布局

### 新页面

- `/subject/topic/:id`：话题详情（条目上下文面包屑、回复列表、回复表单、侧栏条目卡片）
- `/subject/topic/:id/edit`：编辑话题
- `/subject/reply/:id/edit`：编辑回复（回复编辑链接按话题类型指向正确路径）

### 测试

- subject topic 页面 3 个用例、subject reply 编辑页 1 个用例
- 新增 mock fixture 与 handler

## 验证

- `pnpm lint` / `type-check` / `prettier:check` / `pnpm build` 通过
- 全量 Vitest 67 文件 364 测试通过

## 说明

- blog / episode 页面的评论组件为独立实现，未纳入本次骨架；`TopicApi` 接口形状为后续统一预留扩展点