### PR TITLE
fix: disable blog reply submit while sending

### DIFF
--- a/packages/design/components/EditorForm/Editor.tsx
+++ b/packages/design/components/EditorForm/Editor.tsx
@@ -100,6 +100,8 @@ export interface EditorProps {
   rows?: number;
   name?: string;
   onBlur?: FocusEventHandler<HTMLTextAreaElement>;
+  /** 禁用快捷键提交（Ctrl+Enter / Alt+S） */
+  disabled?: boolean;
 }
 
 const keyToEvent: Record<string, string> = {
@@ -124,6 +126,7 @@ const Editor = forwardRef<HTMLTextAreaElement, EditorProps>(
       rows,
       name,
       onBlur,
+      disabled,
     },
     ref,
   ) => {
@@ -234,8 +237,9 @@ const Editor = forwardRef<HTMLTextAreaElement, EditorProps>(
       (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
         // Ctrl + Enter & Alt + S 触发提交
         if (
-          ((e.ctrlKey || e.metaKey) && e.key === 'Enter') ||
-          (e.altKey && e.key.toLowerCase() === 's')
+          !disabled &&
+          (((e.ctrlKey || e.metaKey) && e.key === 'Enter') ||
+            (e.altKey && e.key.toLowerCase() === 's'))
         ) {
           onConfirm?.(innerRef.current!.value);
           e.preventDefault();
@@ -251,7 +255,7 @@ const Editor = forwardRef<HTMLTextAreaElement, EditorProps>(
           }
         }
       },
-      [onConfirm, handleToolboxEvent],
+      [onConfirm, handleToolboxEvent, disabled],
     );
 
     return (

--- a/packages/design/components/EditorForm/__test__/EditorForm.test.tsx
+++ b/packages/design/components/EditorForm/__test__/EditorForm.test.tsx
@@ -55,4 +55,27 @@ describe('<EditorForm />', () => {
     fireEvent.keyDown(textarea, { key: 's', altKey: true });
     expect(onConfirm).toHaveBeenLastCalledWith('test2');
   });
+
+  it('disabled should prevent onConfirm via button click and keyboard shortcut', () => {
+    const onConfirm = vi.fn();
+    const { getByText, getByPlaceholderText } = renderEditorForm(
+      <TestEditorForm
+        onConfirm={onConfirm}
+        confirmText='Confirm'
+        placeholder='placeholder'
+        disabled
+      />,
+    );
+    const textarea = getByPlaceholderText('placeholder') as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: 'test' } });
+    const button = getByText('Confirm') as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    fireEvent.click(button);
+    expect(onConfirm).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(textarea, { key: 'Enter', ctrlKey: true });
+    fireEvent.keyDown(textarea, { key: 's', altKey: true });
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
 });

--- a/packages/design/components/EditorForm/index.tsx
+++ b/packages/design/components/EditorForm/index.tsx
@@ -63,6 +63,11 @@ export interface EditorFormProps extends EditorProps {
    * @default false
    */
   hideCancel?: boolean;
+  /**
+   * 禁用提交（确认按钮与 Ctrl+Enter / Alt+S 快捷键）
+   * @default false
+   */
+  disabled?: boolean;
 }
 
 const EditorForm = forwardRef<HTMLTextAreaElement, EditorFormProps>(
@@ -76,17 +81,19 @@ const EditorForm = forwardRef<HTMLTextAreaElement, EditorFormProps>(
       onCancel,
       submitExtra,
       hideCancel = false,
+      disabled = false,
       ...props
     },
     ref,
   ) => {
     return (
       <div className={cx('bgm-editor__form', editorForm, className)} style={style}>
-        <Editor ref={ref} onConfirm={onConfirm} {...props} />
+        <Editor ref={ref} onConfirm={onConfirm} disabled={disabled} {...props} />
         <div className='bgm-editor__submit'>
           <Button
             color='blue'
             className='bgm-editor__button bgm-editor__button--confirm'
+            disabled={disabled}
             onClick={() => onConfirm?.(props.value ?? '')}
           >
             {confirmText}

--- a/packages/website/src/pages/index/blog/[id]/components/BlogReplyForm.tsx
+++ b/packages/website/src/pages/index/blog/[id]/components/BlogReplyForm.tsx
@@ -40,8 +40,7 @@ const BlogReplyForm = ({
   const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
 
   const sendReply = async () => {
-    if (!content) return; // TODO: show validation message
-    if (sending) return; // TODO: disable button instead
+    if (!content.trim()) return;
     setSending(true);
     try {
       const response = await ozaClient.createBlogComment(entryId, {
@@ -71,6 +70,7 @@ const BlogReplyForm = ({
       value={content}
       // TODO: use loading state
       confirmText={sending ? '...' : undefined}
+      disabled={sending}
       onChange={onChange}
       onConfirm={sendReply}
       submitExtra={


### PR DESCRIPTION
## 变更

- `EditorForm` / `Editor` 新增 `disabled` 属性，禁用确认按钮以及 Ctrl+Enter / Alt+S 提交快捷键。
- `BlogReplyForm` 在发送过程中通过 `disabled={sending}` 禁用提交，替换原先的 `if (sending) return` 守卫。
- 内容为空（含纯空白）时不提交。
