### PR TITLE
fix: dispose Monaco model on wiki editor unmount

### DIFF
--- a/packages/website/src/components/WikiEditor/WikiEditor.tsx
+++ b/packages/website/src/components/WikiEditor/WikiEditor.tsx
@@ -201,6 +201,7 @@ const WikiEditor = ({ defaultValue, instanceRef: instance }: WikiEditorProps) =>
   const editor = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
+    let model: monaco.editor.ITextModel | null = null;
     if (editor.current) {
       monaco.languages.register({ id: 'wiki' });
 
@@ -349,11 +350,12 @@ const WikiEditor = ({ defaultValue, instanceRef: instance }: WikiEditorProps) =>
       });
 
       const uri = monaco.Uri.parse('inmemory://infobox.wiki');
-      const model = monaco.editor.createModel(defaultValue ?? '', 'wiki', uri);
+      const createdModel = monaco.editor.createModel(defaultValue ?? '', 'wiki', uri);
+      model = createdModel;
 
       instance.current = monaco.editor.create(editor.current, {
         theme: 'wiki',
-        model,
+        model: createdModel,
         language: 'wiki',
         automaticLayout: true,
         wordWrap: 'on',
@@ -362,15 +364,17 @@ const WikiEditor = ({ defaultValue, instanceRef: instance }: WikiEditorProps) =>
           showRegionSectionHeaders: false,
         },
       });
-      validate(model);
-      model.onDidChangeContent(() => {
-        validate(model);
+      validate(createdModel);
+      createdModel.onDidChangeContent(() => {
+        validate(createdModel);
       });
     }
     return () => {
       if (instance.current) {
         instance.current.dispose();
+        instance.current = null;
       }
+      model?.dispose();
     };
   }, [defaultValue, instance]);
 


### PR DESCRIPTION
## 问题

进入 subject wiki 的「修改详细描述」tab 后切到其他 tab，再切回该 tab 会报错：

```
ModelService: Cannot add model because it already exists!
```

## 根因

`WikiEditor` 在 effect 中用固定 URI `inmemory://infobox.wiki` 创建 Monaco model，但卸载清理只 dispose 了 editor 实例，没有 dispose 这个单独创建的 model。重新挂载时再次用同一 URI `createModel`，触发 Monaco ModelService 的重复添加错误。

## 修复

在 effect cleanup 中同时 dispose model，并将 `instance.current` 置空。

## 验证

- `pnpm --filter @bangumi/website exec tsc --noEmit` 通过
- `pnpm exec prettier --check packages/website/src/components/WikiEditor/WikiEditor.tsx` 通过