### PR TITLE
fix(website): hide horizontal scrollbar in subject character section

### DIFF
--- a/packages/website/src/pages/index/subject/[id]/components/SubjectDetailBlocks.tsx
+++ b/packages/website/src/pages/index/subject/[id]/components/SubjectDetailBlocks.tsx
@@ -235,6 +235,8 @@ const characterGrid = css({
   gap: '15px',
   padding: '5px',
   overflowX: 'auto',
+  scrollbarWidth: 'none',
+  '&::-webkit-scrollbar': { display: 'none' },
 });
 
 const characterCoverItem = css({


### PR DESCRIPTION
首页条目「角色介绍」区块使用 `overflowX: 'auto'` 实现横向滚动，但滚动条始终可见。本改动隐藏滚动条、保留横向滚动能力：

- 添加 `scrollbarWidth: 'none'`（Firefox）
- 添加 `&::-webkit-scrollbar: { display: 'none' }`（Chrome/Safari）

与仓库内已有隐藏滚动条的模式（如 `SubjectCollectBlock.tsx`）保持一致。