### PR TITLE
feat(website): add rakuen (超展开) topic aggregation page

### DIFF
--- a/packages/client/api.json
+++ b/packages/client/api.json
@@ -617,6 +617,16 @@
           }
         }
       },
+      "RaKuenTopicType": {
+        "type": "string",
+        "enum": ["all", "group", "my_group", "subject", "episode", "character", "person"],
+        "x-ms-enum": {
+          "name": "RaKuenTopicType",
+          "modelAsString": true
+        },
+        "x-enum-varnames": ["All", "Group", "MyGroup", "Subject", "Episode", "Character", "Person"],
+        "description": "超展开聚合类型\n  - all = 全部\n  - group = 小组话题\n  - my_group = 已加入小组的话题（未登录返回空）\n  - subject = 条目话题\n  - episode = 章节\n  - character = 角色\n  - person = 人物"
+      },
       "SearchCharacter": {
         "type": "object",
         "required": ["keyword"],
@@ -2153,6 +2163,191 @@
           }
         },
         "title": "Profile"
+      },
+      "RaKuenCharacter": {
+        "type": "object",
+        "required": ["type", "id", "name", "nameCN", "comment", "updatedAt"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["character"]
+          },
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "nameCN": {
+            "type": "string"
+          },
+          "images": {
+            "$ref": "#/components/schemas/PersonImages"
+          },
+          "comment": {
+            "type": "integer"
+          },
+          "updatedAt": {
+            "type": "integer",
+            "description": "最后回复时间，unix time stamp in seconds"
+          }
+        },
+        "title": "RaKuenCharacter"
+      },
+      "RaKuenEpisode": {
+        "type": "object",
+        "required": ["type", "id", "subject", "episode", "updatedAt"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["episode"]
+          },
+          "id": {
+            "type": "integer"
+          },
+          "subject": {
+            "$ref": "#/components/schemas/SlimSubject"
+          },
+          "episode": {
+            "type": "object",
+            "required": ["id", "sort", "type", "name", "nameCN", "comment"],
+            "properties": {
+              "id": {
+                "type": "integer"
+              },
+              "sort": {
+                "type": "number"
+              },
+              "type": {
+                "$ref": "#/components/schemas/EpisodeType"
+              },
+              "name": {
+                "type": "string"
+              },
+              "nameCN": {
+                "type": "string"
+              },
+              "comment": {
+                "type": "integer"
+              }
+            }
+          },
+          "updatedAt": {
+            "type": "integer",
+            "description": "最后回复时间，unix time stamp in seconds"
+          }
+        },
+        "title": "RaKuenEpisode"
+      },
+      "RaKuenGroupTopic": {
+        "type": "object",
+        "required": ["type", "id", "title", "replyCount", "creator", "group", "updatedAt"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["group"]
+          },
+          "id": {
+            "type": "integer"
+          },
+          "title": {
+            "type": "string"
+          },
+          "replyCount": {
+            "type": "integer"
+          },
+          "creator": {
+            "$ref": "#/components/schemas/SlimUser"
+          },
+          "group": {
+            "$ref": "#/components/schemas/SlimGroup"
+          },
+          "updatedAt": {
+            "type": "integer",
+            "description": "最后回复时间，unix time stamp in seconds"
+          }
+        },
+        "title": "RaKuenGroupTopic"
+      },
+      "RaKuenPerson": {
+        "type": "object",
+        "required": ["type", "id", "name", "nameCN", "comment", "updatedAt"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["person"]
+          },
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "nameCN": {
+            "type": "string"
+          },
+          "images": {
+            "$ref": "#/components/schemas/PersonImages"
+          },
+          "comment": {
+            "type": "integer"
+          },
+          "updatedAt": {
+            "type": "integer",
+            "description": "最后回复时间，unix time stamp in seconds"
+          }
+        },
+        "title": "RaKuenPerson"
+      },
+      "RaKuenSubjectTopic": {
+        "type": "object",
+        "required": ["type", "id", "title", "replyCount", "creator", "subject", "updatedAt"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["subject"]
+          },
+          "id": {
+            "type": "integer"
+          },
+          "title": {
+            "type": "string"
+          },
+          "replyCount": {
+            "type": "integer"
+          },
+          "creator": {
+            "$ref": "#/components/schemas/SlimUser"
+          },
+          "subject": {
+            "$ref": "#/components/schemas/SlimSubject"
+          },
+          "updatedAt": {
+            "type": "integer",
+            "description": "最后回复时间，unix time stamp in seconds"
+          }
+        },
+        "title": "RaKuenSubjectTopic"
+      },
+      "RaKuenTopic": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/RaKuenGroupTopic"
+          },
+          {
+            "$ref": "#/components/schemas/RaKuenSubjectTopic"
+          },
+          {
+            "$ref": "#/components/schemas/RaKuenEpisode"
+          },
+          {
+            "$ref": "#/components/schemas/RaKuenCharacter"
+          },
+          {
+            "$ref": "#/components/schemas/RaKuenPerson"
+          }
+        ],
+        "title": "RaKuenTopic"
       },
       "Reaction": {
         "type": "object",
@@ -12216,6 +12411,77 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "意料之外的服务器错误",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/p1/rakuen/topics": {
+      "get": {
+        "operationId": "getRaKuenTopics",
+        "summary": "获取超展开聚合列表",
+        "tags": ["rakuen"],
+        "description": "按最后回复时间倒序聚合全站讨论（小组话题/条目话题/章节/角色/人物），type=my_group 时仅返回已加入小组的话题，未登录返回空数据。",
+        "parameters": [
+          {
+            "schema": {
+              "$ref": "#/components/schemas/RaKuenTopicType"
+            },
+            "in": "query",
+            "name": "type",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "default": 50,
+              "minimum": 1,
+              "maximum": 200
+            },
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "description": "min 1, max 200"
+          }
+        ],
+        "security": [
+          {
+            "CookiesSession": [],
+            "HTTPBearer": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["data", "total"],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/RaKuenTopic"
+                      }
+                    },
+                    "total": {
+                      "type": "integer",
+                      "description": "limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数"
+                    }
+                  }
                 }
               }
             }

--- a/packages/client/client.ts
+++ b/packages/client/client.ts
@@ -709,6 +709,67 @@ export type PersonCharacter = {
   character: SlimCharacter;
   relations: CharacterSubjectRelation[];
 };
+export type RaKuenGroupTopic = {
+  type: Type2;
+  id: number;
+  title: string;
+  replyCount: number;
+  creator: SlimUser;
+  group: SlimGroup;
+  /** 最后回复时间，unix time stamp in seconds */
+  updatedAt: number;
+};
+export type RaKuenSubjectTopic = {
+  type: Type3;
+  id: number;
+  title: string;
+  replyCount: number;
+  creator: SlimUser;
+  subject: SlimSubject;
+  /** 最后回复时间，unix time stamp in seconds */
+  updatedAt: number;
+};
+export type RaKuenEpisode = {
+  type: Type4;
+  id: number;
+  subject: SlimSubject;
+  episode: {
+    id: number;
+    sort: number;
+    type: EpisodeType;
+    name: string;
+    nameCN: string;
+    comment: number;
+  };
+  /** 最后回复时间，unix time stamp in seconds */
+  updatedAt: number;
+};
+export type RaKuenCharacter = {
+  type: Type5;
+  id: number;
+  name: string;
+  nameCN: string;
+  images?: PersonImages;
+  comment: number;
+  /** 最后回复时间，unix time stamp in seconds */
+  updatedAt: number;
+};
+export type RaKuenPerson = {
+  type: Type6;
+  id: number;
+  name: string;
+  nameCN: string;
+  images?: PersonImages;
+  comment: number;
+  /** 最后回复时间，unix time stamp in seconds */
+  updatedAt: number;
+};
+export type RaKuenTopic =
+  | RaKuenGroupTopic
+  | RaKuenSubjectTopic
+  | RaKuenEpisode
+  | RaKuenCharacter
+  | RaKuenPerson;
 export type CreateReport = {
   type: ReportType;
   /** 被举报对象的 ID */
@@ -4318,6 +4379,44 @@ export function patchPrivacy(
       method: 'PATCH',
       body,
     }),
+  );
+}
+/**
+ * 获取超展开聚合列表
+ */
+export function getRaKuenTopics(
+  {
+    $type,
+    limit,
+  }: {
+    $type?: RaKuenTopicType;
+    limit?: number;
+  } = {},
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: {
+          data: RaKuenTopic[];
+          /** limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+          total: number;
+        };
+      }
+    | {
+        status: 500;
+        data: ErrorResponse;
+      }
+  >(
+    `/p1/rakuen/topics${QS.query(
+      QS.explode({
+        type: $type,
+        limit,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
   );
 }
 /**
@@ -7949,6 +8048,30 @@ export enum CommentNotification {
 export enum FriendNotification {
   All = 'all',
   None = 'none',
+}
+export enum RaKuenTopicType {
+  All = 'all',
+  Group = 'group',
+  MyGroup = 'my_group',
+  Subject = 'subject',
+  Episode = 'episode',
+  Character = 'character',
+  Person = 'person',
+}
+export enum Type2 {
+  Group = 'group',
+}
+export enum Type3 {
+  Subject = 'subject',
+}
+export enum Type4 {
+  Episode = 'episode',
+}
+export enum Type5 {
+  Character = 'character',
+}
+export enum Type6 {
+  Person = 'person',
 }
 export enum ReportType {
   User = 6,

--- a/packages/client/client.ts
+++ b/packages/client/client.ts
@@ -765,11 +765,7 @@ export type RaKuenPerson = {
   updatedAt: number;
 };
 export type RaKuenTopic =
-  | RaKuenGroupTopic
-  | RaKuenSubjectTopic
-  | RaKuenEpisode
-  | RaKuenCharacter
-  | RaKuenPerson;
+  RaKuenGroupTopic | RaKuenSubjectTopic | RaKuenEpisode | RaKuenCharacter | RaKuenPerson;
 export type CreateReport = {
   type: ReportType;
   /** 被举报对象的 ID */

--- a/packages/client/types/index.ts
+++ b/packages/client/types/index.ts
@@ -1361,6 +1361,26 @@ export interface paths {
     patch: operations['patchPrivacy'];
     trace?: never;
   };
+  '/p1/rakuen/topics': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * 获取超展开聚合列表
+     * @description 按最后回复时间倒序聚合全站讨论（小组话题/条目话题/章节/角色/人物），type=my_group 时仅返回已加入小组的话题，未登录返回空数据。
+     */
+    get: operations['getRaKuenTopics'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/p1/report': {
     parameters: {
       query?: never;
@@ -3185,6 +3205,18 @@ export interface components {
     PersonSearchFilter: {
       career?: string[];
     };
+    /**
+     * @description 超展开聚合类型
+     *       - all = 全部
+     *       - group = 小组话题
+     *       - my_group = 已加入小组的话题（未登录返回空）
+     *       - subject = 条目话题
+     *       - episode = 章节
+     *       - character = 角色
+     *       - person = 人物
+     * @enum {string}
+     */
+    RaKuenTopicType: 'all' | 'group' | 'my_group' | 'subject' | 'episode' | 'character' | 'person';
     SearchCharacter: {
       /** @description 搜索关键词 */
       keyword: string;
@@ -3684,6 +3716,78 @@ export interface components {
       location: string;
       permissions: components['schemas']['Permissions'];
     };
+    /** RaKuenCharacter */
+    RaKuenCharacter: {
+      /** @enum {string} */
+      type: 'character';
+      id: number;
+      name: string;
+      nameCN: string;
+      images?: components['schemas']['PersonImages'];
+      comment: number;
+      /** @description 最后回复时间，unix time stamp in seconds */
+      updatedAt: number;
+    };
+    /** RaKuenEpisode */
+    RaKuenEpisode: {
+      /** @enum {string} */
+      type: 'episode';
+      id: number;
+      subject: components['schemas']['SlimSubject'];
+      episode: {
+        id: number;
+        sort: number;
+        type: components['schemas']['EpisodeType'];
+        name: string;
+        nameCN: string;
+        comment: number;
+      };
+      /** @description 最后回复时间，unix time stamp in seconds */
+      updatedAt: number;
+    };
+    /** RaKuenGroupTopic */
+    RaKuenGroupTopic: {
+      /** @enum {string} */
+      type: 'group';
+      id: number;
+      title: string;
+      replyCount: number;
+      creator: components['schemas']['SlimUser'];
+      group: components['schemas']['SlimGroup'];
+      /** @description 最后回复时间，unix time stamp in seconds */
+      updatedAt: number;
+    };
+    /** RaKuenPerson */
+    RaKuenPerson: {
+      /** @enum {string} */
+      type: 'person';
+      id: number;
+      name: string;
+      nameCN: string;
+      images?: components['schemas']['PersonImages'];
+      comment: number;
+      /** @description 最后回复时间，unix time stamp in seconds */
+      updatedAt: number;
+    };
+    /** RaKuenSubjectTopic */
+    RaKuenSubjectTopic: {
+      /** @enum {string} */
+      type: 'subject';
+      id: number;
+      title: string;
+      replyCount: number;
+      creator: components['schemas']['SlimUser'];
+      subject: components['schemas']['SlimSubject'];
+      /** @description 最后回复时间，unix time stamp in seconds */
+      updatedAt: number;
+    };
+    /** RaKuenTopic */
+    RaKuenTopic:
+      | components['schemas']['RaKuenGroupTopic']
+      | components['schemas']['RaKuenSubjectTopic']
+      | components['schemas']['RaKuenEpisode']
+      | components['schemas']['RaKuenCharacter']
+      | components['schemas']['RaKuenPerson'];
     /** Reaction */
     Reaction: {
       users: components['schemas']['SimpleUser'][];
@@ -4313,7 +4417,16 @@ export interface components {
      * @enum {string}
      */
     UserHomepageSection:
-      'anime' | 'game' | 'book' | 'music' | 'real' | 'mono' | 'blog' | 'friend' | 'group' | 'index';
+      | 'anime'
+      | 'game'
+      | 'book'
+      | 'music'
+      | 'real'
+      | 'mono'
+      | 'blog'
+      | 'friend'
+      | 'group'
+      | 'index';
     /** UserIndexStats */
     UserIndexStats: {
       create: number;
@@ -9017,6 +9130,43 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 意料之外的服务器错误 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getRaKuenTopics: {
+    parameters: {
+      query?: {
+        type?: components['schemas']['RaKuenTopicType'];
+        /** @description min 1, max 200 */
+        limit?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            data: components['schemas']['RaKuenTopic'][];
+            /** @description limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数 */
+            total: number;
+          };
         };
       };
       /** @description 意料之外的服务器错误 */

--- a/packages/client/types/index.ts
+++ b/packages/client/types/index.ts
@@ -4417,16 +4417,7 @@ export interface components {
      * @enum {string}
      */
     UserHomepageSection:
-      | 'anime'
-      | 'game'
-      | 'book'
-      | 'music'
-      | 'real'
-      | 'mono'
-      | 'blog'
-      | 'friend'
-      | 'group'
-      | 'index';
+      'anime' | 'game' | 'book' | 'music' | 'real' | 'mono' | 'blog' | 'friend' | 'group' | 'index';
     /** UserIndexStats */
     UserIndexStats: {
       create: number;

--- a/packages/styled-system/styles.css
+++ b/packages/styled-system/styles.css
@@ -780,6 +780,14 @@
     background: #f97f77;
 }
 
+  .p_0_0_12px {
+    padding: 0 0 12px;
+}
+
+  .p_8px_12px {
+    padding: 8px 12px;
+}
+
   .m_15px_0_10px {
     margin: 15px 0 10px;
 }
@@ -1142,6 +1150,14 @@
 
   .bg_\#eee {
     background: #eee;
+}
+
+  .p_9px_6px {
+    padding: 9px 6px;
+}
+
+  .p_24px_0 {
+    padding: 24px 0;
 }
 
   .p_20px_0_40px {
@@ -1596,12 +1612,12 @@
     gap: 4px;
 }
 
-  .bd-t_1px_solid_\#fefefe {
-    border-top: 1px solid #fefefe;
-}
-
   .bd-b_2px_solid_transparent {
     border-bottom: 2px solid transparent;
+}
+
+  .bd-t_1px_solid_\#fefefe {
+    border-top: 1px solid #fefefe;
 }
 
   .gap_9px {
@@ -3251,6 +3267,14 @@
     margin-right: 4px;
 }
 
+  .mb_-1px {
+    margin-bottom: -1px;
+}
+
+  .bd-b-c_\#54b5df {
+    border-bottom-color: #54b5df;
+}
+
   .pr_15px {
     padding-right: 15px;
 }
@@ -3619,6 +3643,14 @@
     padding-right: var(--spacing-0);
 }
 
+  .min-h_58px {
+    min-height: 58px;
+}
+
+  .mt_4px {
+    margin-top: 4px;
+}
+
   .w_980px {
     width: 980px;
 }
@@ -3705,10 +3737,6 @@
 
   .mb_7px {
     margin-bottom: 7px;
-}
-
-  .min-h_58px {
-    min-height: 58px;
 }
 
   .h_106px {
@@ -3861,10 +3889,6 @@
 
   .h_38px {
     height: 38px;
-}
-
-  .mt_4px {
-    margin-top: 4px;
 }
 
   .top_14px {
@@ -4029,6 +4053,10 @@
 
   .\[\&_li\]\:p_8px_0 li {
     padding: 8px 0;
+}
+
+  .\[\&_p\]\:m_6px_0_0 p {
+    margin: 6px 0 0;
 }
 
   .\[\&_\.bgm-avatar\]\:bd_none .bgm-avatar {
@@ -5097,6 +5125,14 @@
 
   .\[\&_a\]\:fw_600 a {
     font-weight: 600;
+}
+
+  .\[\&_p\]\:c_\#9f9b9b p {
+    color: #9f9b9b;
+}
+
+  .\[\&_p\]\:fs_12px p {
+    font-size: 12px;
 }
 
   .\[\&_\.bgm-link\]\:c_\#0084b4 .bgm-link {

--- a/packages/styled-system/styles.css
+++ b/packages/styled-system/styles.css
@@ -2349,6 +2349,10 @@
     flex-shrink: 1;
 }
 
+  .c_\#0084b4 {
+    color: #0084b4;
+}
+
   .lh_32px {
     line-height: 32px;
 }
@@ -2475,10 +2479,6 @@
 
   .tbl_fixed {
     table-layout: fixed;
-}
-
-  .c_\#0084b4 {
-    color: #0084b4;
 }
 
   .fw_normal {
@@ -3271,8 +3271,8 @@
     margin-bottom: -1px;
 }
 
-  .bd-b-c_\#54b5df {
-    border-bottom-color: #54b5df;
+  .bd-b-c_\#0084b4 {
+    border-bottom-color: #0084b4;
 }
 
   .pr_15px {
@@ -5127,8 +5127,12 @@
     font-weight: 600;
 }
 
-  .\[\&_p\]\:c_\#9f9b9b p {
-    color: #9f9b9b;
+  .\[\&_h1\]\:c_\#1f1c1c h1 {
+    color: #1f1c1c;
+}
+
+  .\[\&_p\]\:c_\#595555 p {
+    color: #595555;
 }
 
   .\[\&_p\]\:fs_12px p {
@@ -7056,6 +7060,10 @@
 
   .hover\:c_\#f09199:is(:hover, [data-hover]) {
     color: #f09199;
+}
+
+  .hover\:c_\#0084b4:is(:hover, [data-hover]) {
+    color: #0084b4;
 }
 
   .hover\:c_\#02a3fb:is(:hover, [data-hover]) {

--- a/packages/website/src/components/Header/index.tsx
+++ b/packages/website/src/components/Header/index.tsx
@@ -69,6 +69,7 @@ const navRight = [
   {
     key: 'rakuen',
     label: '超展开',
+    href: '/rakuen',
   },
   {
     key: 'group',

--- a/packages/website/src/hooks/use-rakuen-topics.ts
+++ b/packages/website/src/hooks/use-rakuen-topics.ts
@@ -1,0 +1,27 @@
+import { ok } from '@oazapfts/runtime';
+import useSWR from 'swr';
+
+import { ozaClient } from '@bangumi/client';
+import type { RaKuenTopic, RaKuenTopicType } from '@bangumi/client/client';
+
+interface UseRakuenTopicsRet {
+  data: RaKuenTopic[] | undefined;
+  total: number | undefined;
+}
+
+/**
+ * 获取超展开聚合列表。
+ * type 由 URL query 传入，登录态由服务端统一处理（如 my_group 未登录返回空列表）。
+ */
+export function useRakuenTopics(
+  type: RaKuenTopicType,
+  { limit = 50 }: { limit?: number } = {},
+): UseRakuenTopicsRet {
+  const { data } = useSWR(
+    `rakuen-topics ${type} ${limit}`,
+    async () => ok(ozaClient.getRaKuenTopics({ $type: type, limit })),
+    { suspense: true },
+  );
+
+  return data ?? { data: undefined, total: undefined };
+}

--- a/packages/website/src/mocks/fixtures/p1/rakuen/topics-GET.json
+++ b/packages/website/src/mocks/fixtures/p1/rakuen/topics-GET.json
@@ -38,7 +38,7 @@
     },
     {
       "type": "subject",
-      "id": 431000,
+      "id": 430381,
       "title": "新番组 2026 年春季动画讨论帖",
       "replyCount": 32,
       "creator": {

--- a/packages/website/src/mocks/fixtures/p1/rakuen/topics-GET.json
+++ b/packages/website/src/mocks/fixtures/p1/rakuen/topics-GET.json
@@ -1,0 +1,149 @@
+{
+  "data": [
+    {
+      "type": "group",
+      "id": 430381,
+      "title": "[投票结果] 关于连载书籍平台子分类的关联问题",
+      "replyCount": 107,
+      "creator": {
+        "id": 21804,
+        "username": "test_user",
+        "nickname": "测试用户",
+        "avatar": {
+          "small": "https://lain.bgm.tv/r/100/pic/user/l/000/00/00/00000.jpg",
+          "medium": "https://lain.bgm.tv/r/200/pic/user/l/000/00/00/00000.jpg",
+          "large": "https://lain.bgm.tv/pic/user/l/000/00/00/00000.jpg"
+        },
+        "group": 2,
+        "sign": "测试",
+        "joinedAt": 1700000000,
+        "isFriend": false
+      },
+      "group": {
+        "id": 128,
+        "name": "wiki",
+        "nsfw": false,
+        "title": "番組WIKI計画",
+        "icon": {
+          "small": "https://lain.bgm.tv/r/100/pic/icon/l/000/00/01/128.jpg",
+          "medium": "https://lain.bgm.tv/r/200/pic/icon/l/000/00/01/128.jpg",
+          "large": "https://lain.bgm.tv/pic/icon/l/000/00/01/128.jpg"
+        },
+        "creatorID": 271,
+        "members": 8099,
+        "accessible": true,
+        "createdAt": 1233321099
+      },
+      "updatedAt": 1786465803
+    },
+    {
+      "type": "subject",
+      "id": 431000,
+      "title": "新番组 2026 年春季动画讨论帖",
+      "replyCount": 32,
+      "creator": {
+        "id": 21805,
+        "username": "test_user2",
+        "nickname": "测试用户2",
+        "avatar": {
+          "small": "https://lain.bgm.tv/r/100/pic/user/l/000/00/00/00000.jpg",
+          "medium": "https://lain.bgm.tv/r/200/pic/user/l/000/00/00/00000.jpg",
+          "large": "https://lain.bgm.tv/pic/user/l/000/00/00/00000.jpg"
+        },
+        "group": 2,
+        "sign": "",
+        "joinedAt": 1700000000,
+        "isFriend": false
+      },
+      "subject": {
+        "id": 8,
+        "name": "TEST",
+        "nameCN": "测试条目",
+        "type": 2,
+        "images": {
+          "large": "https://lain.bgm.tv/pic/cover/l/00/00/00/8.jpg",
+          "common": "https://lain.bgm.tv/pic/cover/c/00/00/00/8.jpg",
+          "medium": "https://lain.bgm.tv/pic/cover/m/00/00/00/8.jpg",
+          "small": "https://lain.bgm.tv/pic/cover/s/00/00/00/8.jpg",
+          "grid": "https://lain.bgm.tv/pic/cover/g/00/00/00/8.jpg"
+        },
+        "info": "",
+        "metaTags": [],
+        "rating": {
+          "rank": 0,
+          "count": [],
+          "score": 0,
+          "total": 0
+        },
+        "locked": false,
+        "nsfw": false
+      },
+      "updatedAt": 1786465900
+    },
+    {
+      "type": "episode",
+      "id": 999,
+      "subject": {
+        "id": 8,
+        "name": "TEST",
+        "nameCN": "测试条目",
+        "type": 2,
+        "images": {
+          "large": "https://lain.bgm.tv/pic/cover/l/00/00/00/8.jpg",
+          "common": "https://lain.bgm.tv/pic/cover/c/00/00/00/8.jpg",
+          "medium": "https://lain.bgm.tv/pic/cover/m/00/00/00/8.jpg",
+          "small": "https://lain.bgm.tv/pic/cover/s/00/00/00/8.jpg",
+          "grid": "https://lain.bgm.tv/pic/cover/g/00/00/00/8.jpg"
+        },
+        "info": "",
+        "metaTags": [],
+        "rating": {
+          "rank": 0,
+          "count": [],
+          "score": 0,
+          "total": 0
+        },
+        "locked": false,
+        "nsfw": false
+      },
+      "episode": {
+        "id": 999,
+        "sort": 1,
+        "type": 0,
+        "name": "ep1",
+        "nameCN": "第一话",
+        "comment": 12
+      },
+      "updatedAt": 1786466000
+    },
+    {
+      "type": "character",
+      "id": 1001,
+      "name": "test",
+      "nameCN": "测试角色",
+      "images": {
+        "large": "https://lain.bgm.tv/pic/crt/l/00/00/00/1001.jpg",
+        "medium": "https://lain.bgm.tv/pic/crt/m/00/00/00/1001.jpg",
+        "small": "https://lain.bgm.tv/pic/crt/s/00/00/00/1001.jpg",
+        "grid": "https://lain.bgm.tv/pic/crt/g/00/00/00/1001.jpg"
+      },
+      "comment": 5,
+      "updatedAt": 1786466100
+    },
+    {
+      "type": "person",
+      "id": 1002,
+      "name": "test person",
+      "nameCN": "",
+      "images": {
+        "large": "https://lain.bgm.tv/pic/crt/l/00/00/00/1002.jpg",
+        "medium": "https://lain.bgm.tv/pic/crt/m/00/00/00/1002.jpg",
+        "small": "https://lain.bgm.tv/pic/crt/s/00/00/00/1002.jpg",
+        "grid": "https://lain.bgm.tv/pic/crt/g/00/00/00/1002.jpg"
+      },
+      "comment": 3,
+      "updatedAt": 1786466200
+    }
+  ],
+  "total": 5
+}

--- a/packages/website/src/mocks/handlers.ts
+++ b/packages/website/src/mocks/handlers.ts
@@ -2,6 +2,7 @@ import { mockAPI } from './utils';
 
 export const handlers = [
   mockAPI('/p1/me', 'get'),
+  mockAPI('/p1/rakuen/topics', 'get'),
   mockAPI('/p1/notify', 'get'),
   mockAPI('/p1/clear-notify', 'post'),
   mockAPI('/p1/home', 'get'),

--- a/packages/website/src/pages/index/rakuen/components/RakuenList.tsx
+++ b/packages/website/src/pages/index/rakuen/components/RakuenList.tsx
@@ -1,0 +1,247 @@
+import React from 'react';
+
+import type { RaKuenTopic } from '@bangumi/client/client';
+import { EpisodeType } from '@bangumi/client/client';
+import { Avatar, Typography } from '@bangumi/design';
+import { css } from '@bangumi/styled-system/css';
+import {
+  getCharacterLink,
+  getEpisodeLink,
+  getGroupLink,
+  getGroupTopicLink,
+  getPersonLink,
+  getSubjectLink,
+  getSubjectTopicLink,
+  getUserProfileLink,
+} from '@bangumi/utils/pages';
+import { makeDescriptiveTime } from '@bangumi/website/components/TimelineDescription';
+
+const listItem = css({
+  display: 'flex',
+  gap: '10px',
+  alignItems: 'center',
+  minHeight: '58px',
+  padding: '9px 6px',
+  boxSizing: 'border-box',
+  borderBottom: '1px dotted #e8e3e3',
+});
+
+const inner = css({
+  minWidth: '0',
+  flex: '1',
+});
+
+const title = css({
+  display: 'block',
+  overflow: 'hidden',
+  color: '#54b5df',
+  fontSize: '14px',
+  fontWeight: '400',
+  lineHeight: '1.4',
+  textDecoration: 'none',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  overflowWrap: 'anywhere',
+  _hover: { color: '#f09199' },
+});
+
+const replies = css({
+  marginLeft: '6px',
+  color: '#9f9b9b',
+  fontSize: '11px',
+  fontWeight: 'normal',
+});
+
+const row = css({
+  display: 'block',
+  marginTop: '4px',
+  fontSize: '12px',
+  lineHeight: '1.4',
+  color: '#777',
+});
+
+const parentLink = css({
+  color: '#54b5df',
+  textDecoration: 'none',
+  _hover: { color: '#f09199' },
+});
+
+const time = css({
+  marginLeft: '8px',
+  color: '#9f9b9b',
+  fontSize: '11px',
+});
+
+const cover = css({
+  flex: '0 0 48px',
+  width: '48px',
+  height: '48px',
+  overflow: 'hidden',
+  borderRadius: '6px',
+  background: '#e8e3e3',
+});
+
+const coverImage = css({
+  display: 'block',
+  width: '48px',
+  height: '48px',
+  objectFit: 'cover',
+});
+
+const EPISODE_TYPE_PREFIXES: Record<EpisodeType, string> = {
+  [EpisodeType.Normal]: 'EP',
+  [EpisodeType.Special]: 'SP',
+  [EpisodeType.Op]: 'OP',
+  [EpisodeType.Ed]: 'ED',
+  [EpisodeType.Pre]: 'Movie',
+  [EpisodeType.Mad]: 'MAD',
+  [EpisodeType.Other]: 'Other',
+};
+
+/** 章节显示名，如「EP.1 第一话」 */
+function episodeDisplayName(item: Extract<RaKuenTopic, { type: 'episode' }>): string {
+  const { episode } = item;
+  const prefix = EPISODE_TYPE_PREFIXES[episode.type as EpisodeType] ?? 'EP';
+  const name = episode.nameCN || episode.name;
+  return `${prefix}.${episode.sort} ${name}`.trim();
+}
+
+const GroupItem: React.FC<{ item: Extract<RaKuenTopic, { type: 'group' }> }> = ({ item }) => (
+  <li className={listItem}>
+    <Typography.Link to={getUserProfileLink(item.creator.username)} noStyle>
+      <Avatar src={item.creator.avatar.medium} alt={item.creator.nickname} />
+    </Typography.Link>
+    <div className={inner}>
+      <Typography.Link to={getGroupTopicLink(item.id)} noStyle className={title}>
+        {item.title}
+        <span className={replies}>(+{item.replyCount})</span>
+      </Typography.Link>
+      <span className={row}>
+        <Typography.Link to={getGroupLink(item.group.name)} noStyle className={parentLink}>
+          {item.group.title}
+        </Typography.Link>
+        <small className={time}>{makeDescriptiveTime(item.updatedAt)}</small>
+      </span>
+    </div>
+  </li>
+);
+
+const SubjectItem: React.FC<{ item: Extract<RaKuenTopic, { type: 'subject' }> }> = ({ item }) => (
+  <li className={listItem}>
+    <Typography.Link to={getUserProfileLink(item.creator.username)} noStyle>
+      <Avatar src={item.creator.avatar.medium} alt={item.creator.nickname} />
+    </Typography.Link>
+    <div className={inner}>
+      <Typography.Link to={getSubjectTopicLink(item.id)} noStyle className={title}>
+        {item.title}
+        <span className={replies}>(+{item.replyCount})</span>
+      </Typography.Link>
+      <span className={row}>
+        <Typography.Link to={getSubjectLink(item.subject.id)} noStyle className={parentLink}>
+          {item.subject.nameCN || item.subject.name}
+        </Typography.Link>
+        <small className={time}>{makeDescriptiveTime(item.updatedAt)}</small>
+      </span>
+    </div>
+  </li>
+);
+
+const EpisodeItem: React.FC<{ item: Extract<RaKuenTopic, { type: 'episode' }> }> = ({ item }) => (
+  <li className={listItem}>
+    <LinkWithCover to={getEpisodeLink(item.id)} image={item.subject.images?.common} alt='' />
+    <div className={inner}>
+      <Typography.Link to={getEpisodeLink(item.id)} noStyle className={title}>
+        {episodeDisplayName(item)}
+        <span className={replies}>(+{item.episode.comment})</span>
+      </Typography.Link>
+      <span className={row}>
+        <Typography.Link to={getSubjectLink(item.subject.id)} noStyle className={parentLink}>
+          {item.subject.nameCN || item.subject.name}
+        </Typography.Link>
+        <small className={time}>{makeDescriptiveTime(item.updatedAt)}</small>
+      </span>
+    </div>
+  </li>
+);
+
+const CharacterItem: React.FC<{ item: Extract<RaKuenTopic, { type: 'character' }> }> = ({
+  item,
+}) => (
+  <li className={listItem}>
+    <LinkWithCover to={getCharacterLink(item.id)} image={item.images?.medium} alt='' />
+    <div className={inner}>
+      <Typography.Link to={getCharacterLink(item.id)} noStyle className={title}>
+        {item.nameCN || item.name}
+        <span className={replies}>(+{item.comment})</span>
+      </Typography.Link>
+      <span className={row}>
+        <small className={time}>{makeDescriptiveTime(item.updatedAt)}</small>
+      </span>
+    </div>
+  </li>
+);
+
+const PersonItem: React.FC<{ item: Extract<RaKuenTopic, { type: 'person' }> }> = ({ item }) => (
+  <li className={listItem}>
+    <LinkWithCover to={getPersonLink(item.id)} image={item.images?.medium} alt='' />
+    <div className={inner}>
+      <Typography.Link to={getPersonLink(item.id)} noStyle className={title}>
+        {item.nameCN || item.name}
+        <span className={replies}>(+{item.comment})</span>
+      </Typography.Link>
+      <span className={row}>
+        <small className={time}>{makeDescriptiveTime(item.updatedAt)}</small>
+      </span>
+    </div>
+  </li>
+);
+
+const LinkWithCover: React.FC<{ to: string; image?: string; alt: string }> = ({
+  to,
+  image,
+  alt,
+}) => (
+  <Typography.Link to={to} noStyle className={cover}>
+    {image ? <img src={image} alt={alt} className={coverImage} /> : null}
+  </Typography.Link>
+);
+
+const list = css({
+  padding: '0',
+  margin: '0',
+  listStyle: 'none',
+});
+
+const empty = css({
+  padding: '24px 0',
+  color: '#9f9b9b',
+  fontSize: '13px',
+  textAlign: 'center',
+});
+
+const RakuenList: React.FC<{ topics: RaKuenTopic[] }> = ({ topics }) => {
+  if (topics.length === 0) {
+    return <div className={empty}>暂无内容</div>;
+  }
+
+  return (
+    <ul className={list}>
+      {topics.map((topic) => {
+        switch (topic.type) {
+          case 'group':
+            return <GroupItem key={topic.id} item={topic} />;
+          case 'subject':
+            return <SubjectItem key={topic.id} item={topic} />;
+          case 'episode':
+            return <EpisodeItem key={topic.id} item={topic} />;
+          case 'character':
+            return <CharacterItem key={topic.id} item={topic} />;
+          case 'person':
+            return <PersonItem key={topic.id} item={topic} />;
+        }
+      })}
+    </ul>
+  );
+};
+
+export default RakuenList;

--- a/packages/website/src/pages/index/rakuen/components/RakuenList.tsx
+++ b/packages/website/src/pages/index/rakuen/components/RakuenList.tsx
@@ -225,19 +225,21 @@ const RakuenList: React.FC<{ topics: RaKuenTopic[] }> = ({ topics }) => {
   }
 
   return (
-    <ul className={list}>
+    <ul className={list} data-testid='rakuen-list'>
       {topics.map((topic) => {
+        // 5 类话题的 ID 来自独立数据表，all 模式下可能重复，key 需带 type 前缀
+        const key = `${topic.type}:${topic.id}`;
         switch (topic.type) {
           case 'group':
-            return <GroupItem key={topic.id} item={topic} />;
+            return <GroupItem key={key} item={topic} />;
           case 'subject':
-            return <SubjectItem key={topic.id} item={topic} />;
+            return <SubjectItem key={key} item={topic} />;
           case 'episode':
-            return <EpisodeItem key={topic.id} item={topic} />;
+            return <EpisodeItem key={key} item={topic} />;
           case 'character':
-            return <CharacterItem key={topic.id} item={topic} />;
+            return <CharacterItem key={key} item={topic} />;
           case 'person':
-            return <PersonItem key={topic.id} item={topic} />;
+            return <PersonItem key={key} item={topic} />;
         }
       })}
     </ul>

--- a/packages/website/src/pages/index/rakuen/components/RakuenList.tsx
+++ b/packages/website/src/pages/index/rakuen/components/RakuenList.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import type { RaKuenTopic } from '@bangumi/client/client';
 import { EpisodeType } from '@bangumi/client/client';
 import { Avatar, Typography } from '@bangumi/design';
-import { css } from '@bangumi/styled-system/css';
+import { css, cx } from '@bangumi/styled-system/css';
 import {
   getCharacterLink,
   getEpisodeLink,
@@ -15,6 +15,8 @@ import {
   getUserProfileLink,
 } from '@bangumi/utils/pages';
 import { makeDescriptiveTime } from '@bangumi/website/components/TimelineDescription';
+
+import { topicListLink } from '../../group/components/topicListLink';
 
 const listItem = css({
   display: 'flex',
@@ -34,15 +36,12 @@ const inner = css({
 const title = css({
   display: 'block',
   overflow: 'hidden',
-  color: '#54b5df',
   fontSize: '14px',
   fontWeight: '400',
   lineHeight: '1.4',
-  textDecoration: 'none',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
   overflowWrap: 'anywhere',
-  _hover: { color: '#f09199' },
 });
 
 const replies = css({
@@ -57,18 +56,18 @@ const row = css({
   marginTop: '4px',
   fontSize: '12px',
   lineHeight: '1.4',
-  color: '#777',
+  color: '#595555',
 });
 
 const parentLink = css({
-  color: '#54b5df',
+  color: '#0084b4',
   textDecoration: 'none',
-  _hover: { color: '#f09199' },
+  _hover: { color: '#02a3fb', textDecoration: 'underline' },
 });
 
 const time = css({
   marginLeft: '8px',
-  color: '#9f9b9b',
+  color: '#595555',
   fontSize: '11px',
 });
 
@@ -112,7 +111,7 @@ const GroupItem: React.FC<{ item: Extract<RaKuenTopic, { type: 'group' }> }> = (
       <Avatar src={item.creator.avatar.medium} alt={item.creator.nickname} />
     </Typography.Link>
     <div className={inner}>
-      <Typography.Link to={getGroupTopicLink(item.id)} noStyle className={title}>
+      <Typography.Link to={getGroupTopicLink(item.id)} noStyle className={cx(topicListLink, title)}>
         {item.title}
         <span className={replies}>(+{item.replyCount})</span>
       </Typography.Link>
@@ -132,7 +131,11 @@ const SubjectItem: React.FC<{ item: Extract<RaKuenTopic, { type: 'subject' }> }>
       <Avatar src={item.creator.avatar.medium} alt={item.creator.nickname} />
     </Typography.Link>
     <div className={inner}>
-      <Typography.Link to={getSubjectTopicLink(item.id)} noStyle className={title}>
+      <Typography.Link
+        to={getSubjectTopicLink(item.id)}
+        noStyle
+        className={cx(topicListLink, title)}
+      >
         {item.title}
         <span className={replies}>(+{item.replyCount})</span>
       </Typography.Link>
@@ -150,7 +153,7 @@ const EpisodeItem: React.FC<{ item: Extract<RaKuenTopic, { type: 'episode' }> }>
   <li className={listItem}>
     <LinkWithCover to={getEpisodeLink(item.id)} image={item.subject.images?.common} alt='' />
     <div className={inner}>
-      <Typography.Link to={getEpisodeLink(item.id)} noStyle className={title}>
+      <Typography.Link to={getEpisodeLink(item.id)} noStyle className={cx(topicListLink, title)}>
         {episodeDisplayName(item)}
         <span className={replies}>(+{item.episode.comment})</span>
       </Typography.Link>
@@ -170,7 +173,7 @@ const CharacterItem: React.FC<{ item: Extract<RaKuenTopic, { type: 'character' }
   <li className={listItem}>
     <LinkWithCover to={getCharacterLink(item.id)} image={item.images?.medium} alt='' />
     <div className={inner}>
-      <Typography.Link to={getCharacterLink(item.id)} noStyle className={title}>
+      <Typography.Link to={getCharacterLink(item.id)} noStyle className={cx(topicListLink, title)}>
         {item.nameCN || item.name}
         <span className={replies}>(+{item.comment})</span>
       </Typography.Link>
@@ -185,7 +188,7 @@ const PersonItem: React.FC<{ item: Extract<RaKuenTopic, { type: 'person' }> }> =
   <li className={listItem}>
     <LinkWithCover to={getPersonLink(item.id)} image={item.images?.medium} alt='' />
     <div className={inner}>
-      <Typography.Link to={getPersonLink(item.id)} noStyle className={title}>
+      <Typography.Link to={getPersonLink(item.id)} noStyle className={cx(topicListLink, title)}>
         {item.nameCN || item.name}
         <span className={replies}>(+{item.comment})</span>
       </Typography.Link>

--- a/packages/website/src/pages/index/rakuen/index.spec.tsx
+++ b/packages/website/src/pages/index/rakuen/index.spec.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, screen } from '@testing-library/react';
+import React from 'react';
+
+import { renderPage } from '@bangumi/website/utils/test-utils';
+
+import RakuenIndex from '.';
+
+vi.mock('@bangumi/website/hooks/use-rakuen-topics', async () => {
+  const { data } = await import('../../../mocks/fixtures/p1/rakuen/topics-GET.json');
+  return {
+    useRakuenTopics: (type: string) => ({
+      data: type === 'episode' ? data.filter((topic) => topic.type === 'episode') : data,
+      total: data.length,
+    }),
+  };
+});
+
+describe('RakuenIndex', () => {
+  it('renders page header and tabs', () => {
+    renderPage(<RakuenIndex />);
+
+    expect(screen.getByRole('heading', { name: '超展开' })).toBeInTheDocument();
+    for (const label of ['全部', '小组', '已加入小组', '条目', '章节', '角色', '人物']) {
+      expect(screen.getByRole('tab', { name: label })).toBeInTheDocument();
+    }
+  });
+
+  it('renders mixed topic list items', () => {
+    renderPage(<RakuenIndex />);
+
+    expect(
+      screen.getByRole('link', { name: /\[投票结果\] 关于连载书籍平台子分类的关联问题/ }),
+    ).toHaveAttribute('href', '/group/topic/430381');
+    expect(screen.getByRole('link', { name: /新番组 2026 年春季动画讨论帖/ })).toHaveAttribute(
+      'href',
+      '/subject/topic/431000',
+    );
+    expect(screen.getByRole('link', { name: /EP\.1 第一话/ })).toHaveAttribute('href', '/ep/999');
+    expect(screen.getByRole('link', { name: /测试角色/ })).toHaveAttribute(
+      'href',
+      '/character/1001',
+    );
+    expect(screen.getByRole('link', { name: /test person/ })).toHaveAttribute(
+      'href',
+      '/person/1002',
+    );
+  });
+
+  it('switches list by type query', () => {
+    renderPage(<RakuenIndex />);
+
+    const episodeTab = screen.getByRole('tab', { name: '章节' });
+    fireEvent.click(episodeTab);
+
+    expect(screen.getByRole('tab', { name: '章节' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('link', { name: /EP\.1 第一话/ })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /测试角色/ })).not.toBeInTheDocument();
+  });
+});

--- a/packages/website/src/pages/index/rakuen/index.spec.tsx
+++ b/packages/website/src/pages/index/rakuen/index.spec.tsx
@@ -1,8 +1,9 @@
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, within } from '@testing-library/react';
 import React from 'react';
 
 import { renderPage } from '@bangumi/website/utils/test-utils';
 
+import topicsJson from '../../../mocks/fixtures/p1/rakuen/topics-GET.json';
 import RakuenIndex from '.';
 
 vi.mock('@bangumi/website/hooks/use-rakuen-topics', async () => {
@@ -33,7 +34,7 @@ describe('RakuenIndex', () => {
     ).toHaveAttribute('href', '/group/topic/430381');
     expect(screen.getByRole('link', { name: /新番组 2026 年春季动画讨论帖/ })).toHaveAttribute(
       'href',
-      '/subject/topic/431000',
+      '/subject/topic/430381',
     );
     expect(screen.getByRole('link', { name: /EP\.1 第一话/ })).toHaveAttribute('href', '/ep/999');
     expect(screen.getByRole('link', { name: /测试角色/ })).toHaveAttribute(
@@ -44,6 +45,10 @@ describe('RakuenIndex', () => {
       'href',
       '/person/1002',
     );
+
+    // group 与 subject 话题 ID 相同（不同数据表），仍应渲染为两行，React key 不冲突
+    const listItems = within(screen.getByTestId('rakuen-list')).getAllByRole('listitem');
+    expect(listItems).toHaveLength(topicsJson.data.length);
   });
 
   it('switches list by type query', () => {

--- a/packages/website/src/pages/index/rakuen/index.tsx
+++ b/packages/website/src/pages/index/rakuen/index.tsx
@@ -15,7 +15,7 @@ const pageHeader = css({
   '& h1': {
     display: 'inline',
     margin: '0',
-    color: '#595555',
+    color: '#1f1c1c',
     fontSize: '20px',
     fontWeight: '700',
     lineHeight: '1.4',
@@ -23,7 +23,7 @@ const pageHeader = css({
   },
   '& p': {
     margin: '6px 0 0',
-    color: '#9f9b9b',
+    color: '#595555',
     fontSize: '12px',
   },
 });
@@ -42,17 +42,17 @@ const tab = css({
   display: 'block',
   padding: '8px 12px',
   marginBottom: '-1px',
-  color: '#9f9b9b',
+  color: '#595555',
   fontSize: '13px',
   textDecoration: 'none',
   whiteSpace: 'nowrap',
   borderBottom: '2px solid transparent',
-  _hover: { color: '#54b5df' },
+  _hover: { color: '#0084b4' },
 });
 
 const tabActive = css({
-  color: '#54b5df',
-  borderBottomColor: '#54b5df',
+  color: '#0084b4',
+  borderBottomColor: '#0084b4',
 });
 
 const content = css({

--- a/packages/website/src/pages/index/rakuen/index.tsx
+++ b/packages/website/src/pages/index/rakuen/index.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+
+import { RaKuenTopicType } from '@bangumi/client/client';
+import { css, cx } from '@bangumi/styled-system/css';
+import { withErrorBoundary } from '@bangumi/website/components/ErrorBoundary';
+import Helmet from '@bangumi/website/components/Helmet';
+import PageContainer from '@bangumi/website/components/PageContainer';
+import { useRakuenTopics } from '@bangumi/website/hooks/use-rakuen-topics';
+
+import RakuenList from './components/RakuenList';
+
+const pageHeader = css({
+  padding: '0 0 12px',
+  '& h1': {
+    display: 'inline',
+    margin: '0',
+    color: '#595555',
+    fontSize: '20px',
+    fontWeight: '700',
+    lineHeight: '1.4',
+    letterSpacing: '0',
+  },
+  '& p': {
+    margin: '6px 0 0',
+    color: '#9f9b9b',
+    fontSize: '12px',
+  },
+});
+
+const tabs = css({
+  display: 'flex',
+  gap: '4px',
+  padding: '0',
+  margin: '0 0 12px',
+  listStyle: 'none',
+  borderBottom: '1px solid #e8e3e3',
+  overflowX: 'auto',
+});
+
+const tab = css({
+  display: 'block',
+  padding: '8px 12px',
+  marginBottom: '-1px',
+  color: '#9f9b9b',
+  fontSize: '13px',
+  textDecoration: 'none',
+  whiteSpace: 'nowrap',
+  borderBottom: '2px solid transparent',
+  _hover: { color: '#54b5df' },
+});
+
+const tabActive = css({
+  color: '#54b5df',
+  borderBottomColor: '#54b5df',
+});
+
+const content = css({
+  border: '1px solid #e8e3e3',
+  borderRadius: '6px',
+});
+
+const TABS: { type: RaKuenTopicType; label: string }[] = [
+  { type: RaKuenTopicType.All, label: '全部' },
+  { type: RaKuenTopicType.Group, label: '小组' },
+  { type: RaKuenTopicType.MyGroup, label: '已加入小组' },
+  { type: RaKuenTopicType.Subject, label: '条目' },
+  { type: RaKuenTopicType.Episode, label: '章节' },
+  { type: RaKuenTopicType.Character, label: '角色' },
+  { type: RaKuenTopicType.Person, label: '人物' },
+];
+
+/** URL query 中的字符串 type 转枚举，非法值回退到 all */
+function parseType(param: string | null): RaKuenTopicType {
+  const found = TABS.find((tab) => tab.type === param);
+  return found?.type ?? RaKuenTopicType.All;
+}
+
+const RakuenIndex: React.FC = () => {
+  const [searchParams] = useSearchParams();
+  const type = parseType(searchParams.get('type'));
+
+  const { data: topics } = useRakuenTopics(type);
+
+  return (
+    <>
+      <Helmet title='超展开' />
+      <PageContainer>
+        <div className={pageHeader}>
+          <h1>超展开</h1>
+          <p>汇聚 Bangumi 全站讨论</p>
+        </div>
+        <ul className={tabs} role='tablist'>
+          {TABS.map((item) => (
+            <li key={item.type} role='presentation'>
+              <Link
+                to={item.type === RaKuenTopicType.All ? '/rakuen' : `/rakuen?type=${item.type}`}
+                className={cx(tab, item.type === type && tabActive)}
+                role='tab'
+                aria-selected={item.type === type}
+              >
+                {item.label}
+              </Link>
+            </li>
+          ))}
+        </ul>
+        <div className={content}>
+          <RakuenList topics={topics ?? []} />
+        </div>
+      </PageContainer>
+    </>
+  );
+};
+
+export default withErrorBoundary(RakuenIndex);

--- a/packages/website/src/routes.tsx
+++ b/packages/website/src/routes.tsx
@@ -19,6 +19,7 @@ const Channel = lazy(async () => import('./pages/index/channel'));
 const Episode = lazy(async () => import('./pages/index/ep/[id]'));
 const EpisodeEdit = lazy(async () => import('./pages/index/ep/[id]/edit'));
 const Notifications = lazy(async () => import('./pages/index/notifications'));
+const Rakuen = lazy(async () => import('./pages/index/rakuen'));
 const Group = lazy(async () => import('./pages/index/group/[name]/index'));
 const GroupChannel = lazy(async () => import('./pages/index/group/index'));
 const GroupAll = lazy(async () => import('./pages/index/group/all'));
@@ -129,6 +130,7 @@ export const pageRoutes: RouteObject[] = [
       { path: 'dev/app', element: <DevApp /> },
       { path: 'dollars', element: <Dollars /> },
       { path: 'goodies', element: <Goodies /> },
+      { path: 'rakuen', element: <Rakuen /> },
       { path: 'ep/:id', element: <Episode /> },
       { path: 'ep/:id/edit', element: <EpisodeEdit /> },
       { path: 'blog/:id', element: <BlogEntry /> },


### PR DESCRIPTION
## Summary

Adds the rakuen (超展开) page at `/rakuen`, aggregating the latest discussions across the whole site: group topics, subject topics, episode comments, characters and persons, sorted by last reply time.

This is the frontend half of a cross-repo collaboration; the backend API is implemented in the companion PR [bangumi/server-private#1777](https://github.com/bangumi/server-private/pull/1777) (feat: add rakuen topics aggregation API).

## Changes

- **Page**: `/rakuen` with type tabs (全部/小组/已加入小组/条目/章节/角色/人物) driven by the `type` query param; item rendering for all five topic types (author avatar / subject cover / character & person images, reply counts, parent group/subject name, relative last-reply time)
- **Data**: `useRakuenTopics` SWR hook calling `GET /p1/rakuen/topics`; login state is handled entirely by the backend (e.g. `my_group` returns empty data when logged out)
- **Routing**: register `/rakuen` route, add header nav link for 超展开
- **Client**: regenerate API client from the updated `openapi.json` (adds `RaKuenTopic` union, `RaKuenTopicType`, `getRaKuenTopics`)
- **Tests**: MSW fixture + page tests covering header/tabs rendering, mixed list items with correct links, and type-tab switching

## API contract (agreed with backend)

`GET /p1/rakuen/topics?type=all|group|my_group|subject|episode|character|person&limit=1..200` (default 50), returns `{ data: RaKuenTopic[], total }` sorted by `updatedAt` desc. No `offset`; backend applies a site-wide 60s cache (per-uid for `my_group`) and uniform NSFW filtering.

## Verification

- `pnpm lint` ✅
- `pnpm type-check` ✅
- `pnpm test` (368 passed; one pre-existing jsdom `window is not defined` unhandled rejection in a blog test unrelated to this change) ✅
- `pnpm run build` ✅
- Playwright screenshot of `/rakuen` renders correctly ✅