### PR TITLE
fix(website): show active home timeline and progress filter buttons

### DIFF
--- a/packages/styled-system/styles.css
+++ b/packages/styled-system/styles.css
@@ -4115,6 +4115,10 @@
     padding: 11px 4px;
 }
 
+  .\[\&\[data-active\]\]\:bg_\#f09199[data-active] {
+    background: #f09199;
+}
+
   .disabled\:bg_\#fff:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
     background: #fff;
 }
@@ -5367,6 +5371,14 @@
     font-size: 1.125rem;
 }
 
+  .\[\&\[data-active\]\]\:c_\#fff[data-active] {
+    color: #fff;
+}
+
+  .\[\&\[data-active\]\]\:c_\#f09199[data-active] {
+    color: #f09199;
+}
+
   .disabled\:c_\#9f9b9b:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
     color: #9f9b9b;
 }
@@ -6550,6 +6562,10 @@
     margin-bottom: 6px;
 }
 
+  .\[\&\[data-active\]\]\:bd-b-c_\#f09199[data-active] {
+    border-bottom-color: #f09199;
+}
+
   .\[\&_\>_li\]\:min-h_58px > li {
     min-height: 58px;
 }
@@ -7484,6 +7500,10 @@
 
   .\[\&_\.bgm-input\]\:\[\&\:\:placeholder\]\:c_\#9f9b9b .bgm-input::placeholder {
     color: #9f9b9b;
+}
+
+  .\[\&\[data-active\]\]\:hover\:c_\#fff[data-active]:is(:hover, [data-hover]) {
+    color: #fff;
 }
 
   .\[\&_\>_li\]\:\[\&_\>_div_\>_a\,_\&_small\]\:d_block > li > div > a,.\[\&_\>_li\]\:\[\&_\>_div_\>_a\,_\&_small\]\:d_block > li small {

--- a/packages/website/src/pages/index/index/HomePage.spec.tsx
+++ b/packages/website/src/pages/index/index/HomePage.spec.tsx
@@ -64,6 +64,22 @@ describe('HomePage', () => {
     expect(document.querySelector('a[href="https://bgm.tv/subject/12"]')).not.toBeInTheDocument();
   });
 
+  it('should mark the active progress tab and timeline filter', async () => {
+    setupHome();
+    await renderHome();
+
+    // 进度管理器默认「全部」tab 激活
+    expect(await screen.findByRole('button', { name: '全部' })).toHaveAttribute('data-active');
+    // 时间线 filter 默认「动态」激活
+    const allFilter = await screen.findByRole('button', { name: '动态' });
+    expect(allFilter).toHaveAttribute('data-active');
+
+    // 切换时间线 filter 后激活态跟随移动
+    fireEvent.click(screen.getByRole('button', { name: '吐槽' }));
+    expect(allFilter).not.toHaveAttribute('data-active');
+    expect(screen.getByRole('button', { name: '吐槽' })).toHaveAttribute('data-active');
+  });
+
   it('should render timeline subject cards and action summaries', async () => {
     const baseTimeline = homeFixture.timeline[0];
     const anime = {

--- a/packages/website/src/pages/index/index/components/PrgManager.tsx
+++ b/packages/website/src/pages/index/index/components/PrgManager.tsx
@@ -51,11 +51,11 @@ const tab = css({
     paddingRight: '12px',
     paddingLeft: '12px',
   },
-});
-
-const tabActive = css({
-  color: '#fff',
-  background: '#f09199',
+  // 激活态用属性选择器提升特异性，避免与基类原子样式争抢生成顺序
+  '&[data-active]': {
+    color: '#fff',
+    background: '#f09199',
+  },
 });
 
 const viewSwitch = css({
@@ -79,11 +79,11 @@ const viewBtn = css({
   background: 'none',
   color: '#9f9b9b',
   _hover: { color: '#1f1c1c' },
-});
-
-const viewActive = css({
-  color: '#f09199',
-  borderBottomColor: '#f09199',
+  // 激活态用属性选择器提升特异性，避免与基类原子样式争抢生成顺序
+  '&[data-active]': {
+    color: '#f09199',
+    borderBottomColor: '#f09199',
+  },
 });
 
 const empty = css({
@@ -867,7 +867,8 @@ const PrgManager: React.FC<{ progress: ProgressItem[] }> = ({ progress }) => {
           <button
             key={cat.type}
             type='button'
-            className={`${tab} ${activeType === cat.type ? tabActive : ''}`}
+            data-active={activeType === cat.type || undefined}
+            className={tab}
             onClick={() => setActiveType(cat.type)}
           >
             {cat.label}
@@ -876,7 +877,8 @@ const PrgManager: React.FC<{ progress: ProgressItem[] }> = ({ progress }) => {
         <div className={viewSwitch}>
           <button
             type='button'
-            className={`${viewBtn} ${view === 'list' ? viewActive : ''}`}
+            data-active={view === 'list' || undefined}
+            className={viewBtn}
             onClick={() => switchView('list')}
             title='列表视图'
             aria-label='列表视图'
@@ -886,7 +888,8 @@ const PrgManager: React.FC<{ progress: ProgressItem[] }> = ({ progress }) => {
           </button>
           <button
             type='button'
-            className={`${viewBtn} ${view === 'grid' ? viewActive : ''}`}
+            data-active={view === 'grid' || undefined}
+            className={viewBtn}
             onClick={() => switchView('grid')}
             title='网格视图'
             aria-label='网格视图'

--- a/packages/website/src/pages/index/index/components/TimelineBlock.tsx
+++ b/packages/website/src/pages/index/index/components/TimelineBlock.tsx
@@ -58,12 +58,12 @@ const filterBtn = css({
     paddingRight: '10px',
     paddingLeft: '10px',
   },
-});
-
-const filterActive = css({
-  color: '#fff',
-  background: '#f09199',
-  _hover: { color: '#fff' },
+  // 激活态用属性选择器提升特异性，避免与基类原子样式争抢生成顺序
+  '&[data-active]': {
+    color: '#fff',
+    background: '#f09199',
+    _hover: { color: '#fff' },
+  },
 });
 
 const crawl = css({
@@ -746,7 +746,8 @@ const TimelineBlock: React.FC<{ timeline: Timeline[] }> = ({ timeline }) => {
             <button
               key={item.key}
               type='button'
-              className={`${filterBtn} ${filter === item.key ? filterActive : ''}`}
+              data-active={filter === item.key || undefined}
+              className={filterBtn}
               onClick={() => setFilter(item.key)}
             >
               {item.label}


### PR DESCRIPTION
## Summary

The "全部" tab on the home progress manager and the first filter button ("动态", the "all" filter) on the home timeline toolbar rendered as invisible white-on-transparent buttons.

### Root cause

After the Panda CSS migration (#1032), active styles were applied by concatenating two independent `css()` classes (e.g. `filterBtn` + `filterActive`). Panda generates atomic utility classes ordered by hashed class name, so the base class's `background: transparent` can be emitted **after** the active class's `background: #f09199` and override it, while `color: #fff` from the active class still applies. The result: the active button gets white text on a transparent background — invisible on the white toolbar.

### Fix

Merge the active styles into the base `css()` class via an `&[data-active]` attribute selector. Its specificity `(0,2,0)` always beats the base class `(0,1,0)`, independent of atomic class emission order.

Applied to three button groups on the home page:

- Timeline filters: 动态 / 吐槽 / 收藏 / 进度 / 日志 / 更多 (`TimelineBlock.tsx`)
- Progress manager tabs: 全部 / 动画 / 三次元 / 书籍 (`PrgManager.tsx`)
- Progress manager view switcher: 列表 / 网格 (`PrgManager.tsx`)

### Verification

- Locally built and visually confirmed via Playwright screenshot: active buttons now show pink background with white text
- Added a regression test asserting the active `data-active` attribute on the progress tab and timeline filter, including switching filters
- `pnpm test` (369 passed), `pnpm lint`, `pnpm type-check`, `pnpm prettier:check`, `pnpm build` all pass
- Regenerated `packages/styled-system/styles.css` via `panda:codegen` / `panda:cssgen`

### Note

`PrgManager.tsx` also uses a similar concatenation for the sidebar nav button (`cx(navButton, navButtonActive)`), but its current emission order happens to be correct, so it is left unchanged to keep this PR focused.
