### PR TITLE
ci: check panda styles.css is up to date

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,3 +36,6 @@ jobs:
 
       - run: pnpm lint:style
         name: Lint Style
+
+      - run: pnpm lint:panda
+        name: Check Panda CSS is up to date

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint": "eslint ./ .github/scripts --ext cjs,mjs,js,jsx,ts,mts,cts,tsx",
     "lint:fix": "pnpm lint --fix",
     "lint:style": "stylelint \"./packages/**/*.css\" --ignore-pattern \"packages/styled-system/**\"",
+    "lint:panda": "pnpm panda:cssgen && git diff --exit-code packages/styled-system/styles.css",
     "lint:style-fix": "pnpm lint:style --fix",
     "prettier": "prettier --write --list-different ./",
     "format": "prettier --write --list-different ./",


### PR DESCRIPTION
## What

Add a lint check that verifies `packages/styled-system/styles.css` is up to date with the source code and panda config.

- `package.json`: new `lint:panda` script — re-runs `panda cssgen` then `git diff --exit-code packages/styled-system/styles.css`
- `.github/workflows/lint.yml`: run `pnpm lint:panda` as part of the Lint workflow

## Why

`styles.css` is a generated artifact. If it gets out of sync with the source (e.g. someone forgets to re-run `pnpm panda:cssgen`), the deployed styles silently drift. This check fails the lint job when the committed artifact is stale.

## Verification

- Clean workspace: `pnpm lint:panda` passes (exit 0)
- Simulated stale artifact (changed `panda.config.ts` without regenerating): correctly fails (exit 1)