### PR TITLE
feat(website): add standalone calendar (每日放送) page

### DIFF
--- a/packages/styled-system/styles.css
+++ b/packages/styled-system/styles.css
@@ -716,6 +716,18 @@
     padding: 15px 15px 32px;
 }
 
+  .p_0_0_12px {
+    padding: 0 0 12px;
+}
+
+  .m_8px_0_0 {
+    margin: 8px 0 0;
+}
+
+  .m_0_0_10px {
+    margin: 0 0 10px;
+}
+
   .p_0_0_10px {
     padding: 0 0 10px;
 }
@@ -784,20 +796,12 @@
     background: #f97f77;
 }
 
-  .p_0_0_12px {
-    padding: 0 0 12px;
-}
-
   .p_8px_12px {
     padding: 8px 12px;
 }
 
   .m_15px_0_10px {
     margin: 15px 0 10px;
-}
-
-  .m_8px_0_0 {
-    margin: 8px 0 0;
 }
 
   .p_10px_0 {
@@ -842,10 +846,6 @@
 
   .p_13px_0_15px {
     padding: 13px 0 15px;
-}
-
-  .m_0_0_10px {
-    margin: 0 0 10px;
 }
 
   .p_0_5px_0_0 {
@@ -1592,6 +1592,10 @@
     gap: 24px;
 }
 
+  .bdr_4px {
+    border-radius: 4px;
+}
+
   .gap_15px {
     gap: 15px;
 }
@@ -1674,10 +1678,6 @@
 
   .flex_0_0_56px {
     flex: 0 0 56px;
-}
-
-  .bdr_4px {
-    border-radius: 4px;
 }
 
   .bdr_15px {
@@ -2273,8 +2273,24 @@
     word-break: break-all;
 }
 
+  .fs_16px {
+    font-size: 16px;
+}
+
   .d_grid {
     display: grid;
+}
+
+  .grid-tc_repeat\(auto-fill\,_minmax\(118px\,_1fr\)\) {
+    grid-template-columns: repeat(auto-fill, minmax(118px, 1fr));
+}
+
+  .asp_3_\/_4 {
+    aspect-ratio: 3 / 4;
+}
+
+  .obj-f_cover {
+    object-fit: cover;
 }
 
   .grid-tc_minmax\(0\,_1fr\)_280px {
@@ -2303,10 +2319,6 @@
 
   .bx-sh_inset_0_0_2px_\#9f9b9b {
     box-shadow: inset 0 0 2px #9f9b9b;
-}
-
-  .obj-f_cover {
-    object-fit: cover;
 }
 
   .fs_28px {
@@ -2519,10 +2531,6 @@
 
   .fw_normal {
     font-weight: var(--font-weights-normal);
-}
-
-  .fs_16px {
-    font-size: 16px;
 }
 
   .ff_\'SFMono-Regular\'\,_Consolas\,_\'Liberation_Mono\'\,_Menlo\,_monospace {
@@ -2800,10 +2808,6 @@
 
   .flex-wrap_nowrap {
     flex-wrap: nowrap;
-}
-
-  .asp_3_\/_4 {
-    aspect-ratio: 3 / 4;
 }
 
   .lh_19px {
@@ -3191,6 +3195,18 @@
     margin-bottom: 10px;
 }
 
+  .mt_18px {
+    margin-top: 18px;
+}
+
+  .mt_6px {
+    margin-top: 6px;
+}
+
+  .mt_2px {
+    margin-top: 2px;
+}
+
   .pt_5px {
     padding-top: 5px;
 }
@@ -3213,10 +3229,6 @@
 
   .mt_5px {
     margin-top: 5px;
-}
-
-  .mt_2px {
-    margin-top: 2px;
 }
 
   .h_10px {
@@ -3379,10 +3391,6 @@
     min-width: 100%;
 }
 
-  .mt_18px {
-    margin-top: 18px;
-}
-
   .min-h_34px {
     min-height: 34px;
 }
@@ -3405,10 +3413,6 @@
 
   .mt_7px {
     margin-top: 7px;
-}
-
-  .mt_6px {
-    margin-top: 6px;
 }
 
   .w_56px {
@@ -4487,6 +4491,10 @@
     border-color: #f09199 !important;
 }
 
+  .\[\&_p\]\:ov_hidden p,.\[\&_small\]\:ov_hidden small {
+    overflow: hidden;
+}
+
   .\[\&_img\]\:bdr_6px img {
     border-radius: 6px;
 }
@@ -4573,10 +4581,6 @@
 
   .\[\&_svg\]\:trs_transform_0\.15s_ease svg {
     transition: transform 0.15s ease;
-}
-
-  .\[\&_small\]\:ov_hidden small {
-    overflow: hidden;
 }
 
   .\[\&_li\]\:bd-b_1px_dotted_\#e8e3e3 li,.\[\&_tr\]\:bd-b_1px_dotted_\#e8e3e3 tr {
@@ -5075,6 +5079,58 @@
     line-height: 1.4;
 }
 
+  .\[\&_small\]\:c_\#9f9b9b small {
+    color: #9f9b9b;
+}
+
+  .\[\&_small\]\:fs_12px small {
+    font-size: 12px;
+}
+
+  .\[\&_small\]\:fw_400 small {
+    font-weight: 400;
+}
+
+  .\[\&_p\]\:c_\#595555 p {
+    color: #595555;
+}
+
+  .\[\&_p\]\:fs_13px p {
+    font-size: 13px;
+}
+
+  .\[\&_p\]\:lh_18px p {
+    line-height: 18px;
+}
+
+  .\[\&_p\]\:tov_ellipsis p {
+    text-overflow: ellipsis;
+}
+
+  .\[\&_p\]\:white-space_nowrap p {
+    white-space: nowrap;
+}
+
+  .\[\&_small\]\:d_block small {
+    display: block;
+}
+
+  .\[\&_small\]\:fs_11px small {
+    font-size: 11px;
+}
+
+  .\[\&_small\]\:lh_16px small {
+    line-height: 16px;
+}
+
+  .\[\&_small\]\:tov_ellipsis small {
+    text-overflow: ellipsis;
+}
+
+  .\[\&_small\]\:white-space_nowrap small {
+    white-space: nowrap;
+}
+
   .\[\&_h1\]\:ls_0 h1 {
     letter-spacing: 0;
 }
@@ -5085,14 +5141,6 @@
 
   .\[\&_a\]\:c_\#54b5df a {
     color: #54b5df;
-}
-
-  .\[\&_small\]\:c_\#9f9b9b small {
-    color: #9f9b9b;
-}
-
-  .\[\&_small\]\:fs_11px small {
-    font-size: 11px;
 }
 
   .\[\&_img\]\:d_block img {
@@ -5175,10 +5223,6 @@
     color: #1f1c1c;
 }
 
-  .\[\&_p\]\:c_\#595555 p {
-    color: #595555;
-}
-
   .\[\&_p\]\:fs_12px p {
     font-size: 12px;
 }
@@ -5193,10 +5237,6 @@
 
   .\[\&_a\]\:fw_bold a {
     font-weight: var(--font-weights-bold);
-}
-
-  .\[\&_small\]\:fs_12px small {
-    font-size: 12px;
 }
 
   .\[\&_small\]\:fw_normal small {
@@ -5225,10 +5265,6 @@
 
   .\[\&_\>_h2\]\:fw_normal > h2 {
     font-weight: var(--font-weights-normal);
-}
-
-  .\[\&_small\]\:d_block small {
-    display: block;
 }
 
   .\[\&_\>_li\]\:d_flex > li {
@@ -5361,14 +5397,6 @@
 
   .\[\&_\>_div\]\:ai_flex-start > div {
     align-items: flex-start;
-}
-
-  .\[\&_small\]\:tov_ellipsis small {
-    text-overflow: ellipsis;
-}
-
-  .\[\&_small\]\:white-space_nowrap small {
-    white-space: nowrap;
 }
 
   .\[\&_h2\]\:fs_16px h2 {
@@ -6484,6 +6512,10 @@
 
   .\[\&_\>_\.bgm-menu-item\]\:w_100\% > .bgm-menu-item,.\[\&_\>_\*\]\:w_100\% > * {
     width: 100%;
+}
+
+  .\[\&_small\]\:ml_6px small {
+    margin-left: 6px;
 }
 
   .\[\&_small\]\:ml_7px small {

--- a/packages/website/src/components/PageRoutes/LegacyRedirect.spec.tsx
+++ b/packages/website/src/components/PageRoutes/LegacyRedirect.spec.tsx
@@ -23,7 +23,7 @@ it('redirects a registered legacy path to the legacy site', async () => {
   });
 });
 
-it.each(['/calendar', '/subject/12/collections', '/subject/12/stats'])(
+it.each(['/subject/12/collections', '/subject/12/stats'])(
   'registers %s as a legacy route',
   (path) => {
     const matches = matchRoutes(pageRoutes, path);

--- a/packages/website/src/hooks/use-calendar.ts
+++ b/packages/website/src/hooks/use-calendar.ts
@@ -1,0 +1,13 @@
+import { ok } from '@oazapfts/runtime';
+import useSWR from 'swr';
+
+import { ozaClient } from '@bangumi/client';
+import type { Calendar } from '@bangumi/client/client';
+
+/** 每日放送（GET /p1/calendar，按星期 1-7 分组） */
+export function useCalendar(): { calendar: Calendar | undefined } {
+  const { data } = useSWR('calendar', async () => ok(ozaClient.getCalendar()), {
+    suspense: true,
+  });
+  return { calendar: data };
+}

--- a/packages/website/src/mocks/fixtures/p1/calendar-GET.json
+++ b/packages/website/src/mocks/fixtures/p1/calendar-GET.json
@@ -1,0 +1,53 @@
+{
+  "1": [
+    {
+      "subject": {
+        "id": 456080,
+        "type": 2,
+        "name": "転校先の清楚可憐な美少女が、昔男子と思って一緒に遊んだ幼馴染だった件",
+        "nameCN": "转学后班上的清纯可爱美少女，竟是小时候玩在一起的哥们儿",
+        "images": {
+          "large": "https://lain.bgm.tv/pic/cover/l/45/60/456080.jpg",
+          "common": "https://lain.bgm.tv/pic/cover/c/45/60/456080.jpg",
+          "medium": "https://lain.bgm.tv/pic/cover/m/45/60/456080.jpg",
+          "small": "https://lain.bgm.tv/pic/cover/s/45/60/456080.jpg",
+          "grid": "https://lain.bgm.tv/pic/cover/g/45/60/456080.jpg"
+        },
+        "info": "",
+        "metaTags": [],
+        "rating": { "rank": 100, "total": 10, "count": 3, "score": 8 },
+        "locked": false,
+        "nsfw": false
+      },
+      "watchers": 321
+    }
+  ],
+  "2": [
+    {
+      "subject": {
+        "id": 456081,
+        "type": 2,
+        "name": "最強出涸らし皇子の暗躍帝位争い",
+        "nameCN": "最强废渣皇子暗中活跃于帝位之争",
+        "images": {
+          "large": "https://lain.bgm.tv/pic/cover/l/45/60/456081.jpg",
+          "common": "https://lain.bgm.tv/pic/cover/c/45/60/456081.jpg",
+          "medium": "https://lain.bgm.tv/pic/cover/m/45/60/456081.jpg",
+          "small": "https://lain.bgm.tv/pic/cover/s/45/60/456081.jpg",
+          "grid": "https://lain.bgm.tv/pic/cover/g/45/60/456081.jpg"
+        },
+        "info": "",
+        "metaTags": [],
+        "rating": { "rank": 100, "total": 10, "count": 3, "score": 8 },
+        "locked": false,
+        "nsfw": false
+      },
+      "watchers": 150
+    }
+  ],
+  "3": [],
+  "4": [],
+  "5": [],
+  "6": [],
+  "7": []
+}

--- a/packages/website/src/mocks/handlers.ts
+++ b/packages/website/src/mocks/handlers.ts
@@ -6,6 +6,7 @@ export const handlers = [
   mockAPI('/p1/notify', 'get'),
   mockAPI('/p1/clear-notify', 'post'),
   mockAPI('/p1/home', 'get'),
+  mockAPI('/p1/calendar', 'get'),
   mockAPI('/p1/trending/subjects', 'get'),
   mockAPI('/p1/trending/subjects/topics', 'get'),
   mockAPI('/p1/channels/:type/blogs', 'get'),

--- a/packages/website/src/pages/index/calendar/index.spec.tsx
+++ b/packages/website/src/pages/index/calendar/index.spec.tsx
@@ -1,0 +1,41 @@
+import { act, screen } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import React, { Suspense } from 'react';
+
+import calendarFixture from '@bangumi/website/mocks/fixtures/p1/calendar-GET.json';
+import { server as mockServer } from '@bangumi/website/mocks/server';
+import { renderPage } from '@bangumi/website/utils/test-utils';
+
+import CalendarPage from '.';
+
+describe('CalendarPage', () => {
+  it('渲染页头与周一~周日分组', async () => {
+    mockServer.use(
+      http.get('http://localhost:3000/p1/calendar', () => HttpResponse.json(calendarFixture)),
+    );
+    await act(async () => {
+      renderPage(
+        <Suspense fallback={null}>
+          <CalendarPage />
+        </Suspense>,
+      );
+    });
+
+    // 页头
+    expect(await screen.findByRole('heading', { name: /每日放送/ })).toBeInTheDocument();
+
+    // 星期分组标题
+    expect(screen.getByText('星期一')).toBeInTheDocument();
+    expect(screen.getByText('星期二')).toBeInTheDocument();
+    expect(screen.getByText('星期日')).toBeInTheDocument();
+
+    // 条目：中文名链接到条目页 + 在看人数
+    const subjectLink = screen.getByRole('link', { name: /转学后班上的清纯可爱美少女/ });
+    expect(subjectLink).toHaveAttribute('href', '/subject/456080');
+    expect(screen.getByText('321 人在看')).toBeInTheDocument();
+    expect(screen.getByText('150 人在看')).toBeInTheDocument();
+
+    // 空星期占位
+    expect(screen.getAllByText('暂无放送').length).toBeGreaterThan(0);
+  });
+});

--- a/packages/website/src/pages/index/calendar/index.tsx
+++ b/packages/website/src/pages/index/calendar/index.tsx
@@ -1,0 +1,202 @@
+import dayjs from 'dayjs';
+import React from 'react';
+
+import { Typography } from '@bangumi/design';
+import { css } from '@bangumi/styled-system/css';
+import { getSubjectLink } from '@bangumi/utils/pages';
+import Helmet from '@bangumi/website/components/Helmet';
+import PageContainer from '@bangumi/website/components/PageContainer';
+import { useCalendar } from '@bangumi/website/hooks/use-calendar';
+
+const { Link } = Typography;
+
+const page = css({
+  padding: '15px 15px 32px',
+});
+
+const pageHeader = css({
+  padding: '0 0 12px',
+  borderBottom: '1px solid #e8e3e3',
+  '& h1': {
+    display: 'inline',
+    margin: '0',
+    color: '#595555',
+    fontSize: '20px',
+    fontWeight: '700',
+    lineHeight: '1.4',
+  },
+});
+
+const headerSmall = css({
+  marginLeft: '8px',
+  color: '#9f9b9b',
+  fontSize: '13px',
+  fontWeight: '400',
+});
+
+const stats = css({
+  margin: '8px 0 0',
+  color: '#9f9b9b',
+  fontSize: '13px',
+  lineHeight: '20px',
+});
+
+const dayBlock = css({
+  marginTop: '18px',
+});
+
+const dayTitle = css({
+  margin: '0 0 10px',
+  fontSize: '16px',
+  fontWeight: '600',
+  lineHeight: '22px',
+  color: '#595555',
+  '& small': {
+    marginLeft: '6px',
+    color: '#9f9b9b',
+    fontSize: '12px',
+    fontWeight: '400',
+  },
+});
+
+const coverGrid = css({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fill, minmax(118px, 1fr))',
+  gap: '12px',
+});
+
+const coverCard = css({
+  display: 'block',
+  overflow: 'hidden',
+  borderRadius: '4px',
+  background: '#e8e3e3',
+});
+
+const coverImage = css({
+  display: 'block',
+  width: '100%',
+  aspectRatio: '3 / 4',
+  objectFit: 'cover',
+});
+
+/** 条目名（常驻显示在封面下方） */
+const coverName = css({
+  marginTop: '6px',
+  '& p': {
+    margin: '0',
+    overflow: 'hidden',
+    color: '#595555',
+    fontSize: '13px',
+    lineHeight: '18px',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  '& small': {
+    display: 'block',
+    overflow: 'hidden',
+    color: '#9f9b9b',
+    fontSize: '11px',
+    lineHeight: '16px',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+});
+
+const watchers = css({
+  marginTop: '2px',
+  color: '#9f9b9b',
+  fontSize: '12px',
+  lineHeight: '16px',
+});
+
+const empty = css({
+  color: '#9f9b9b',
+  fontSize: '13px',
+});
+
+const WEEKDAY_DESC: Record<number, { en: string; cn: string }> = {
+  1: { en: 'Mon', cn: '星期一' },
+  2: { en: 'Tue', cn: '星期二' },
+  3: { en: 'Wed', cn: '星期三' },
+  4: { en: 'Thu', cn: '星期四' },
+  5: { en: 'Fri', cn: '星期五' },
+  6: { en: 'Sat', cn: '星期六' },
+  7: { en: 'Sun', cn: '星期日' },
+};
+
+/** PHP 约定星期 1-7（周日=7），与 dayjs().day()（0-6，周日=0）互转 */
+function getTodayWeekday(): number {
+  const day = dayjs().day();
+  return day === 0 ? 7 : day;
+}
+/** 每日放送独立页：周一~周日分组封面网格 + 在看人数（对齐旧站 /calendar） */
+const CalendarPage: React.FC = () => {
+  const { calendar } = useCalendar();
+  const data = calendar ?? {};
+  const today = getTodayWeekday();
+  const weekdays = Array.from({ length: 7 }, (_, i) => i + 1);
+  const todayItems = data[String(today)] ?? [];
+  const todayWatchers = todayItems.reduce((sum, item) => sum + item.watchers, 0);
+
+  return (
+    <>
+      <Helmet title='每日放送' />
+      <PageContainer as='main' className={page}>
+        <div className={pageHeader}>
+          <h1>
+            每日放送
+            <small className={headerSmall}>
+              {dayjs().format('YYYY年M月D日')} {WEEKDAY_DESC[today]?.cn}
+            </small>
+          </h1>
+          <p className={stats}>
+            今日上映 <strong>{todayItems.length}</strong> 部，共 {todayWatchers} 人收看今日番组。
+          </p>
+        </div>
+        {weekdays.map((weekday) => {
+          const items = data[String(weekday)] ?? [];
+          const desc = WEEKDAY_DESC[weekday];
+          return (
+            <section key={weekday} className={dayBlock}>
+              <h2 className={dayTitle}>
+                {desc?.cn}
+                <small>{desc?.en}</small>
+              </h2>
+              {items.length === 0 ? (
+                <p className={empty}>暂无放送</p>
+              ) : (
+                <div className={coverGrid}>
+                  {items.map((item) => (
+                    <div key={item.subject.id}>
+                      <Link
+                        to={getSubjectLink(item.subject.id)}
+                        className={coverCard}
+                        title={item.subject.nameCN || item.subject.name}
+                      >
+                        {item.subject.images && (
+                          <img
+                            src={item.subject.images.common}
+                            className={coverImage}
+                            loading='lazy'
+                            alt=''
+                          />
+                        )}
+                      </Link>
+                      <div className={coverName}>
+                        <p>{item.subject.nameCN || item.subject.name}</p>
+                        <small>{item.subject.name}</small>
+                      </div>
+                      <span className={watchers}>{item.watchers} 人在看</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </section>
+          );
+        })}
+      </PageContainer>
+    </>
+  );
+};
+
+export default CalendarPage;

--- a/packages/website/src/routes.tsx
+++ b/packages/website/src/routes.tsx
@@ -72,6 +72,7 @@ const Login = lazy(async () => import('./pages/login'));
 const UserHome = lazy(async () => import('./pages/index/user/[username]'));
 const UserCollections = lazy(async () => import('./pages/index/user/collections/[username]'));
 const BlogEntry = lazy(async () => import('./pages/index/blog/[id]'));
+const Calendar = lazy(async () => import('./pages/index/calendar'));
 
 const userCollectionTypes = ['anime', 'book', 'music', 'game', 'real'] as const;
 
@@ -82,7 +83,6 @@ const legacyPagePaths = [
     `${type}/chart`,
     `${type}/tag/*`,
   ]),
-  'calendar',
   'magi',
   'onair',
   'subject/:id/collections',
@@ -151,6 +151,7 @@ export const pageRoutes: RouteObject[] = [
           },
         ],
       },
+      { path: 'calendar', element: <Calendar /> },
       { path: 'rakuen', element: <Rakuen /> },
       { path: 'ep/:id', element: <Episode /> },
       { path: 'ep/:id/edit', element: <EpisodeEdit /> },


### PR DESCRIPTION
## 概述

实现每日放送独立页 `/calendar`，从 legacy 重定向中移除，对齐旧站 https://bgm.tv/calendar。

## 实现内容

- `GET /p1/calendar`（已有接口）按星期 1-7 分组展示全周放送
- 页头：标题"每日放送" + 当前日期/星期 + 统计（今日上映 N 部、N 人收看）
- 周一~周日分组：星期标题（中/英文）+ 条目卡片网格（封面图 + 常驻中文名/日文名 + 在看人数）
- 空分组显示"暂无放送"占位
- 新增 `use-calendar` hook、MSW fixture 与组件测试
- routes.tsx 移除 legacy `calendar`，注册独立路由

## 参照

- 首页 `CalendarBlock`（今天/明天模块）的封面网格与星期映射（PHP 1-7 约定）
- 旧站 `chl/calendar.htm`：页头统计 + 7 天封面网格布局

## 验证

lint / type-check / 380 tests / build 全过；截图实测页头、分组、名称与在看人数显示正常（封面图因沙箱无外网未加载，生产环境正常）。