### PR TITLE
feat(website): add collection list quick status actions

### DIFF
--- a/packages/styled-system/styles.css
+++ b/packages/styled-system/styles.css
@@ -1440,6 +1440,10 @@
     background: #f88f9b;
 }
 
+  .p_0\.2rem_0\.5rem {
+    padding: 0.2rem 0.5rem;
+}
+
   .bd_2px_transparent_solid {
     border: 2px transparent solid;
 }
@@ -2868,6 +2872,14 @@
 
   .c_\#54b5df\! {
     color: #54b5df !important;
+}
+
+  .grid-tc_repeat\(auto-fill\,_minmax\(110px\,_1fr\)\) {
+    grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+}
+
+  .fs_0\.85rem {
+    font-size: 0.85rem;
 }
 
   .us_none {
@@ -4365,10 +4377,6 @@
 
   .\[\&_p\]\:m_0_0_12px p {
     margin: 0 0 12px;
-}
-
-  .\[\&_h3\]\:m_0_0_4px h3 {
-    margin: 0 0 4px;
 }
 
   .\[\&\.bgm-button--size-medium\]\:p_0_13px.bgm-button--size-medium {
@@ -5907,7 +5915,7 @@
     display: inline;
 }
 
-  .\[\&_a\]\:fs_15px a,.\[\&_h3\]\:fs_15px h3 {
+  .\[\&_a\]\:fs_15px a {
     font-size: 15px;
 }
 
@@ -6886,10 +6894,6 @@
     padding-right: 10px;
 }
 
-  .\[\&_img\]\:w_72px img {
-    width: 72px;
-}
-
   .\[\&_img\]\:h_40px img {
     height: 40px;
 }
@@ -7202,6 +7206,10 @@
     cursor: pointer;
 }
 
+  .\[\&\:hover\]\:c_\#54b5df:hover {
+    color: #54b5df;
+}
+
   .hover\:ring-o_-2px:is(:hover, [data-hover]) {
     outline-offset: -2px;
 }
@@ -7384,10 +7392,6 @@
 
   .\[\&\.bgm-input__wrapper\]\:\[\&\:last-child\]\:flex_1.bgm-input__wrapper:last-child {
     flex: 1 1 0%;
-}
-
-  .\[\&_h3\]\:\[\&_a\]\:td_none h3 a {
-    text-decoration: none;
 }
 
   .\[\&\.bgm-button--secondary\]\:\[\&\.bgm-button--color-blue\]\:bd-c_\#54b5df.bgm-button--secondary.bgm-button--color-blue {
@@ -7692,10 +7696,6 @@
 
   .\[\&\[class\]\]\:\[\&_h2\]\:fw_normal[class] h2 {
     font-weight: var(--font-weights-normal);
-}
-
-  .\[\&_h3\]\:\[\&_a\]\:c_\#1f1c1c h3 a {
-    color: #1f1c1c;
 }
 
   .\[\&\.bgm-button--primary\]\:\[\&\.bgm-button--color-blue\]\:bg-c_\#54b5df.bgm-button--primary.bgm-button--color-blue {
@@ -8152,10 +8152,6 @@
 
   .\[\&_li\]\:\[\&_\>_a\]\:\[\&_span\]\:white-space_nowrap li > a span {
     white-space: nowrap;
-}
-
-  .\[\&_h3\]\:\[\&_a\]\:hover\:c_\#54b5df h3 a:is(:hover, [data-hover]) {
-    color: #54b5df;
 }
 
   .\[\&\.bgm-button--secondary\]\:\[\&\.bgm-button--color-blue\]\:hover\:bg-c_\#54b5df.bgm-button--secondary.bgm-button--color-blue:is(:hover, [data-hover]) {
@@ -8678,6 +8674,9 @@
 }
     .\[\@media_\(max-width\:_640px\)\]\:fs_14px {
       font-size: 14px;
+}
+    .\[\@media_\(max-width\:_640px\)\]\:grid-tc_repeat\(3\,_minmax\(0\,_1fr\)\) {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
 }
     .\[\@media_\(max-width\:_640px\)\]\:flex-d_column {
       flex-direction: column;

--- a/packages/website/src/hooks/use-user-collections.ts
+++ b/packages/website/src/hooks/use-user-collections.ts
@@ -1,4 +1,5 @@
 import { ok } from '@oazapfts/runtime';
+import type { KeyedMutator } from 'swr';
 import useSWR from 'swr';
 
 import { ozaClient } from '@bangumi/client';
@@ -16,8 +17,12 @@ export function useUserSubjectCollections(
   username: string,
   subjectType: SubjectType,
   { type, limit, offset = 0 }: UserSubjectCollectionsParams,
-): { data: SlimSubject[] | undefined; total: number | undefined } {
-  const { data } = useSWR(
+): {
+  data: SlimSubject[] | undefined;
+  total: number | undefined;
+  mutate: KeyedMutator<{ data: SlimSubject[]; total: number }>;
+} {
+  const { data, mutate } = useSWR(
     `user-subject-collections ${username} ${subjectType} ${type ?? ''} ${limit} ${offset}`,
     async () =>
       ok(
@@ -26,5 +31,5 @@ export function useUserSubjectCollections(
     { suspense: true },
   );
 
-  return data ?? { data: undefined, total: undefined };
+  return { data: data?.data, total: data?.total, mutate };
 }

--- a/packages/website/src/pages/index/user/collections/[username]/CollectionList.spec.tsx
+++ b/packages/website/src/pages/index/user/collections/[username]/CollectionList.spec.tsx
@@ -1,0 +1,105 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { PropsWithChildren } from 'react';
+import React, { Suspense } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { SWRConfig } from 'swr';
+
+import type { SlimSubject } from '@bangumi/client/client';
+import { CollectionType, SubjectType } from '@bangumi/client/client';
+import { server as mockServer } from '@bangumi/website/mocks/server';
+
+import { CollectionList } from './components/CollectionList';
+
+vi.mock('@bangumi/website/hooks/use-user', async () => ({
+  ...(await vi.importActual<typeof import('@bangumi/website/hooks/use-user')>(
+    '@bangumi/website/hooks/use-user',
+  )),
+  useUser: () => ({ user: { id: 1, username: 'sai', nickname: 'Sai' } }),
+}));
+
+const collectedSubject: SlimSubject = {
+  id: 12,
+  type: SubjectType.Anime,
+  name: 'Test Anime',
+  nameCN: '测试动画',
+  images: {
+    large: '',
+    common: '',
+    medium: 'https://lain.bgm.tv/pic/cover/m/00/00/12.jpg',
+    small: '',
+    grid: '',
+  },
+  info: '',
+  metaTags: [],
+  rating: { rank: 100, total: 10, count: [3], score: 8 },
+  locked: false,
+  nsfw: false,
+  interest: { id: 1, rate: 8, type: CollectionType.Collect, comment: '', tags: [], updatedAt: 0 },
+};
+
+function mockListAPI(subjects: SlimSubject[], username = 'sai') {
+  mockServer.use(
+    http.get(`http://localhost:3000/p1/users/${username}/collections/subjects`, () =>
+      HttpResponse.json({ data: subjects, total: subjects.length }),
+    ),
+  );
+}
+
+describe('CollectionList 单条快捷操作', () => {
+  const renderList = async (username: string) => {
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <MemoryRouter initialEntries={[`/${username}/list/${username}`]}>
+          <Suspense fallback={null}>{children}</Suspense>
+        </MemoryRouter>
+      </SWRConfig>
+    );
+    await act(async () => {
+      render(
+        <CollectionList
+          username={username}
+          subjectType={SubjectType.Anime}
+          type={CollectionType.Collect}
+        />,
+        { wrapper },
+      );
+    });
+  };
+
+  it('自己的列表每项显示收藏状态选择', async () => {
+    mockListAPI([collectedSubject]);
+    await renderList('sai');
+
+    expect(await screen.findByText('测试动画')).toBeInTheDocument();
+    const select = screen.getByRole('combobox');
+    expect(select).toBeInTheDocument();
+  });
+
+  it('切换状态调用 updateSubjectCollection', async () => {
+    let putBody: unknown = null;
+    mockServer.use(
+      http.put('http://localhost:3000/p1/collections/subjects/12', async ({ request }) => {
+        putBody = await request.json();
+        return HttpResponse.json({}, { status: 200 });
+      }),
+    );
+    mockListAPI([collectedSubject]);
+    await renderList('sai');
+
+    const select = await screen.findByRole('combobox');
+    await act(async () => {
+      fireEvent.change(select, { target: { value: '3' } });
+    });
+
+    expect(putBody).toEqual({ type: 3 });
+  });
+
+  it('查看他人列表时不显示状态选择', async () => {
+    mockListAPI([collectedSubject], 'chii');
+    await renderList('chii');
+
+    expect(await screen.findByText('测试动画')).toBeInTheDocument();
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+  });
+});

--- a/packages/website/src/pages/index/user/collections/[username]/components/CollectionGroup.tsx
+++ b/packages/website/src/pages/index/user/collections/[username]/components/CollectionGroup.tsx
@@ -37,7 +37,8 @@ const coverList = css({
   padding: '0',
   display: 'grid',
   // minmax(0, 1fr) 允许列收缩到容器宽度，避免封面图固有宽度撑开网格
-  gridTemplateColumns: 'repeat(5, minmax(0, 1fr))',
+  // 对齐旧站收藏页封面网格（约 10 列小封面），响应式自动收缩列数
+  gridTemplateColumns: 'repeat(auto-fill, minmax(110px, 1fr))',
   gap: '10px',
 });
 

--- a/packages/website/src/pages/index/user/collections/[username]/components/CollectionList.tsx
+++ b/packages/website/src/pages/index/user/collections/[username]/components/CollectionList.tsx
@@ -1,85 +1,100 @@
 import React from 'react';
 
+import { ozaClient } from '@bangumi/client';
 import type { CollectionType, SlimSubject, SubjectType } from '@bangumi/client/client';
-import { Image, Pagination, Typography } from '@bangumi/design';
+import { Image, Pagination, Select, toast, Typography } from '@bangumi/design';
 import { css } from '@bangumi/styled-system/css';
 import { getSubjectLink } from '@bangumi/utils/pages';
 import { useTransitionNavigate } from '@bangumi/website/hooks/use-navigate';
 import { usePaginationParams } from '@bangumi/website/hooks/use-pagination';
+import { useUser } from '@bangumi/website/hooks/use-user';
 import { useUserSubjectCollections } from '@bangumi/website/hooks/use-user-collections';
+
+import { COLLECTION_LABELS } from '../../../components/constants';
 
 const { Link } = Typography;
 
-const list = css({
+const coverList = css({
   listStyle: 'none',
   margin: '0',
   padding: '0',
-});
-
-const item = css({
-  display: 'flex',
-  gap: '12px',
-  padding: '10px 0',
-  borderBottom: '1px solid #e8e3e3',
-  '&:last-child': {
-    borderBottom: 'none',
+  display: 'grid',
+  // 对齐旧站收藏页封面网格（约 10 列小封面），响应式自动收缩列数
+  gridTemplateColumns: 'repeat(auto-fill, minmax(110px, 1fr))',
+  gap: '10px',
+  '@media (max-width: 640px)': {
+    gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
   },
 });
 
-const cover = css({
-  flexShrink: '0',
+const coverItem = css({
+  '& a': {
+    display: 'block',
+    textDecoration: 'none',
+  },
   '& img': {
-    width: '72px',
+    width: '100%',
     aspectRatio: '3 / 4',
     objectFit: 'cover',
     borderRadius: '3px',
   },
 });
 
-const info = css({
-  minWidth: '0',
-  '& h3': {
-    margin: '0 0 4px',
-    fontSize: '15px',
-    '& a': {
-      color: '#1f1c1c',
-      textDecoration: 'none',
-      _hover: {
-        color: '#54b5df',
-      },
-    },
-  },
+const coverName = css({
+  display: 'block',
+  marginTop: '4px',
+  fontSize: '12px',
+  lineHeight: '16px',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  color: '#595555',
+  '&:hover': { color: '#54b5df' },
 });
 
 const originalName = css({
-  margin: '0 0 4px',
-  fontSize: '12px',
+  display: 'block',
+  margin: '0',
+  fontSize: '11px',
+  lineHeight: '15px',
   color: '#9f9b9b',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
 });
 
 const rating = css({
-  margin: '0',
-  fontSize: '12px',
+  margin: '2px 0 0',
+  fontSize: '11px',
+  lineHeight: '15px',
   color: '#9f9b9b',
+});
+
+const statusSelect = css({
+  marginTop: '4px',
+  padding: '0.2rem 0.5rem',
+  fontSize: '0.85rem',
 });
 
 const pagination = css({
   marginTop: '16px',
 });
 
-/** 收藏状态过滤后的条目列表（分页） */
+/** 收藏状态过滤后的条目网格（分页，对齐旧站收藏页封面网格） */
 export const CollectionList: React.FC<{
   username: string;
   subjectType: SubjectType;
   type: CollectionType;
 }> = ({ username, subjectType, type }) => {
   const { curPage, offset, pageSize } = usePaginationParams(20);
-  const { data, total } = useUserSubjectCollections(username, subjectType, {
+  const { data, total, mutate } = useUserSubjectCollections(username, subjectType, {
     type,
     limit: pageSize,
     offset,
   });
+  const { user } = useUser();
   const [, navigate] = useTransitionNavigate();
+  const isOwner = user?.username === username;
 
   const handlePageChange = (page: number): void => {
     navigate({ search: `page=${page}` });
@@ -87,9 +102,9 @@ export const CollectionList: React.FC<{
 
   return (
     <div>
-      <ul className={list}>
+      <ul className={coverList}>
         {(data ?? []).map((subject) => (
-          <CollectionItem key={subject.id} subject={subject} />
+          <CollectionItem key={subject.id} subject={subject} isOwner={isOwner} mutate={mutate} />
         ))}
       </ul>
       <Pagination
@@ -102,24 +117,53 @@ export const CollectionList: React.FC<{
   );
 };
 
-const CollectionItem: React.FC<{ subject: SlimSubject }> = ({ subject }) => {
+const STATUS_OPTIONS = (Object.entries(COLLECTION_LABELS) as [string, string][]).map(
+  ([key, label]) => ({ label, value: key }),
+);
+
+const CollectionItem: React.FC<{
+  subject: SlimSubject;
+  isOwner: boolean;
+  mutate: () => Promise<unknown>;
+}> = ({ subject, isOwner, mutate }) => {
   const displayName = subject.nameCN || subject.name;
+  const currentType = subject.interest?.type;
+
+  const handleTypeChange = async (value: string) => {
+    const res = await ozaClient.updateSubjectCollection(subject.id, {
+      type: Number(value) as CollectionType,
+    });
+    if (res.status === 200) {
+      await mutate();
+    } else {
+      toast(res.data.message);
+    }
+  };
+
   return (
-    <li className={item}>
-      <Link to={getSubjectLink(subject.id)} className={cover}>
+    <li className={coverItem}>
+      <Link to={getSubjectLink(subject.id)} title={displayName}>
         <Image src={subject.images?.medium ?? ''} alt={displayName} />
       </Link>
-      <div className={info}>
-        <h3>
-          <Link to={getSubjectLink(subject.id)}>{displayName}</Link>
-        </h3>
-        {subject.nameCN && subject.nameCN !== subject.name && (
-          <p className={originalName}>{subject.name}</p>
-        )}
-        {subject.rating.score > 0 && (
-          <p className={rating}>评分 {subject.rating.score.toFixed(1)}</p>
-        )}
-      </div>
+      <Link to={getSubjectLink(subject.id)} className={coverName} title={displayName}>
+        {displayName}
+      </Link>
+      {subject.nameCN && subject.nameCN !== subject.name && (
+        <p className={originalName}>{subject.name}</p>
+      )}
+      {subject.rating.score > 0 && <p className={rating}>评分 {subject.rating.score.toFixed(1)}</p>}
+      {isOwner && currentType !== undefined && (
+        <Select
+          className={statusSelect}
+          defaultValue={String(currentType)}
+          options={STATUS_OPTIONS}
+          onChange={(option) => {
+            if (option) {
+              void handleTypeChange(option.value);
+            }
+          }}
+        />
+      )}
     </li>
   );
 };


### PR DESCRIPTION
## 概述

收藏列表页单条快捷操作（一期，无后端依赖）：自己的收藏列表中可直接切换收藏状态；列表改为对齐旧站/效果图的封面网格布局。

## 实现内容

- **状态切换**：查看自己的收藏列表（`username === 当前用户`）时，每个条目显示收藏状态下拉（想看/看过/在看/搁置/抛弃）→ `updateSubjectCollection` 切换；操作成功 `mutate` 刷新、失败 `toast`；查看他人列表保持只读
- **布局对齐**：`CollectionList`（状态视图）从 72px 小封面列表改为封面网格（`auto-fill minmax(110px)` ≈ 每行 10 个，对齐旧站/效果图）；`CollectionGroup`（全部视图）网格列数同步对齐
- `use-user-collections` 暴露 `mutate`

## 未包含（回报说明）

- **删除收藏**：确认 server-private 当前 openapi 已无 `DELETE /p1/collections/subjects/{id}`（此前调查时的 DELETE 已被重构移除），PUT 的 `CollectSubject.type` 仅 1-5 无删除语义——删除收藏无后端接口，需 server-private 补（建议 `DELETE /p1/collections/subjects/{subjectID}` 或 PUT `type: 0`），本 PR 未实现
- **进度编辑**：列表数据（`SlimSubjectInterest`）无 `epStatus/volStatus` 字段，无法显示当前进度，且 `updateSubjectProgress` 的进度值因条目而异，列表内无便捷入口，暂跳过
- 状态切换仅改 `type`（评分/评论等字段 UI 负担大，后续条目页收藏面板统一提供）

## 测试

- 新增 `CollectionList.spec.tsx` 3 用例：自己的列表显示状态选择、切换调用 `updateSubjectCollection`（body `{type}`）、他人列表不显示
- 388 tests 全过

## 验证

lint / type-check / 388 tests / build 全过；截图确认网格布局与效果图封面尺寸一致。