### PR TITLE
fix(website): implement header search box

### DIFF
--- a/packages/styled-system/styles.css
+++ b/packages/styled-system/styles.css
@@ -2256,6 +2256,10 @@
     color: #999;
 }
 
+  .cursor_pointer {
+    cursor: pointer;
+}
+
   .fw_500 {
     font-weight: 500;
 }
@@ -2519,10 +2523,6 @@
 
   .white-space_pre-line {
     white-space: pre-line;
-}
-
-  .cursor_pointer {
-    cursor: pointer;
 }
 
   .lh_1\.65 {
@@ -8315,11 +8315,83 @@
 }
 
   @media (max-width: 1200px) {
+    .\[\@media_\(max-width\:_1200px\)\]\:p_0 {
+      padding: var(--spacing-0);
+}
+    .\[\@media_\(max-width\:_1200px\)\]\:bg_transparent\! {
+      background: var(--colors-transparent) !important;
+}
+    .\[\@media_\(max-width\:_1200px\)\]\:bd_0 {
+      border: 0;
+}
+    .\[\@media_\(max-width\:_1200px\)\]\:p_4px_10px_0 {
+      padding: 4px 10px 0;
+}
+    .\[\@media_\(max-width\:_1200px\)\]\:bg_\#fff\! {
+      background: #fff !important;
+}
+    .\[\@media_\(max-width\:_1200px\)\]\:flex_0_0_32px {
+      flex: 0 0 32px;
+}
+    .\[\@media_\(max-width\:_1200px\)\]\:bdr_50\% {
+      border-radius: 50%;
+}
+    .\[\@media_\(max-width\:_1200px\)\]\:bd-b_1px_solid_rgba\(249\,_188\,_193\,_0\.95\) {
+      border-bottom: 1px solid rgba(249, 188, 193, 0.95);
+}
     .\[\@media_\(max-width\:_1200px\)\]\:ai_flex-end {
       align-items: flex-end;
 }
     .\[\@media_\(max-width\:_1200px\)\]\:d_none {
       display: none;
+}
+    .\[\@media_\(max-width\:_1200px\)\]\:d_flex {
+      display: flex;
+}
+    .\[\@media_\(max-width\:_1200px\)\]\:ai_center {
+      align-items: center;
+}
+    .\[\@media_\(max-width\:_1200px\)\]\:jc_center {
+      justify-content: center;
+}
+    .\[\@media_\(max-width\:_1200px\)\]\:c_\#f09199 {
+      color: #f09199;
+}
+    .\[\@media_\(max-width\:_1200px\)\]\:pos_absolute {
+      position: absolute;
+}
+    .\[\@media_\(max-width\:_1200px\)\]\:z_1 {
+      z-index: 1;
+}
+    .\[\@media_\(max-width\:_1200px\)\]\:bx-s_border-box {
+      box-sizing: border-box;
+}
+    .\[\@media_\(max-width\:_1200px\)\]\:bx-sh_0_0_0_2px_rgba\(0\,_0\,_0\,_0\.04\) {
+      box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.04);
+}
+    .\[\@media_\(max-width\:_1200px\)\]\:d_block {
+      display: block;
+}
+    .\[\@media_\(max-width\:_1200px\)\]\:w_32px {
+      width: 32px;
+}
+    .\[\@media_\(max-width\:_1200px\)\]\:h_32px {
+      height: 32px;
+}
+    .\[\@media_\(max-width\:_1200px\)\]\:top_100\% {
+      top: 100%;
+}
+    .\[\@media_\(max-width\:_1200px\)\]\:left_0 {
+      left: var(--spacing-0);
+}
+    .\[\@media_\(max-width\:_1200px\)\]\:w_100\% {
+      width: 100%;
+}
+    .\[\@media_\(max-width\:_1200px\)\]\:\[\&_svg\]\:w_20px svg {
+      width: 20px;
+}
+    .\[\@media_\(max-width\:_1200px\)\]\:\[\&_svg\]\:h_20px svg {
+      height: 20px;
 }
 }
 
@@ -9005,15 +9077,6 @@
     .smDown\:bd_1px_solid_\#e5e5e5 {
       border: 1px solid #e5e5e5;
 }
-    .smDown\:bd_0 {
-      border: 0;
-}
-    .smDown\:p_4px_10px_0 {
-      padding: 4px 10px 0;
-}
-    .smDown\:bg_\#fff\! {
-      background: #fff !important;
-}
     .smDown\:flex_0_0_40px {
       flex: 0 0 40px;
 }
@@ -9022,15 +9085,6 @@
 }
     .smDown\:gap_18px {
       gap: 18px;
-}
-    .smDown\:flex_0_0_32px {
-      flex: 0 0 32px;
-}
-    .smDown\:bdr_50\% {
-      border-radius: 50%;
-}
-    .smDown\:bd-b_1px_solid_rgba\(249\,_188\,_193\,_0\.95\) {
-      border-bottom: 1px solid rgba(249, 188, 193, 0.95);
 }
     .smDown\:d_block {
       display: block;
@@ -9052,21 +9106,6 @@
 }
     .smDown\:d_none {
       display: none;
-}
-    .smDown\:c_\#f09199 {
-      color: #f09199;
-}
-    .smDown\:pos_absolute {
-      position: absolute;
-}
-    .smDown\:z_1 {
-      z-index: 1;
-}
-    .smDown\:bx-s_border-box {
-      box-sizing: border-box;
-}
-    .smDown\:bx-sh_0_0_0_2px_rgba\(0\,_0\,_0\,_0\.04\) {
-      box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.04);
 }
     .smDown\:grid-tc_repeat\(2\,_1fr\) {
       grid-template-columns: repeat(2, 1fr);
@@ -9101,20 +9140,8 @@
     .smDown\:ml_10px {
       margin-left: 10px;
 }
-    .smDown\:w_32px {
-      width: 32px;
-}
     .smDown\:w_78px {
       width: 78px;
-}
-    .smDown\:top_100\% {
-      top: 100%;
-}
-    .smDown\:left_0 {
-      left: var(--spacing-0);
-}
-    .smDown\:w_100\% {
-      width: 100%;
 }
     .smDown\:\[\&\[aria-expanded\=\'true\'\]\]\:bg_\#f09199\![aria-expanded='true'] {
       background: #f09199 !important;
@@ -9127,12 +9154,6 @@
 }
     .smDown\:\[\&_a\]\:fs_12px a {
       font-size: 12px;
-}
-    .smDown\:\[\&_svg\]\:w_20px svg {
-      width: 20px;
-}
-    .smDown\:\[\&_svg\]\:h_20px svg {
-      height: 20px;
 }
     .smDown\:\[\&_a\:first-of-type\]\:pr_7px a:first-of-type {
       padding-right: 7px;

--- a/packages/website/e2e/specs/main.spec.ts
+++ b/packages/website/e2e/specs/main.spec.ts
@@ -71,7 +71,7 @@ test.describe('main page', () => {
     await expect(
       page
         .locator('div')
-        .filter({ hasText: '全部条目动画书籍游戏三次元人物' })
+        .filter({ hasText: '全部动画书籍音乐游戏三次元人物' })
         .getByRole('img')
         .first(),
     ).toBeVisible();

--- a/packages/website/src/components/Header/index.spec.tsx
+++ b/packages/website/src/components/Header/index.spec.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 
 import { UserProvider } from '@bangumi/website/hooks/use-user';
 
@@ -11,6 +11,23 @@ const renderHeader = () =>
     <MemoryRouter>
       <UserProvider>
         <Header />
+      </UserProvider>
+    </MemoryRouter>,
+  );
+
+function LocationDisplay() {
+  const location = useLocation();
+  return <span data-testid='location'>{location.pathname + location.search}</span>;
+}
+
+const renderHeaderWithLocation = () =>
+  render(
+    <MemoryRouter>
+      <UserProvider>
+        <Routes>
+          <Route path='*' element={<Header />} />
+        </Routes>
+        <LocationDisplay />
       </UserProvider>
     </MemoryRouter>,
   );
@@ -67,5 +84,55 @@ describe('Header', () => {
     await waitFor(() => {
       expect(screen.getByRole('textbox', { name: '搜索' })).toHaveFocus();
     });
+  });
+
+  it('桌面端搜索表单提交后跳转到搜索结果页', () => {
+    renderHeaderWithLocation();
+
+    fireEvent.change(screen.getByRole('textbox', { name: '条目搜索' }), {
+      target: { value: '夏目友人帐' },
+    });
+    fireEvent.submit(screen.getByRole('textbox', { name: '条目搜索' }).closest('form')!);
+
+    expect(screen.getByTestId('location')).toHaveTextContent(
+      '/subject_search/%E5%A4%8F%E7%9B%AE%E5%8F%8B%E4%BA%BA%E5%B8%90?cat=all',
+    );
+  });
+
+  it('桌面端搜索可选择分类并按分类跳转', () => {
+    renderHeaderWithLocation();
+
+    fireEvent.change(screen.getByRole('combobox', { name: '搜索分类' }), {
+      target: { value: '1' },
+    });
+    fireEvent.change(screen.getByRole('textbox', { name: '条目搜索' }), {
+      target: { value: '测试' },
+    });
+    fireEvent.submit(screen.getByRole('textbox', { name: '条目搜索' }).closest('form')!);
+
+    expect(screen.getByTestId('location')).toHaveTextContent(
+      '/subject_search/%E6%B5%8B%E8%AF%95?cat=1',
+    );
+  });
+
+  it('点击桌面端搜索图标按钮提交搜索', () => {
+    renderHeaderWithLocation();
+
+    fireEvent.change(screen.getByRole('textbox', { name: '条目搜索' }), {
+      target: { value: '巨人' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '提交搜索' }));
+
+    expect(screen.getByTestId('location')).toHaveTextContent(
+      '/subject_search/%E5%B7%A8%E4%BA%BA?cat=all',
+    );
+  });
+
+  it('空白关键词提交不会跳转', () => {
+    renderHeaderWithLocation();
+
+    fireEvent.submit(screen.getByRole('textbox', { name: '条目搜索' }).closest('form')!);
+
+    expect(screen.getByTestId('location')).toHaveTextContent('/');
   });
 });

--- a/packages/website/src/components/Header/index.tsx
+++ b/packages/website/src/components/Header/index.tsx
@@ -266,9 +266,18 @@ const searchDivider = css({
   background: '#e8e3e3',
 });
 
+const searchSubmitButton = css({
+  display: 'flex',
+  alignItems: 'center',
+  padding: '0',
+  background: 'transparent',
+  border: 'none',
+  cursor: 'pointer',
+});
+
 const mobileSearchButton = css({
   display: 'none',
-  smDown: {
+  '@media (max-width: 1200px)': {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
@@ -350,7 +359,7 @@ const userLogin = css({
 
 const mobilePanelStyle = css({
   display: 'none',
-  smDown: {
+  '@media (max-width: 1200px)': {
     position: 'absolute',
     top: '100%',
     left: '0',
@@ -365,7 +374,7 @@ const mobilePanelStyle = css({
 });
 
 const mobilePanelOpen = css({
-  smDown: { display: 'block' },
+  '@media (max-width: 1200px)': { display: 'block' },
 });
 
 const mobileSearch = css({
@@ -458,7 +467,7 @@ const Header: FC = () => {
     setMobilePanel((panel) => (panel === 'menu' ? 'closed' : 'menu'));
   };
 
-  const handleMobileSearch = (event: React.FormEvent<HTMLFormElement>): void => {
+  const handleSearch = (event: React.FormEvent<HTMLFormElement>): void => {
     event.preventDefault();
     const keyword = searchValue.trim();
     if (!keyword) {
@@ -531,6 +540,7 @@ const Header: FC = () => {
           <div className={infoBox}>
             <form onSubmit={handleDesktopSearch}>
               <Input
+                aria-label='条目搜索'
                 value={searchValue}
                 onChange={(event) => setSearchValue(event.target.value)}
                 prefix={
@@ -538,20 +548,24 @@ const Header: FC = () => {
                     <select
                       name='cat'
                       className={searchSelect}
+                      aria-label='搜索分类'
                       value={searchCategory}
                       onChange={(event) => setSearchCategory(event.target.value)}
                     >
-                      <option value='all'>全部条目</option>
-                      <option value='1'>动画</option>
-                      <option value='2'>书籍</option>
-                      <option value='4'>游戏</option>
-                      <option value='6'>三次元</option>
-                      <option value='mono'>人物</option>
+                      {searchCategories.map((category) => (
+                        <option key={category.value} value={category.value}>
+                          {category.label}
+                        </option>
+                      ))}
                     </select>
                     <Divider orientation='vertical' className={searchDivider} />
                   </>
                 }
-                suffix={<SearchIcon style={{ flexShrink: 0 }} />}
+                suffix={
+                  <button type='submit' className={searchSubmitButton} aria-label='提交搜索'>
+                    <SearchIcon style={{ flexShrink: 0 }} />
+                  </button>
+                }
                 wrapperClass={search}
               />
             </form>
@@ -585,7 +599,7 @@ const Header: FC = () => {
         id='mobile-search-panel'
         className={cx(mobilePanelStyle, showMobilePanel && mobilePanelOpen)}
       >
-        <form className={mobileSearchForm} onSubmit={handleMobileSearch}>
+        <form className={mobileSearchForm} onSubmit={handleSearch}>
           <Input
             ref={searchInputRef}
             aria-label='搜索'


### PR DESCRIPTION
## Summary

The desktop header search box was an unimplemented stub (marked `Search Todo`): pressing Enter or clicking the search icon did nothing, and the category select used placeholder values that did not match the search page.

## Changes

- Wrap the desktop search input in a form that navigates to `/subject_search/:keyword?cat=...`
- Make the input and category select controlled; category values now match the search page (`all | 1 | 2 | 3 | 4 | 6`)
- Make the search icon a real submit button
- Expand the mobile search button/panel breakpoint from `smDown` to `max-width: 1200px` so the search entry point is not missing between 640px and 1200px
- Add tests covering desktop search submission, category selection, icon click and empty keyword

## Verification

- Header tests (12 cases) and full suite (395 cases) pass
- eslint / tsc / prettier pass
- `pnpm panda:codegen` + `pnpm panda:cssgen` regenerated and `packages/styled-system/styles.css` committed
- `pnpm build` succeeds