### PR TITLE
feat(website): character/person search page + Header search entry

### DIFF
--- a/packages/styled-system/styles.css
+++ b/packages/styled-system/styles.css
@@ -1184,6 +1184,38 @@
     padding: 1px 6px;
 }
 
+  .p_20px_0_40px {
+    padding: 20px 0 40px;
+}
+
+  .m_0_-2px {
+    margin: 0 -2px;
+}
+
+  .p_6px_14px_5px {
+    padding: 6px 14px 5px;
+}
+
+  .p_0_4px_5px {
+    padding: 0 4px 5px;
+}
+
+  .p_10px_0_8px {
+    padding: 10px 0 8px;
+}
+
+  .p_0_4px_8px {
+    padding: 0 4px 8px;
+}
+
+  .p_50px_20px {
+    padding: 50px 20px;
+}
+
+  .m_20px_0_0 {
+    margin: 20px 0 0;
+}
+
   .p_2px {
     padding: 2px;
 }
@@ -1212,22 +1244,6 @@
     padding: 24px 0;
 }
 
-  .p_20px_0_40px {
-    padding: 20px 0 40px;
-}
-
-  .m_0_-2px {
-    margin: 0 -2px;
-}
-
-  .p_6px_14px_5px {
-    padding: 6px 14px 5px;
-}
-
-  .p_0_4px_5px {
-    padding: 0 4px 5px;
-}
-
   .bg_\#54b5df {
     background: #54b5df;
 }
@@ -1242,14 +1258,6 @@
 
   .p_7px_5px {
     padding: 7px 5px;
-}
-
-  .p_50px_20px {
-    padding: 50px 20px;
-}
-
-  .m_20px_0_0 {
-    margin: 20px 0 0;
 }
 
   .p_7px_16px {
@@ -1838,6 +1846,10 @@
 
   .gap_16px {
     gap: 16px;
+}
+
+  .gap_18px_12px {
+    gap: 18px 12px;
 }
 
   .flex_0_1_auto {
@@ -2646,6 +2658,26 @@
     line-height: 17px;
 }
 
+  .grid-tc_100px_minmax\(0\,_655px\)_200px {
+    grid-template-columns: 100px minmax(0, 655px) 200px;
+}
+
+  .as_start {
+    align-self: start;
+}
+
+  .grid-tc_repeat\(4\,_minmax\(0\,_1fr\)\) {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+  .asp_1_\/_1\.2 {
+    aspect-ratio: 1 / 1.2;
+}
+
+  .bx-sh_0_1px_4px_rgba\(0\,_0\,_0\,_0\.22\) {
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.22);
+}
+
   .grid-tc_minmax\(220px\,_1fr\)_minmax\(260px\,_1\.15fr\) {
     grid-template-columns: minmax(220px, 1fr) minmax(260px, 1.15fr);
 }
@@ -2658,14 +2690,6 @@
     grid-template-columns: repeat(6, minmax(0, 1fr));
 }
 
-  .grid-tc_100px_minmax\(0\,_655px\)_200px {
-    grid-template-columns: 100px minmax(0, 655px) 200px;
-}
-
-  .as_start {
-    align-self: start;
-}
-
   .d_inline-flex {
     display: inline-flex;
 }
@@ -2676,10 +2700,6 @@
 
   .asp_5_\/_7 {
     aspect-ratio: 5 / 7;
-}
-
-  .bx-sh_0_1px_4px_rgba\(0\,_0\,_0\,_0\.22\) {
-    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.22);
 }
 
   .c_\#bbb {
@@ -3723,6 +3743,18 @@
     width: 140px;
 }
 
+  .w_980px {
+    width: 980px;
+}
+
+  .min-h_24px {
+    min-height: 24px;
+}
+
+  .min-h_240px {
+    min-height: 240px;
+}
+
   .pb_0\! {
     padding-bottom: var(--spacing-0) !important;
 }
@@ -3749,14 +3781,6 @@
 
   .min-h_58px {
     min-height: 58px;
-}
-
-  .w_980px {
-    width: 980px;
-}
-
-  .min-h_24px {
-    min-height: 24px;
 }
 
   .w_8px {
@@ -3805,10 +3829,6 @@
 
   .right_50\% {
     right: 50%;
-}
-
-  .min-h_240px {
-    min-height: 240px;
 }
 
   .pb_40px {
@@ -4219,30 +4239,6 @@
     margin: 0 0 5px;
 }
 
-  .\[\&_\>_li\]\:p_5px > li {
-    padding: 5px;
-}
-
-  .\[\&_li\]\:p_4px_6px li {
-    padding: 4px 6px;
-}
-
-  .even\:bg_\#fafafa:nth-child(even) {
-    background: #fafafa;
-}
-
-  .\[\&_\>_li\]\:p_8px_5px > li {
-    padding: 8px 5px;
-}
-
-  .\[\&_p\]\:m_4px_0_0_-4px p {
-    margin: 4px 0 0 -4px;
-}
-
-  .\[\&_\>_li\]\:p_8px_4px > li {
-    padding: 8px 4px;
-}
-
   .\[\&_input\]\:p_6px_10px input {
     padding: 6px 10px;
 }
@@ -4291,8 +4287,44 @@
     background: #f09199;
 }
 
+  .\[\&_select\]\:p_0_6px select {
+    padding: 0 6px;
+}
+
+  .\[\&_select\]\:bd_1px_solid_\#e8e3e3 select {
+    border: 1px solid #e8e3e3;
+}
+
+  .\[\&_select\]\:bg_\#fff select {
+    background: #fff;
+}
+
   .\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:m_0 .bgm-pagination-prev,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:m_0 .bgm-pagination-next,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:m_0 .bgm-pagination-pager {
     margin: var(--spacing-0);
+}
+
+  .\[\&_\>_li\]\:p_5px > li {
+    padding: 5px;
+}
+
+  .\[\&_li\]\:p_4px_6px li {
+    padding: 4px 6px;
+}
+
+  .even\:bg_\#fafafa:nth-child(even) {
+    background: #fafafa;
+}
+
+  .\[\&_\>_li\]\:p_8px_5px > li {
+    padding: 8px 5px;
+}
+
+  .\[\&_p\]\:m_4px_0_0_-4px p {
+    margin: 4px 0 0 -4px;
+}
+
+  .\[\&_\>_li\]\:p_8px_4px > li {
+    padding: 8px 4px;
 }
 
   .\[\&_h2\]\:m_0_0_8px h2 {
@@ -4659,14 +4691,6 @@
     overflow: hidden;
 }
 
-  .\[\&_li\]\:bd-t_1px_solid_\#e8e3e3 li {
-    border-top: 1px solid #e8e3e3;
-}
-
-  .\[\&_\>_a\]\:flex_0_0_auto > a {
-    flex: 0 0 auto;
-}
-
   .\[\&_input\]\:bdr_4px input {
     border-radius: 4px;
 }
@@ -4703,6 +4727,34 @@
     text-decoration: none;
 }
 
+  .\[\&_select\]\:bdr_4px select {
+    border-radius: 4px;
+}
+
+  .\[\&_select\]\:ring_none select {
+    outline: var(--borders-none);
+}
+
+  .\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:bd-w_1px .bgm-pagination-prev,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:bd-w_1px .bgm-pagination-next,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:bd-w_1px .bgm-pagination-pager {
+    border-width: 1px;
+}
+
+  .\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:bdr_50\% .bgm-pagination-prev,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:bdr_50\% .bgm-pagination-next,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:bdr_50\% .bgm-pagination-pager {
+    border-radius: 50%;
+}
+
+  .\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\]\:bdr_13px .bgm-pagination-prev,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\]\:bdr_13px .bgm-pagination-next {
+    border-radius: 13px;
+}
+
+  .\[\&_li\]\:bd-t_1px_solid_\#e8e3e3 li {
+    border-top: 1px solid #e8e3e3;
+}
+
+  .\[\&_\>_a\]\:flex_0_0_auto > a {
+    flex: 0 0 auto;
+}
+
   .\[\&\:last-child\]\:bd-r_0:last-child {
     border-right: 0;
 }
@@ -4717,18 +4769,6 @@
 
   .\[\&_\>_li\]\:gap_14px > li {
     gap: 14px;
-}
-
-  .\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:bd-w_1px .bgm-pagination-prev,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:bd-w_1px .bgm-pagination-next,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:bd-w_1px .bgm-pagination-pager {
-    border-width: 1px;
-}
-
-  .\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:bdr_50\% .bgm-pagination-prev,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:bdr_50\% .bgm-pagination-next,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:bdr_50\% .bgm-pagination-pager {
-    border-radius: 50%;
-}
-
-  .\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\]\:bdr_13px .bgm-pagination-prev,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\]\:bdr_13px .bgm-pagination-next {
-    border-radius: 13px;
 }
 
   .\[\&_h2\]\:bd-b_1px_solid_\#e8e3e3 h2 {
@@ -5543,26 +5583,6 @@
     line-height: 18px;
 }
 
-  .\[\&_\>_li\]\:lh_1\.4 > li {
-    line-height: 1.4;
-}
-
-  .\[\&_\>_a\]\:fs_12px > a {
-    font-size: 12px;
-}
-
-  .\[\&_\>_li\]\:grid-tc_minmax\(0\,_1fr\)_36px > li {
-    grid-template-columns: minmax(0, 1fr) 36px;
-}
-
-  .\[\&_\>_li\]\:ai_start > li {
-    align-items: start;
-}
-
-  .\[\&_\>_li\]\:ai_flex-start > li {
-    align-items: flex-start;
-}
-
   .\[\&_label\]\:c_\#595555 label {
     color: #595555;
 }
@@ -5631,6 +5651,38 @@
     color: #fff;
 }
 
+  .\[\&_select\]\:c_\#595555 select {
+    color: #595555;
+}
+
+  .\[\&_select\]\:fs_12px select {
+    font-size: 12px;
+}
+
+  .\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:fs_11px .bgm-pagination-prev,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:fs_11px .bgm-pagination-next,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:fs_11px .bgm-pagination-pager {
+    font-size: 11px;
+}
+
+  .\[\&_\>_li\]\:lh_1\.4 > li {
+    line-height: 1.4;
+}
+
+  .\[\&_\>_a\]\:fs_12px > a {
+    font-size: 12px;
+}
+
+  .\[\&_\>_li\]\:grid-tc_minmax\(0\,_1fr\)_36px > li {
+    grid-template-columns: minmax(0, 1fr) 36px;
+}
+
+  .\[\&_\>_li\]\:ai_start > li {
+    align-items: start;
+}
+
+  .\[\&_\>_li\]\:ai_flex-start > li {
+    align-items: flex-start;
+}
+
   .\[\&_svg\]\:fill_currentcolor svg {
     fill: currentcolor;
 }
@@ -5649,10 +5701,6 @@
 
   .\[\&_\>_li\]\:bx-s_border-box > li {
     box-sizing: border-box;
-}
-
-  .\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:fs_11px .bgm-pagination-prev,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:fs_11px .bgm-pagination-next,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:fs_11px .bgm-pagination-pager {
-    font-size: 11px;
 }
 
   .\[\&_h2\]\:c_\#9f9b9b h2 {
@@ -6702,14 +6750,6 @@
     min-height: 200px;
 }
 
-  .\[\&_\>_li\]\:min-h_58px > li {
-    min-height: 58px;
-}
-
-  .\[\&_li\]\:min-w_0 li {
-    min-width: var(--sizes-0);
-}
-
   .\[\&_label\]\:w_100px label {
     width: 100px;
 }
@@ -6726,28 +6766,8 @@
     height: 34px;
 }
 
-  .\[\&_svg\]\:w_14px svg {
-    width: 14px;
-}
-
-  .\[\&_svg\]\:h_14px svg {
-    height: 14px;
-}
-
-  .\[\&_svg\]\:w_10px svg {
-    width: 10px;
-}
-
-  .\[\&_svg\]\:h_10px svg {
-    height: 10px;
-}
-
-  .\[\&_\>_li\]\:min-h_126px > li {
-    min-height: 126px;
-}
-
-  .\[\&_\>_li\]\:min-h_82px > li {
-    min-height: 82px;
+  .\[\&_select\]\:h_26px select {
+    height: 26px;
 }
 
   .\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:w_26px .bgm-pagination-prev,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:w_26px .bgm-pagination-next,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:w_26px .bgm-pagination-pager {
@@ -6772,6 +6792,38 @@
 
   .\[\&_\.bgm-pagination-icon\]\:h_14px .bgm-pagination-icon {
     height: 14px;
+}
+
+  .\[\&_\>_li\]\:min-h_58px > li {
+    min-height: 58px;
+}
+
+  .\[\&_li\]\:min-w_0 li {
+    min-width: var(--sizes-0);
+}
+
+  .\[\&_svg\]\:w_14px svg {
+    width: 14px;
+}
+
+  .\[\&_svg\]\:h_14px svg {
+    height: 14px;
+}
+
+  .\[\&_svg\]\:w_10px svg {
+    width: 10px;
+}
+
+  .\[\&_svg\]\:h_10px svg {
+    height: 10px;
+}
+
+  .\[\&_\>_li\]\:min-h_126px > li {
+    min-height: 126px;
+}
+
+  .\[\&_\>_li\]\:min-h_82px > li {
+    min-height: 82px;
 }
 
   .\[\&_h2\]\:pb_7px h2 {
@@ -7286,20 +7338,20 @@
     padding: 6px 5px;
 }
 
-  .\[\&_\>_li\]\:\[\&_p\]\:m_3px_0_0 > li p {
-    margin: 3px 0 0;
-}
-
-  .\[\&_li\]\:\[\&_\>_p\]\:m_0_0_3px li > p {
-    margin: 0 0 3px;
-}
-
   .\[\&_button\]\:hover\:bg_\#3aa4d2 button:is(:hover, [data-hover]) {
     background: #3aa4d2;
 }
 
   .\[\&_li_a\]\:hover\:bg_\#fff6f7 li a:is(:hover, [data-hover]) {
     background: #fff6f7;
+}
+
+  .\[\&_\>_li\]\:\[\&_p\]\:m_3px_0_0 > li p {
+    margin: 3px 0 0;
+}
+
+  .\[\&_li\]\:\[\&_\>_p\]\:m_0_0_3px li > p {
+    margin: 0 0 3px;
 }
 
   .\[\&_\>_li\]\:even\:bg_\#fafafa > li:nth-child(even) {
@@ -7394,15 +7446,11 @@
     text-decoration: none;
 }
 
-  .\[\&_\>_li\]\:\[\&_\>_div_\>_a\,_\&_small\]\:ov_hidden > li > div > a,.\[\&_\>_li\]\:\[\&_\>_div_\>_a\,_\&_small\]\:ov_hidden > li small {
-    overflow: hidden;
-}
-
   .\[\&_input\]\:focus\:bd-c_\#f09199 input:is(:focus, [data-focus]) {
     border-color: #f09199;
 }
 
-  .\[\&_a\]\:\[\&_\>_span\:last-child\]\:ov_hidden a > span:last-child {
+  .\[\&_\>_li\]\:\[\&_\>_div_\>_a\,_\&_small\]\:ov_hidden > li > div > a,.\[\&_\>_li\]\:\[\&_\>_div_\>_a\,_\&_small\]\:ov_hidden > li small,.\[\&_a\]\:\[\&_\>_span\:last-child\]\:ov_hidden a > span:last-child {
     overflow: hidden;
 }
 
@@ -7642,6 +7690,22 @@
     color: #fff;
 }
 
+  .\[\&_input\]\:focus\:bx-sh_0_0_0_2px_rgba\(240\,_145\,_153\,_0\.18\) input:is(:focus, [data-focus]) {
+    box-shadow: 0 0 0 2px rgba(240, 145, 153, 0.18);
+}
+
+  .\[\&_button\]\:\[\&_svg\]\:fill_currentcolor button svg {
+    fill: currentcolor;
+}
+
+  .\[\&_li_a\]\:hover\:c_\#f09199 li a:is(:hover, [data-hover]),.\[\&_a\]\:\[\&\[class\]\]\:c_\#f09199 a[class] {
+    color: #f09199;
+}
+
+  .\[\&_a\]\:\[\&\[class\]\]\:fw_600 a[class] {
+    font-weight: 600;
+}
+
   .\[\&_\>_li\]\:\[\&_\>_div_\>_a\,_\&_small\]\:d_block > li > div > a,.\[\&_\>_li\]\:\[\&_\>_div_\>_a\,_\&_small\]\:d_block > li small {
     display: block;
 }
@@ -7666,15 +7730,7 @@
     font-size: 11px;
 }
 
-  .\[\&_input\]\:focus\:bx-sh_0_0_0_2px_rgba\(240\,_145\,_153\,_0\.18\) input:is(:focus, [data-focus]) {
-    box-shadow: 0 0 0 2px rgba(240, 145, 153, 0.18);
-}
-
-  .\[\&_button\]\:\[\&_svg\]\:fill_currentcolor button svg {
-    fill: currentcolor;
-}
-
-  .\[\&_li_a\]\:hover\:c_\#f09199 li a:is(:hover, [data-hover]),.\[\&_\>_a\]\:hover\:c_\#f09199 > a:is(:hover, [data-hover]) {
+  .\[\&_\>_a\]\:hover\:c_\#f09199 > a:is(:hover, [data-hover]) {
     color: #f09199;
 }
 
@@ -7918,16 +7974,16 @@
     height: 18px;
 }
 
-  .\[\&_li\]\:\[\&_\>_p\]\:min-h_20px li > p {
-    min-height: 20px;
-}
-
   .\[\&_button\]\:\[\&_svg\]\:w_14px button svg {
     width: 14px;
 }
 
   .\[\&_button\]\:\[\&_svg\]\:h_14px button svg {
     height: 14px;
+}
+
+  .\[\&_li\]\:\[\&_\>_p\]\:min-h_20px li > p {
+    min-height: 20px;
 }
 
   .\[\&_a\]\:\[\&_\>_span\:last-child\]\:w_100\% a > span:last-child {
@@ -8355,6 +8411,9 @@
     .\[\@media_\(max-width\:_768px\)\]\:gap_12px {
       gap: 12px;
 }
+    .\[\@media_\(max-width\:_768px\)\]\:gap_14px_10px {
+      gap: 14px 10px;
+}
     .\[\@media_\(max-width\:_768px\)\]\:gap_10px {
       gap: 10px;
 }
@@ -8373,14 +8432,17 @@
     .\[\@media_\(max-width\:_768px\)\]\:d_flex {
       display: flex;
 }
+    .\[\@media_\(max-width\:_768px\)\]\:grid-tc_repeat\(3\,_minmax\(0\,_1fr\)\) {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+    .\[\@media_\(max-width\:_768px\)\]\:d_none {
+      display: none;
+}
     .\[\@media_\(max-width\:_768px\)\]\:fs_13px {
       font-size: 13px;
 }
     .\[\@media_\(max-width\:_768px\)\]\:lh_18px {
       line-height: 18px;
-}
-    .\[\@media_\(max-width\:_768px\)\]\:d_none {
-      display: none;
 }
     .\[\@media_\(max-width\:_768px\)\]\:fs_11px {
       font-size: 11px;
@@ -8418,6 +8480,9 @@
     .\[\@media_\(max-width\:_768px\)\]\:pl_2px {
       padding-left: 2px;
 }
+    .\[\@media_\(max-width\:_768px\)\]\:mt_14px {
+      margin-top: 14px;
+}
     .\[\@media_\(max-width\:_768px\)\]\:pr_0 {
       padding-right: var(--spacing-0);
 }
@@ -8435,9 +8500,6 @@
 }
     .\[\@media_\(max-width\:_768px\)\]\:w_72px {
       width: 72px;
-}
-    .\[\@media_\(max-width\:_768px\)\]\:mt_14px {
-      margin-top: 14px;
 }
     .\[\@media_\(max-width\:_768px\)\]\:pt_16px {
       padding-top: 16px;

--- a/packages/website/src/components/Header/index.tsx
+++ b/packages/website/src/components/Header/index.tsx
@@ -541,11 +541,12 @@ const Header: FC = () => {
                       value={searchCategory}
                       onChange={(event) => setSearchCategory(event.target.value)}
                     >
-                      {searchCategories.map((category) => (
-                        <option key={category.value} value={category.value}>
-                          {category.label}
-                        </option>
-                      ))}
+                      <option value='all'>全部条目</option>
+                      <option value='1'>动画</option>
+                      <option value='2'>书籍</option>
+                      <option value='4'>游戏</option>
+                      <option value='6'>三次元</option>
+                      <option value='mono'>人物</option>
                     </select>
                     <Divider orientation='vertical' className={searchDivider} />
                   </>

--- a/packages/website/src/components/Header/index.tsx
+++ b/packages/website/src/components/Header/index.tsx
@@ -90,6 +90,7 @@ const searchCategories = [
   { value: '3', label: '音乐' },
   { value: '4', label: '游戏' },
   { value: '6', label: '三次元' },
+  { value: 'mono', label: '人物' },
 ] as const;
 
 const container = css({
@@ -464,7 +465,24 @@ const Header: FC = () => {
       return;
     }
     setMobilePanel('closed');
-    navigate(`/subject_search/${encodeURIComponent(keyword)}?cat=${searchCategory}`);
+    if (searchCategory === 'mono') {
+      navigate(`/mono_search/${encodeURIComponent(keyword)}?cat=prsn`);
+    } else {
+      navigate(`/subject_search/${encodeURIComponent(keyword)}?cat=${searchCategory}`);
+    }
+  };
+
+  const handleDesktopSearch = (event: React.FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    const keyword = searchValue.trim();
+    if (!keyword) {
+      return;
+    }
+    if (searchCategory === 'mono') {
+      navigate(`/mono_search/${encodeURIComponent(keyword)}?cat=prsn`);
+    } else {
+      navigate(`/subject_search/${encodeURIComponent(keyword)}?cat=${searchCategory}`);
+    }
   };
 
   return (
@@ -511,24 +529,31 @@ const Header: FC = () => {
             <SearchIcon />
           </button>
           <div className={infoBox}>
-            {/* Search Todo */}
-            <Input
-              prefix={
-                <>
-                  <select name='cat' className={searchSelect} defaultValue='value1'>
-                    <option value='value1'>全部条目</option>
-                    <option value='value2'>动画</option>
-                    <option value='value3'>书籍</option>
-                    <option value='value4'>游戏</option>
-                    <option value='value5'>三次元</option>
-                    <option value='value6'>人物</option>
-                  </select>
-                  <Divider orientation='vertical' className={searchDivider} />
-                </>
-              }
-              suffix={<SearchIcon style={{ flexShrink: 0 }} />}
-              wrapperClass={search}
-            />
+            <form onSubmit={handleDesktopSearch}>
+              <Input
+                value={searchValue}
+                onChange={(event) => setSearchValue(event.target.value)}
+                prefix={
+                  <>
+                    <select
+                      name='cat'
+                      className={searchSelect}
+                      value={searchCategory}
+                      onChange={(event) => setSearchCategory(event.target.value)}
+                    >
+                      {searchCategories.map((category) => (
+                        <option key={category.value} value={category.value}>
+                          {category.label}
+                        </option>
+                      ))}
+                    </select>
+                    <Divider orientation='vertical' className={searchDivider} />
+                  </>
+                }
+                suffix={<SearchIcon style={{ flexShrink: 0 }} />}
+                wrapperClass={search}
+              />
+            </form>
           </div>
           {/* Avatar */}
           {user ? (

--- a/packages/website/src/hooks/use-mono-search.ts
+++ b/packages/website/src/hooks/use-mono-search.ts
@@ -1,0 +1,42 @@
+import { ok } from '@oazapfts/runtime';
+import useSWR from 'swr';
+
+import { ozaClient } from '@bangumi/client';
+import type { SlimCharacter, SlimPerson } from '@bangumi/client/client';
+
+const PAGE_SIZE = 15;
+
+/** 角色搜索；keyword 为 null 时不发起请求 */
+export function useCharacterSearch(keyword: string | null, offset: number) {
+  const { data } = useSWR(
+    keyword === null ? null : ['character-search', keyword, offset],
+    async () =>
+      ok(ozaClient.searchCharacters({ keyword: keyword as string }, { limit: PAGE_SIZE, offset })),
+    { keepPreviousData: true, suspense: true },
+  );
+
+  return { characters: data?.data ?? [], total: data?.total ?? 0 };
+}
+
+/** 人物搜索（可按职业过滤）；keyword 为 null 时不发起请求 */
+export function usePersonSearch(
+  keyword: string | null,
+  career: string | undefined,
+  offset: number,
+) {
+  const { data } = useSWR(
+    keyword === null ? null : ['person-search', keyword, career, offset],
+    async () =>
+      ok(
+        ozaClient.searchPersons(
+          { keyword: keyword as string, filter: career ? { career: [career] } : undefined },
+          { limit: PAGE_SIZE, offset },
+        ),
+      ),
+    { keepPreviousData: true, suspense: true },
+  );
+
+  return { persons: data?.data ?? [], total: data?.total ?? 0 };
+}
+
+export type { SlimCharacter, SlimPerson };

--- a/packages/website/src/pages/index/mono_search/[keyword]/MonoSearchPage.spec.tsx
+++ b/packages/website/src/pages/index/mono_search/[keyword]/MonoSearchPage.spec.tsx
@@ -1,0 +1,70 @@
+import { act, screen } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import React, { Suspense } from 'react';
+import { useParams, useSearchParams } from 'react-router-dom';
+
+import {
+  characterSearchFixture,
+  personSearchFixture,
+} from '@bangumi/website/mocks/fixtures/p1/search';
+import { server as mockServer } from '@bangumi/website/mocks/server';
+import { renderPage } from '@bangumi/website/utils/test-utils';
+
+import MonoSearchPage from '.';
+
+vi.mock('react-router-dom', async () => ({
+  ...(await vi.importActual<typeof import('react-router-dom')>('react-router-dom')),
+  useParams: vi.fn(),
+  useSearchParams: vi.fn(),
+}));
+
+const mockedUseParams = vi.mocked(useParams);
+const mockedUseSearchParams = vi.mocked(useSearchParams);
+
+beforeEach(() => {
+  mockedUseParams.mockReturnValue({ keyword: '巨人' });
+  mockedUseSearchParams.mockReturnValue([new URLSearchParams('cat=crt'), vi.fn()]);
+
+  mockServer.use(
+    http.post('http://localhost:3000/p1/search/characters', () =>
+      HttpResponse.json(characterSearchFixture),
+    ),
+    http.post('http://localhost:3000/p1/search/persons', () =>
+      HttpResponse.json(personSearchFixture),
+    ),
+  );
+});
+
+describe('MonoSearchPage', () => {
+  it('renders character results with pagination', async () => {
+    await act(async () => {
+      renderPage(
+        <Suspense fallback={null}>
+          <MonoSearchPage />
+        </Suspense>,
+      );
+    });
+
+    const links = await screen.findAllByRole('link');
+    expect(links.some((el) => el.getAttribute('href') === '/character/99657')).toBe(true);
+    expect(screen.getByText('找到 40 个角色')).toBeInTheDocument();
+    // 分类侧栏：角色分类高亮
+    expect(screen.getByRole('link', { name: '虚构角色' }).className).toContain('bg_#f09199');
+  });
+
+  it('renders person results with career filter when cat=prsn', async () => {
+    mockedUseSearchParams.mockReturnValue([new URLSearchParams('cat=prsn'), vi.fn()]);
+    await act(async () => {
+      renderPage(
+        <Suspense fallback={null}>
+          <MonoSearchPage />
+        </Suspense>,
+      );
+    });
+
+    const links = await screen.findAllByRole('link');
+    expect(links.some((el) => el.getAttribute('href') === '/person/49410')).toBe(true);
+    expect(screen.getByText('找到 3 个现实人物')).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: '' })).toBeInTheDocument();
+  });
+});

--- a/packages/website/src/pages/index/mono_search/[keyword]/index.tsx
+++ b/packages/website/src/pages/index/mono_search/[keyword]/index.tsx
@@ -1,0 +1,649 @@
+import React, { useEffect, useState } from 'react';
+import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom';
+
+import type { SlimCharacter, SlimPerson } from '@bangumi/client/client';
+import { Pagination } from '@bangumi/design';
+import { Search } from '@bangumi/icons';
+import { css } from '@bangumi/styled-system/css';
+import { getCharacterLink, getLegacyPageLink, getPersonLink } from '@bangumi/utils/pages';
+import { withErrorBoundary } from '@bangumi/website/components/ErrorBoundary';
+import Helmet from '@bangumi/website/components/Helmet';
+import { useCharacterSearch, usePersonSearch } from '@bangumi/website/hooks/use-mono-search';
+import { usePaginationParams } from '@bangumi/website/hooks/use-pagination';
+
+const PAGE_SIZE = 15;
+
+const searchBand = css({
+  borderBottom: '1px solid #e8e3e3',
+  background: '#fafafa',
+});
+
+const searchForm = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '6px',
+  width: '980px',
+  margin: '0 auto',
+  padding: '10px 0',
+  boxSizing: 'border-box',
+  '& label': {
+    width: '100px',
+    marginRight: '9px',
+    color: '#595555',
+    fontSize: '16px',
+    fontWeight: '600',
+    lineHeight: '35px',
+    textAlign: 'right',
+  },
+  '& input': {
+    width: '375px',
+    height: '34px',
+    padding: '6px 10px',
+    border: '1px solid #ccc',
+    borderRadius: '4px',
+    background: '#fff',
+    color: '#1f1c1c',
+    fontSize: '14px',
+    outline: 'none',
+    boxShadow: 'inset 0 1px 2px rgba(0, 0, 0, 0.08)',
+    _focus: {
+      borderColor: '#f09199',
+      boxShadow: '0 0 0 2px rgba(240, 145, 153, 0.18)',
+    },
+  },
+  '& button': {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: '5px',
+    height: '34px',
+    padding: '0 16px',
+    border: '0',
+    borderRadius: '4px',
+    background: '#54b5df',
+    color: '#fff',
+    cursor: 'pointer',
+    _hover: { background: '#3aa4d2' },
+    '& svg': {
+      width: '14px',
+      height: '14px',
+      fill: 'currentcolor',
+    },
+  },
+  '@media (max-width: 1024px)': {
+    width: 'calc(100% - 40px)',
+  },
+  '@media (max-width: 768px)': {
+    width: '100%',
+    paddingRight: '16px',
+    paddingLeft: '16px',
+    '& label': {
+      width: 'auto',
+      marginRight: '4px',
+      fontSize: '13px',
+      whiteSpace: 'nowrap',
+    },
+    '& input': {
+      minWidth: '0',
+      width: 'auto',
+      flex: '1',
+    },
+  },
+  '@media (max-width: 640px)': {
+    '& button': {
+      width: '38px',
+      padding: '0',
+      '& span': {
+        display: 'none',
+      },
+    },
+  },
+});
+
+const page = css({
+  display: 'grid',
+  gridTemplateColumns: '100px minmax(0, 655px) 200px',
+  gap: '10px',
+  width: '980px',
+  margin: '0 auto',
+  padding: '20px 0 40px',
+  boxSizing: 'border-box',
+  '@media (max-width: 1024px)': {
+    width: 'calc(100% - 40px)',
+    gridTemplateColumns: '100px minmax(0, 1fr) 200px',
+  },
+  '@media (max-width: 768px)': {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '12px',
+    width: '100%',
+    padding: '10px 8px 24px',
+  },
+});
+
+const categories = css({
+  alignSelf: 'start',
+  '& ul': {
+    overflow: 'hidden',
+    margin: '0',
+    padding: '0 2px 5px',
+    border: '1px solid #e8e3e3',
+    borderRadius: '8px',
+    background: '#fff',
+    boxShadow: '0 1px 5px rgba(50, 46, 46, 0.08)',
+    listStyle: 'none',
+  },
+  '& li a': {
+    display: 'block',
+    margin: '5px 0',
+    padding: '3px 12px',
+    borderRadius: '999px',
+    color: '#54b5df',
+    fontSize: '13px',
+    lineHeight: '18px',
+    textDecoration: 'none',
+    _hover: {
+      background: '#fff6f7',
+      color: '#f09199',
+    },
+  },
+  '@media (max-width: 768px)': {
+    '& ul': {
+      padding: '4px 6px',
+      borderRadius: '6px',
+    },
+    '& li': {
+      display: 'inline-block',
+    },
+    '& li a': {
+      margin: '0',
+      padding: '3px 6px',
+      fontSize: '12px',
+    },
+  },
+});
+
+const categorySelected = css({
+  '&[class]': {
+    background: '#f09199',
+    color: '#fff',
+  },
+});
+
+const categoryRoot = css({
+  margin: '0 -2px',
+  padding: '6px 14px 5px',
+  borderBottom: '1px solid #e8e3e3',
+  color: '#9f9b9b',
+  fontSize: '12px',
+  fontWeight: '600',
+  '@media (max-width: 768px)': {
+    margin: '0',
+    padding: '3px 5px',
+    border: '0',
+  },
+});
+
+const results = css({
+  minWidth: '0',
+  '@media (max-width: 768px)': {
+    width: '100%',
+  },
+});
+
+const resultTools = css({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  minHeight: '24px',
+  padding: '0 4px 5px',
+  color: '#9f9b9b',
+  fontSize: '12px',
+  '@media (max-width: 768px)': {
+    paddingRight: '2px',
+    paddingLeft: '2px',
+  },
+  '@media (max-width: 640px)': {
+    justifyContent: 'flex-end',
+    '& > span': {
+      display: 'none',
+    },
+  },
+});
+
+const monoTabs = css({
+  display: 'flex',
+  gap: '16px',
+  padding: '10px 0 8px',
+  '& a': {
+    color: '#9f9b9b',
+    fontSize: '13px',
+    textDecoration: 'none',
+    '&[class]': {
+      color: '#f09199',
+      fontWeight: '600',
+    },
+    _hover: { color: '#f09199' },
+  },
+});
+
+const careerFilter = css({
+  display: 'flex',
+  flexWrap: 'wrap',
+  alignItems: 'center',
+  gap: '10px',
+  padding: '0 4px 8px',
+  color: '#9f9b9b',
+  fontSize: '12px',
+  '& select': {
+    height: '26px',
+    padding: '0 6px',
+    border: '1px solid #e8e3e3',
+    borderRadius: '4px',
+    background: '#fff',
+    color: '#595555',
+    fontSize: '12px',
+    outline: 'none',
+  },
+});
+
+const resultsGrid = css({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(4, minmax(0, 1fr))',
+  gap: '18px 12px',
+  margin: '0',
+  padding: '8px 0',
+  listStyle: 'none',
+  '@media (max-width: 768px)': {
+    gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+    gap: '14px 10px',
+  },
+});
+
+const cardLink = css({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  color: '#54b5df',
+  fontSize: '13px',
+  lineHeight: '18px',
+  textAlign: 'center',
+  textDecoration: 'none',
+  _hover: { color: '#f09199' },
+});
+
+const cardCover = css({
+  display: 'block',
+  width: '100%',
+  aspectRatio: '1 / 1.2',
+  borderRadius: '4px',
+  objectFit: 'cover',
+  boxShadow: '0 1px 4px rgba(0, 0, 0, 0.22)',
+});
+
+const cardCoverPlaceholder = css({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '100%',
+  aspectRatio: '1 / 1.2',
+  borderRadius: '4px',
+  background: '#e8e3e3',
+  color: '#9f9b9b',
+  fontSize: '20px',
+});
+
+const cardName = css({
+  overflow: 'hidden',
+  maxWidth: '100%',
+  marginTop: '6px',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+});
+
+const cardSub = css({
+  overflow: 'hidden',
+  maxWidth: '100%',
+  color: '#9f9b9b',
+  fontSize: '11px',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+});
+
+const cardInfo = css({
+  overflow: 'hidden',
+  margin: '4px 0 0',
+  color: '#9f9b9b',
+  fontSize: '11px',
+  lineHeight: '16px',
+  textAlign: 'center',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+});
+
+const empty = css({
+  minHeight: '240px',
+  margin: '0',
+  padding: '50px 20px',
+  borderTop: '1px solid #e8e3e3',
+  color: '#9f9b9b',
+  boxSizing: 'border-box',
+  textAlign: 'center',
+});
+
+const pagination = css({
+  flexWrap: 'wrap',
+  gap: '6px',
+  margin: '20px 0 0',
+  '& .bgm-pagination-prev, & .bgm-pagination-next, & .bgm-pagination-pager': {
+    width: '26px',
+    height: '26px',
+    margin: '0',
+    borderWidth: '1px',
+    borderRadius: '50%',
+    fontSize: '11px',
+  },
+  '& .bgm-pagination-pager + .bgm-pagination-pager': {
+    marginLeft: '0',
+  },
+  '& .bgm-pagination-prev, & .bgm-pagination-next': {
+    width: '34px',
+    borderRadius: '13px',
+  },
+  '& .bgm-pagination-icon': {
+    width: '14px',
+    height: '14px',
+  },
+  '@media (max-width: 768px)': {
+    marginTop: '14px',
+  },
+});
+
+/** 人物职业（旧站 PersonCareer） */
+const PERSON_CAREERS: { value: string; label: string }[] = [
+  { value: '', label: '全部职业' },
+  { value: 'producer', label: '制作人' },
+  { value: 'mangaka', label: '漫画家' },
+  { value: 'seiyu', label: '声优' },
+  { value: 'writer', label: '作家' },
+  { value: 'illustrator', label: '插画家' },
+  { value: 'actor', label: '演员' },
+];
+
+type MonoCategory = 'crt' | 'prsn' | 'all';
+
+function parseCategory(value: string | null): MonoCategory {
+  return value === 'crt' || value === 'prsn' || value === 'all' ? value : 'crt';
+}
+
+function CharacterCard({ character }: { character: SlimCharacter }) {
+  const displayName = character.nameCN || character.name;
+  const showSub = Boolean(character.nameCN) && character.name !== character.nameCN;
+
+  return (
+    <li>
+      <Link className={cardLink} to={getCharacterLink(character.id)}>
+        {character.images?.grid ? (
+          <img className={cardCover} src={character.images.grid} alt='' loading='lazy' />
+        ) : (
+          <span className={cardCoverPlaceholder} aria-hidden='true'>
+            {displayName.slice(0, 1)}
+          </span>
+        )}
+        <span className={cardName} title={displayName}>
+          {displayName}
+        </span>
+        {showSub && (
+          <span className={cardSub} title={character.name}>
+            {character.name}
+          </span>
+        )}
+      </Link>
+      {character.info && (
+        <p className={cardInfo} title={character.info}>
+          {character.info}
+        </p>
+      )}
+    </li>
+  );
+}
+
+function PersonCard({ person }: { person: SlimPerson }) {
+  const displayName = person.nameCN || person.name;
+  const showSub = Boolean(person.nameCN) && person.name !== person.nameCN;
+
+  return (
+    <li>
+      <Link className={cardLink} to={getPersonLink(person.id)}>
+        {person.images?.grid ? (
+          <img className={cardCover} src={person.images.grid} alt='' loading='lazy' />
+        ) : (
+          <span className={cardCoverPlaceholder} aria-hidden='true'>
+            {displayName.slice(0, 1)}
+          </span>
+        )}
+        <span className={cardName} title={displayName}>
+          {displayName}
+        </span>
+        {showSub && (
+          <span className={cardSub} title={person.name}>
+            {person.name}
+          </span>
+        )}
+      </Link>
+      {person.info && (
+        <p className={cardInfo} title={person.info}>
+          {person.info}
+        </p>
+      )}
+    </li>
+  );
+}
+
+function MonoSearchPage() {
+  const { keyword: routeKeyword = '' } = useParams<{ keyword: string }>();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const category = parseCategory(searchParams.get('cat'));
+  const career = searchParams.get('career') ?? undefined;
+  const { curPage, offset } = usePaginationParams(PAGE_SIZE);
+  const [searchValue, setSearchValue] = useState(routeKeyword);
+
+  const showCharacters = category === 'all' || category === 'crt';
+  const showPersons = category === 'prsn';
+
+  const { characters, total: characterTotal } = useCharacterSearch(
+    showCharacters ? routeKeyword : null,
+    offset,
+  );
+  const { persons, total: personTotal } = usePersonSearch(
+    showPersons ? routeKeyword : null,
+    career,
+    offset,
+  );
+
+  useEffect(() => {
+    setSearchValue(routeKeyword);
+  }, [routeKeyword]);
+
+  const handleSearch = (event: React.FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    const nextKeyword = searchValue.trim();
+    if (nextKeyword) {
+      navigate(`/mono_search/${encodeURIComponent(nextKeyword)}?cat=${category}`);
+    }
+  };
+
+  const handlePageChange = (page: number): void => {
+    setSearchParams((params) => {
+      params.set('page', String(page));
+      return params;
+    });
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  const keywordParam = encodeURIComponent(routeKeyword);
+
+  return (
+    <>
+      <Helmet title={`搜索: ${routeKeyword}`} />
+      <div className={searchBand}>
+        <form className={searchForm} onSubmit={handleSearch}>
+          <label htmlFor='mono-search-input'>人物搜索</label>
+          <input
+            id='mono-search-input'
+            name='search_text'
+            type='search'
+            value={searchValue}
+            onChange={(event) => setSearchValue(event.target.value)}
+          />
+          <button type='submit'>
+            <Search />
+            <span>搜索</span>
+          </button>
+        </form>
+      </div>
+
+      <main className={page}>
+        <nav className={categories} aria-label='搜索分类'>
+          <ul>
+            <li className={categoryRoot}>条目</li>
+            <li>
+              <Link to={`/subject_search/${keywordParam}?cat=all`}>全部</Link>
+            </li>
+            <li>
+              <Link to={`/subject_search/${keywordParam}?cat=2`}>动画</Link>
+            </li>
+            <li>
+              <Link to={`/subject_search/${keywordParam}?cat=1`}>书籍</Link>
+            </li>
+            <li>
+              <Link to={`/subject_search/${keywordParam}?cat=4`}>游戏</Link>
+            </li>
+            <li className={categoryRoot}>人物</li>
+            <li>
+              <Link
+                className={category === 'crt' ? categorySelected : undefined}
+                to={`/mono_search/${keywordParam}?cat=crt`}
+              >
+                虚构角色
+              </Link>
+            </li>
+            <li>
+              <Link
+                className={category === 'prsn' ? categorySelected : undefined}
+                to={`/mono_search/${keywordParam}?cat=prsn`}
+              >
+                现实人物
+              </Link>
+            </li>
+            <li>
+              <Link
+                className={category === 'all' ? categorySelected : undefined}
+                to={`/mono_search/${keywordParam}?cat=all`}
+              >
+                全部
+              </Link>
+            </li>
+          </ul>
+        </nav>
+
+        <section className={results} aria-label='搜索结果'>
+          <div className={monoTabs}>
+            <Link
+              className={showCharacters ? categorySelected : undefined}
+              to={`/mono_search/${keywordParam}?cat=${category === 'prsn' ? 'all' : 'crt'}`}
+            >
+              角色
+            </Link>
+            <Link
+              className={showPersons ? categorySelected : undefined}
+              to={`/mono_search/${keywordParam}?cat=prsn`}
+            >
+              人物
+            </Link>
+          </div>
+          {category === 'prsn' && (
+            <div className={careerFilter}>
+              <span>职业筛选：</span>
+              <select
+                value={career ?? ''}
+                onChange={(event) => {
+                  const nextCareer = event.target.value;
+                  setSearchParams((params) => {
+                    if (nextCareer) {
+                      params.set('career', nextCareer);
+                    } else {
+                      params.delete('career');
+                    }
+                    params.delete('page');
+                    return params;
+                  });
+                }}
+              >
+                {PERSON_CAREERS.map((item) => (
+                  <option key={item.value} value={item.value}>
+                    {item.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+          {showCharacters && (
+            <>
+              <div className={resultTools}>
+                <span>找到 {characterTotal} 个角色</span>
+              </div>
+              {characters.length > 0 ? (
+                <ul className={resultsGrid}>
+                  {characters.map((character) => (
+                    <CharacterCard key={character.id} character={character} />
+                  ))}
+                </ul>
+              ) : (
+                <p className={empty}>没有找到相关角色</p>
+              )}
+            </>
+          )}
+          {showPersons && (
+            <>
+              <div className={resultTools}>
+                <span>找到 {personTotal} 个现实人物</span>
+              </div>
+              {persons.length > 0 ? (
+                <ul className={resultsGrid}>
+                  {persons.map((person) => (
+                    <PersonCard key={person.id} person={person} />
+                  ))}
+                </ul>
+              ) : (
+                <p className={empty}>没有找到相关现实人物</p>
+              )}
+            </>
+          )}
+          <Pagination
+            key={curPage}
+            wrapperClass={pagination}
+            total={category === 'prsn' ? personTotal : characterTotal}
+            pageSize={PAGE_SIZE}
+            currentPage={curPage}
+            onChange={handlePageChange}
+          />
+        </section>
+
+        <aside className={css({ '@media (max-width: 768px)': { display: 'none' } })}>
+          <a
+            href={getLegacyPageLink(
+              `/mono_search/${keywordParam}?cat=${category === 'prsn' ? 'prsn' : 'crt'}`,
+            )}
+            style={{ color: '#54b5df', fontSize: '12px', textDecoration: 'none' }}
+          >
+            前往旧版页面
+          </a>
+        </aside>
+      </main>
+    </>
+  );
+}
+
+export default withErrorBoundary(MonoSearchPage);

--- a/packages/website/src/routes.tsx
+++ b/packages/website/src/routes.tsx
@@ -54,6 +54,7 @@ const SubjectBoard = lazy(async () => import('./pages/index/subject/[id]/board')
 const SubjectComments = lazy(async () => import('./pages/index/subject/[id]/comments'));
 const SubjectReviews = lazy(async () => import('./pages/index/subject/[id]/reviews'));
 const SubjectSearch = lazy(async () => import('./pages/index/subject_search/[keyword]'));
+const MonoSearch = lazy(async () => import('./pages/index/mono_search/[keyword]'));
 const SubjectTopic = lazy(async () => import('./pages/index/subject/topic/[id]'));
 const SubjectTopicEdit = lazy(async () => import('./pages/index/subject/topic/[id]/edit'));
 const SubjectTopicHome = lazy(async () => import('./pages/index/subject/topic/[id]/index'));
@@ -268,6 +269,10 @@ export const pageRoutes: RouteObject[] = [
       {
         path: 'subject_search/:keyword',
         element: <SubjectSearch />,
+      },
+      {
+        path: 'mono_search/:keyword',
+        element: <MonoSearch />,
       },
       {
         path: 'user',


### PR DESCRIPTION
## 变更
- 新增 `/mono_search/:keyword` 页面（对齐旧站 /mono_search 形态）：分类切换（虚构角色 crt / 现实人物 prsn / 全部 all）
- 角色/人物结果卡片网格：封面（或占位）、中文名、日文名、简介；分页（15/页）
- 人物 tab 提供职业筛选（PersonSearchFilter.career：producer/mangaka/seiyu/writer/illustrator/actor）
- Header 搜索入口接通：桌面端 select+输入框表单（原为 Search Todo 占位）、移动端分类加"人物"选项；人物 → /mono_search，其余 → /subject_search
- 结果侧栏保留旧版页面链接

## 取舍说明
- 采用旧站 /mono_search 单页 + cat 切换形态（而非独立 /character/search、/person/search 两页），与 subject_search 分类侧栏一致，URL 与旧站兼容
- 角色类型筛选未做：后端 CharacterSearchFilter 仅支持 nsfw，无角色类型过滤字段
- legacyPagePaths 未加 mono_search：新版同路径实现，旧 URL 直接命中新路由

## 测试
- MonoSearchPage.spec：角色结果渲染+分页、人物结果+职业筛选（2 用例）
- 本地：lint / type-check / prettier / test（395 passed）/ build 全绿