### PR TITLE
feat(website): unify search page UI with shared SearchPage component

### DIFF
--- a/packages/styled-system/styles.css
+++ b/packages/styled-system/styles.css
@@ -696,6 +696,42 @@
     padding: 24px 30px;
 }
 
+  .bg_\#f7f8fa {
+    background: #f7f8fa;
+}
+
+  .p_18px_0_12px {
+    padding: 18px 0 12px;
+}
+
+  .p_28px_0_64px {
+    padding: 28px 0 64px;
+}
+
+  .p_80px_20px {
+    padding: 80px 20px;
+}
+
+  .m_28px_0_0 {
+    margin: 28px 0 0;
+}
+
+  .p_16px {
+    padding: 16px;
+}
+
+  .bd_1px_solid_\#e8e5e6 {
+    border: 1px solid #e8e5e6;
+}
+
+  .bg_\#fff {
+    background: #fff;
+}
+
+  .m_0_0_14px {
+    margin: 0 0 14px;
+}
+
   .p_9px_0 {
     padding: 9px 0;
 }
@@ -916,10 +952,6 @@
     border: 1px solid #d8d3d3;
 }
 
-  .bg_\#fff {
-    background: #fff;
-}
-
   .p_8px {
     padding: 8px;
 }
@@ -974,10 +1006,6 @@
 
   .bd_1px_solid_\#ccc {
     border: 1px solid #ccc;
-}
-
-  .p_16px {
-    padding: 16px;
 }
 
   .bg_\#fafafa {
@@ -1184,36 +1212,24 @@
     padding: 1px 6px;
 }
 
-  .p_20px_0_40px {
-    padding: 20px 0 40px;
+  .p_12px_14px {
+    padding: 12px 14px;
 }
 
-  .m_0_-2px {
-    margin: 0 -2px;
+  .bd_1px_solid_\#eee9ea {
+    border: 1px solid #eee9ea;
 }
 
-  .p_6px_14px_5px {
-    padding: 6px 14px 5px;
+  .bg_\#faf9f9 {
+    background: #faf9f9;
 }
 
-  .p_0_4px_5px {
-    padding: 0 4px 5px;
+  .p_24px_0_4px {
+    padding: 24px 0 4px;
 }
 
-  .p_10px_0_8px {
-    padding: 10px 0 8px;
-}
-
-  .p_0_4px_8px {
-    padding: 0 4px 8px;
-}
-
-  .p_50px_20px {
-    padding: 50px 20px;
-}
-
-  .m_20px_0_0 {
-    margin: 20px 0 0;
+  .bg_\#eee9ea {
+    background: #eee9ea;
 }
 
   .p_2px {
@@ -1244,8 +1260,8 @@
     padding: 24px 0;
 }
 
-  .bg_\#54b5df {
-    background: #54b5df;
+  .bd_1px_solid_\#ded9da {
+    border: 1px solid #ded9da;
 }
 
   .bd_1px_solid_\#c6d0d4 {
@@ -1256,8 +1272,24 @@
     background: #08a9ef;
 }
 
-  .p_7px_5px {
-    padding: 7px 5px;
+  .p_20px_0 {
+    padding: 20px 0;
+}
+
+  .p_18px_6px {
+    padding: 18px 6px;
+}
+
+  .p_12px_6px {
+    padding: 12px 6px;
+}
+
+  .p_14px_16px {
+    padding: 14px 16px;
+}
+
+  .bg_\#fff8f8 {
+    background: #fff8f8;
 }
 
   .p_7px_16px {
@@ -1350,6 +1382,10 @@
 
   .bg_\#9f9b9b {
     background: #9f9b9b;
+}
+
+  .bg_\#54b5df {
+    background: #54b5df;
 }
 
   .bg_\#e0dcdc {
@@ -1608,6 +1644,50 @@
     border-radius: 9999px;
 }
 
+  .bd-b_1px_solid_\#e8e5e6 {
+    border-bottom: 1px solid #e8e5e6;
+}
+
+  .gap_18px {
+    gap: 18px;
+}
+
+  .flex_0_0_180px {
+    flex: 0 0 180px;
+}
+
+  .flex_1 {
+    flex: 1 1 0%;
+}
+
+  .bd-t_1px_solid_\#e5e1e2 {
+    border-top: 1px solid #e5e1e2;
+}
+
+  .gap_6px {
+    gap: 6px;
+}
+
+  .gap_36px {
+    gap: 36px;
+}
+
+  .gap_16px {
+    gap: 16px;
+}
+
+  .gap_14px {
+    gap: 14px;
+}
+
+  .bdr_6px {
+    border-radius: 6px;
+}
+
+  .bd-b_1px_solid_\#eee9ea {
+    border-bottom: 1px solid #eee9ea;
+}
+
   .bdr_19px {
     border-radius: 19px;
 }
@@ -1664,10 +1744,6 @@
     border-bottom: 1px dashed #e8e3e3;
 }
 
-  .bdr_6px {
-    border-radius: 6px;
-}
-
   .gap_4px {
     gap: 4px;
 }
@@ -1692,20 +1768,12 @@
     flex: 0 0 48px;
 }
 
-  .flex_1 {
-    flex: 1 1 0%;
-}
-
   .gap_28px {
     gap: 28px;
 }
 
   .flex_0_0_auto {
     flex: 0 0 auto;
-}
-
-  .gap_6px {
-    gap: 6px;
 }
 
   .flex_0_0_56px {
@@ -1780,10 +1848,6 @@
     border-radius: inherit;
 }
 
-  .gap_14px {
-    gap: 14px;
-}
-
   .bdr_9px {
     border-radius: 9px;
 }
@@ -1844,12 +1908,12 @@
     flex: 0 0 40px;
 }
 
-  .gap_16px {
-    gap: 16px;
+  .gap_30px_20px {
+    gap: 30px 20px;
 }
 
-  .gap_18px_12px {
-    gap: 18px 12px;
+  .bd-r_1px_solid_\#e8e5e6 {
+    border-right: 1px solid #e8e5e6;
 }
 
   .flex_0_1_auto {
@@ -1860,16 +1924,12 @@
     gap: 1px;
 }
 
-  .gap_16px_10px {
-    gap: 16px 10px;
+  .gap_24px_14px {
+    gap: 24px 14px;
 }
 
-  .gap_18px {
-    gap: 18px;
-}
-
-  .gap_10px_4px {
-    gap: 10px 4px;
+  .gap_14px_8px {
+    gap: 14px 8px;
 }
 
   .gap_2px {
@@ -2277,6 +2337,46 @@
     border-inline-end-width: var(--thickness);
 }
 
+  .fs_18px {
+    font-size: 18px;
+}
+
+  .fw_650 {
+    font-weight: 650;
+}
+
+  .lh_26px {
+    line-height: 26px;
+}
+
+  .scr-bar-w_none {
+    scrollbar-width: none;
+}
+
+  .d_grid {
+    display: grid;
+}
+
+  .grid-tc_minmax\(0\,_1fr\)_260px {
+    grid-template-columns: minmax(0, 1fr) 260px;
+}
+
+  .c_\#8c8587 {
+    color: #8c8587;
+}
+
+  .as_start {
+    align-self: start;
+}
+
+  .bx-sh_0_2px_10px_rgba\(48\,_44\,_45\,_0\.04\) {
+    box-shadow: 0 2px 10px rgba(48, 44, 45, 0.04);
+}
+
+  .c_\#302c2d {
+    color: #302c2d;
+}
+
   .resize_vertical {
     resize: vertical;
 }
@@ -2301,20 +2401,12 @@
     font-size: 26px;
 }
 
-  .fs_18px {
-    font-size: 18px;
-}
-
   .lh_1\.8 {
     line-height: 1.8;
 }
 
   .wb_break-all {
     word-break: break-all;
-}
-
-  .d_grid {
-    display: grid;
 }
 
   .grid-tc_minmax\(0\,_2fr\)_minmax\(0\,_1fr\) {
@@ -2451,10 +2543,6 @@
 
   .lh_1\.3 {
     line-height: 1.3;
-}
-
-  .scr-bar-w_none {
-    scrollbar-width: none;
 }
 
   .c_\#888 {
@@ -2658,24 +2746,16 @@
     line-height: 17px;
 }
 
-  .grid-tc_100px_minmax\(0\,_655px\)_200px {
-    grid-template-columns: 100px minmax(0, 655px) 200px;
+  .grid-tc_repeat\(5\,_minmax\(0\,_1fr\)\) {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
 }
 
-  .as_start {
-    align-self: start;
+  .asp_4_\/_5 {
+    aspect-ratio: 4 / 5;
 }
 
-  .grid-tc_repeat\(4\,_minmax\(0\,_1fr\)\) {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-}
-
-  .asp_1_\/_1\.2 {
-    aspect-ratio: 1 / 1.2;
-}
-
-  .bx-sh_0_1px_4px_rgba\(0\,_0\,_0\,_0\.22\) {
-    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.22);
+  .bx-sh_0_3px_12px_rgba\(48\,_44\,_45\,_0\.14\) {
+    box-shadow: 0 3px 12px rgba(48, 44, 45, 0.14);
 }
 
   .grid-tc_minmax\(220px\,_1fr\)_minmax\(260px\,_1\.15fr\) {
@@ -2702,6 +2782,14 @@
     aspect-ratio: 5 / 7;
 }
 
+  .bx-sh_0_3px_10px_rgba\(48\,_44\,_45\,_0\.16\) {
+    box-shadow: 0 3px 10px rgba(48, 44, 45, 0.16);
+}
+
+  .bx-sh_0_3px_10px_rgba\(48\,_44\,_45\,_0\.12\) {
+    box-shadow: 0 3px 10px rgba(48, 44, 45, 0.12);
+}
+
   .c_\#bbb {
     color: #bbb;
 }
@@ -2714,16 +2802,12 @@
     color: #f09b2d;
 }
 
-  .grid-tc_repeat\(auto-fill\,_minmax\(105px\,_1fr\)\) {
-    grid-template-columns: repeat(auto-fill, minmax(105px, 1fr));
+  .grid-tc_repeat\(auto-fill\,_minmax\(120px\,_1fr\)\) {
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
 }
 
   .trf_translateX\(52px\) {
     transform: translateX(52px);
-}
-
-  .bx-sh_0_1px_5px_rgba\(50\,_46\,_46\,_0\.06\) {
-    box-shadow: 0 1px 5px rgba(50, 46, 46, 0.06);
 }
 
   .grid-tc_repeat\(3\,_minmax\(0\,_1fr\)\) {
@@ -2804,10 +2888,6 @@
 
   .lh_40px {
     line-height: 40px;
-}
-
-  .grid-tc_repeat\(5\,_minmax\(0\,_1fr\)\) {
-    grid-template-columns: repeat(5, minmax(0, 1fr));
 }
 
   .c_\#f68ab1 {
@@ -3199,6 +3279,38 @@
     padding-bottom: var(--spacing-0);
 }
 
+  .w_1120px {
+    width: 1120px;
+}
+
+  .max-w_760px {
+    max-width: 760px;
+}
+
+  .ov-x_auto {
+    overflow-x: auto;
+}
+
+  .pt_14px {
+    padding-top: 14px;
+}
+
+  .min-h_42px {
+    min-height: 42px;
+}
+
+  .pb_12px {
+    padding-bottom: 12px;
+}
+
+  .min-h_260px {
+    min-height: 260px;
+}
+
+  .pb_10px {
+    padding-bottom: 10px;
+}
+
   .min-h_500px {
     min-height: 500px;
 }
@@ -3269,10 +3381,6 @@
 
   .pt_5px {
     padding-top: 5px;
-}
-
-  .ov-x_auto {
-    overflow-x: auto;
 }
 
   .w_100px {
@@ -3571,10 +3679,6 @@
     margin-top: 8px;
 }
 
-  .min-h_42px {
-    min-height: 42px;
-}
-
   .min-w_62px {
     min-width: 62px;
 }
@@ -3743,16 +3847,12 @@
     width: 140px;
 }
 
-  .w_980px {
-    width: 980px;
+  .mb_18px {
+    margin-bottom: 18px;
 }
 
-  .min-h_24px {
-    min-height: 24px;
-}
-
-  .min-h_240px {
-    min-height: 240px;
+  .mt_28px {
+    margin-top: 28px;
 }
 
   .pb_0\! {
@@ -3783,6 +3883,14 @@
     min-height: 58px;
 }
 
+  .w_34px {
+    width: 34px;
+}
+
+  .w_96px {
+    width: 96px;
+}
+
   .w_8px {
     width: 8px;
 }
@@ -3807,16 +3915,20 @@
     right: 8px;
 }
 
-  .min-h_126px {
-    min-height: 126px;
+  .min-h_164px {
+    min-height: 164px;
 }
 
-  .min-h_82px {
-    min-height: 82px;
+  .min-h_94px {
+    min-height: 94px;
 }
 
-  .w_105px {
-    width: 105px;
+  .w_52px {
+    width: 52px;
+}
+
+  .w_120px {
+    width: 120px;
 }
 
   .pt_1px {
@@ -3893,10 +4005,6 @@
 
   .mb_23px {
     margin-bottom: 23px;
-}
-
-  .w_120px {
-    width: 120px;
 }
 
   .mb_4px {
@@ -3999,6 +4107,10 @@
     height: 38px;
 }
 
+  .min-h_126px {
+    min-height: 126px;
+}
+
   .top_14px {
     top: 14px;
 }
@@ -4033,10 +4145,6 @@
 
   .min-h_162px {
     min-height: 162px;
-}
-
-  .w_34px {
-    width: 34px;
 }
 
   .mr_3px {
@@ -4135,7 +4243,47 @@
     background: #f7f7f7;
 }
 
-  .\[\&_h1\]\:m_0 h1 {
+  .\[\&_label\]\:p_0 label {
+    padding: var(--spacing-0);
+}
+
+  .\[\&_label\]\:bd_0 label {
+    border: 0;
+}
+
+  .\[\&_input\]\:p_0_14px input {
+    padding: 0 14px;
+}
+
+  .\[\&_input\]\:bd_1px_solid_\#d8d3d5 input {
+    border: 1px solid #d8d3d5;
+}
+
+  .\[\&_input\]\:bg_\#fff input {
+    background: #fff;
+}
+
+  .\[\&_button\]\:p_0_20px button {
+    padding: 0 20px;
+}
+
+  .\[\&_button\]\:bg_\#f09199 button {
+    background: #f09199;
+}
+
+  .\[\&_a\]\:p_0_10px a {
+    padding: 0 10px;
+}
+
+  .\[\&_h2\]\:m_0 h2 {
+    margin: var(--spacing-0);
+}
+
+  .\[\&_p\]\:m_2px_0_0 p {
+    margin: 2px 0 0;
+}
+
+  .\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:m_0 .bgm-pagination-prev,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:m_0 .bgm-pagination-next,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:m_0 .bgm-pagination-pager,.\[\&_h1\]\:m_0 h1 {
     margin: var(--spacing-0);
 }
 
@@ -4207,10 +4355,6 @@
     padding: 10px 5px;
 }
 
-  .\[\&_h2\]\:m_0 h2 {
-    margin: var(--spacing-0);
-}
-
   .\[\&_a\]\:bg_\#fff6f7 a {
     background: #fff6f7;
 }
@@ -4231,64 +4375,20 @@
     background: #fff;
 }
 
-  .\[\&_p\]\:m_2px_0_0 p {
-    margin: 2px 0 0;
-}
-
   .\[\&_h3\]\:m_0_0_5px h3 {
     margin: 0 0 5px;
-}
-
-  .\[\&_input\]\:p_6px_10px input {
-    padding: 6px 10px;
-}
-
-  .\[\&_input\]\:bd_1px_solid_\#ccc input {
-    border: 1px solid #ccc;
-}
-
-  .\[\&_input\]\:bg_\#fff input {
-    background: #fff;
-}
-
-  .\[\&_button\]\:p_0_16px button {
-    padding: 0 16px;
-}
-
-  .\[\&_button\]\:bg_\#54b5df button {
-    background: #54b5df;
-}
-
-  .\[\&_ul\]\:m_0 ul {
-    margin: var(--spacing-0);
-}
-
-  .\[\&_ul\]\:p_0_2px_5px ul {
-    padding: 0 2px 5px;
-}
-
-  .\[\&_ul\]\:bd_1px_solid_\#e8e3e3 ul {
-    border: 1px solid #e8e3e3;
-}
-
-  .\[\&_ul\]\:bg_\#fff ul {
-    background: #fff;
-}
-
-  .\[\&_li_a\]\:m_5px_0 li a {
-    margin: 5px 0;
-}
-
-  .\[\&_li_a\]\:p_3px_12px li a {
-    padding: 3px 12px;
 }
 
   .\[\&\[class\]\]\:bg_\#f09199[class] {
     background: #f09199;
 }
 
-  .\[\&_select\]\:p_0_6px select {
-    padding: 0 6px;
+  .\[\&_a\]\:p_0_13px a {
+    padding: 0 13px;
+}
+
+  .\[\&_select\]\:p_0_9px select {
+    padding: 0 9px;
 }
 
   .\[\&_select\]\:bd_1px_solid_\#e8e3e3 select {
@@ -4297,10 +4397,6 @@
 
   .\[\&_select\]\:bg_\#fff select {
     background: #fff;
-}
-
-  .\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:m_0 .bgm-pagination-prev,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:m_0 .bgm-pagination-next,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:m_0 .bgm-pagination-pager {
-    margin: var(--spacing-0);
 }
 
   .\[\&_\>_li\]\:p_5px > li {
@@ -4327,8 +4423,12 @@
     padding: 8px 4px;
 }
 
-  .\[\&_h2\]\:m_0_0_8px h2 {
-    margin: 0 0 8px;
+  .\[\&_\>_li\]\:p_18px_6px > li {
+    padding: 18px 6px;
+}
+
+  .\[\&_\>_li\]\:p_12px_6px > li {
+    padding: 12px 6px;
 }
 
   .\[\&\[class\]\]\:bd_1px_solid_\#e8e3e3[class] {
@@ -4563,6 +4663,46 @@
     border-color: #f09199 !important;
 }
 
+  .\[\&_label\]\:ov_hidden label {
+    overflow: hidden;
+}
+
+  .\[\&_input\]\:flex_1 input {
+    flex: 1 1 0%;
+}
+
+  .\[\&_input\]\:bdr_6px input {
+    border-radius: 6px;
+}
+
+  .\[\&_input\]\:ring_none input {
+    outline: var(--borders-none);
+}
+
+  .\[\&_button\]\:gap_7px button {
+    gap: 7px;
+}
+
+  .\[\&_button\]\:bdr_6px button {
+    border-radius: 6px;
+}
+
+  .\[\&_\>_div\]\:gap_24px > div {
+    gap: 24px;
+}
+
+  .\[\&_a\]\:bdr_5px a {
+    border-radius: 5px;
+}
+
+  .\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:bd-w_1px .bgm-pagination-prev,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:bd-w_1px .bgm-pagination-next,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:bd-w_1px .bgm-pagination-pager {
+    border-width: 1px;
+}
+
+  .\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:bdr_6px .bgm-pagination-prev,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:bdr_6px .bgm-pagination-next,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:bdr_6px .bgm-pagination-pager {
+    border-radius: 6px;
+}
+
   .\[\&_p\]\:ov_hidden p,.\[\&_small\]\:ov_hidden small {
     overflow: hidden;
 }
@@ -4691,60 +4831,12 @@
     overflow: hidden;
 }
 
-  .\[\&_input\]\:bdr_4px input {
-    border-radius: 4px;
-}
-
-  .\[\&_input\]\:ring_none input {
-    outline: var(--borders-none);
-}
-
-  .\[\&_button\]\:gap_5px button {
-    gap: 5px;
-}
-
-  .\[\&_button\]\:bdr_4px button {
-    border-radius: 4px;
-}
-
-  .\[\&_ul\]\:ov_hidden ul {
-    overflow: hidden;
-}
-
-  .\[\&_ul\]\:bdr_8px ul {
-    border-radius: 8px;
-}
-
-  .\[\&_ul\]\:li-s_none ul {
-    list-style: none;
-}
-
-  .\[\&_li_a\]\:bdr_999px li a {
-    border-radius: 999px;
-}
-
-  .\[\&_li_a\]\:td_none li a {
-    text-decoration: none;
-}
-
   .\[\&_select\]\:bdr_4px select {
     border-radius: 4px;
 }
 
   .\[\&_select\]\:ring_none select {
     outline: var(--borders-none);
-}
-
-  .\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:bd-w_1px .bgm-pagination-prev,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:bd-w_1px .bgm-pagination-next,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:bd-w_1px .bgm-pagination-pager {
-    border-width: 1px;
-}
-
-  .\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:bdr_50\% .bgm-pagination-prev,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:bdr_50\% .bgm-pagination-next,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:bdr_50\% .bgm-pagination-pager {
-    border-radius: 50%;
-}
-
-  .\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\]\:bdr_13px .bgm-pagination-prev,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\]\:bdr_13px .bgm-pagination-next {
-    border-radius: 13px;
 }
 
   .\[\&_li\]\:bd-t_1px_solid_\#e8e3e3 li {
@@ -4763,16 +4855,12 @@
     text-decoration: none;
 }
 
-  .\[\&_\>_li\]\:gap_18px > li {
-    gap: 18px;
+  .\[\&_\>_li\]\:gap_20px > li {
+    gap: 20px;
 }
 
   .\[\&_\>_li\]\:gap_14px > li {
     gap: 14px;
-}
-
-  .\[\&_h2\]\:bd-b_1px_solid_\#e8e3e3 h2 {
-    border-bottom: 1px solid #e8e3e3;
 }
 
   .\[\&\[class\]\]\:flex_0_0_120px[class] {
@@ -5131,6 +5219,130 @@
     font-weight: 600;
 }
 
+  .\[\&_label\]\:pos_absolute label {
+    position: absolute;
+}
+
+  .\[\&_label\]\:clip_rect\(0\,_0\,_0\,_0\) label {
+    clip: rect(0, 0, 0, 0);
+}
+
+  .\[\&_label\]\:white-space_nowrap label {
+    white-space: nowrap;
+}
+
+  .\[\&_input\]\:c_\#302c2d input {
+    color: #302c2d;
+}
+
+  .\[\&_input\]\:fs_15px input {
+    font-size: 15px;
+}
+
+  .\[\&_input\]\:bx-sh_0_1px_2px_rgba\(48\,_44\,_45\,_0\.04\) input {
+    box-shadow: 0 1px 2px rgba(48, 44, 45, 0.04);
+}
+
+  .\[\&_button\]\:d_inline-flex button {
+    display: inline-flex;
+}
+
+  .\[\&_button\]\:ai_center button {
+    align-items: center;
+}
+
+  .\[\&_button\]\:jc_center button {
+    justify-content: center;
+}
+
+  .\[\&_button\]\:fs_14px button {
+    font-size: 14px;
+}
+
+  .\[\&_button\]\:fw_600 button {
+    font-weight: 600;
+}
+
+  .\[\&\:\:-webkit-scrollbar\]\:d_none::-webkit-scrollbar {
+    display: none;
+}
+
+  .\[\&_\>_div\]\:d_flex > div {
+    display: flex;
+}
+
+  .\[\&_\>_div\]\:ai_center > div {
+    align-items: center;
+}
+
+  .\[\&_\>_span\]\:c_\#8c8587 > span {
+    color: #8c8587;
+}
+
+  .\[\&_\>_span\]\:fs_12px > span {
+    font-size: 12px;
+}
+
+  .\[\&_\>_span\]\:fw_600 > span {
+    font-weight: 600;
+}
+
+  .\[\&_\>_span\]\:white-space_nowrap > span {
+    white-space: nowrap;
+}
+
+  .\[\&_a\]\:d_inline-flex a {
+    display: inline-flex;
+}
+
+  .\[\&_a\]\:ai_center a {
+    align-items: center;
+}
+
+  .\[\&_a\]\:c_\#5f595b a {
+    color: #5f595b;
+}
+
+  .\[\&_a\]\:fs_13px a {
+    font-size: 13px;
+}
+
+  .\[\&_a\]\:white-space_nowrap a {
+    white-space: nowrap;
+}
+
+  .\[\&_h2\]\:c_\#302c2d h2 {
+    color: #302c2d;
+}
+
+  .\[\&_h2\]\:fs_19px h2 {
+    font-size: 19px;
+}
+
+  .\[\&_h2\]\:fw_650 h2 {
+    font-weight: 650;
+}
+
+  .\[\&_h2\]\:lh_26px h2 {
+    line-height: 26px;
+}
+
+  .\[\&_p\]\:c_\#8c8587 p {
+    color: #8c8587;
+}
+
+  .\[\&_p\]\:fs_12px p {
+    font-size: 12px;
+}
+
+  .\[\&_p\]\:lh_18px p {
+    line-height: 18px;
+}
+
+  .\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:fs_12px .bgm-pagination-prev,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:fs_12px .bgm-pagination-next,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:fs_12px .bgm-pagination-pager {
+    font-size: 12px;
+}
+
   .\[\&_div\]\:ta_center div {
     text-align: center;
 }
@@ -5177,10 +5389,6 @@
 
   .\[\&_p\]\:fs_13px p {
     font-size: 13px;
-}
-
-  .\[\&_p\]\:lh_18px p {
-    line-height: 18px;
 }
 
   .\[\&_p\]\:tov_ellipsis p {
@@ -5235,10 +5443,6 @@
     text-overflow: ellipsis;
 }
 
-  .\[\&_a\]\:white-space_nowrap a {
-    white-space: nowrap;
-}
-
   .\[\&_time\]\:d_block time {
     display: block;
 }
@@ -5275,10 +5479,6 @@
     box-sizing: border-box;
 }
 
-  .\[\&_a\]\:fs_13px a {
-    font-size: 13px;
-}
-
   .\[\&_a\]\:ta_center a {
     text-align: center;
 }
@@ -5303,10 +5503,6 @@
     color: #1f1c1c;
 }
 
-  .\[\&_p\]\:fs_12px p {
-    font-size: 12px;
-}
-
   .\[\&_\.bgm-link\]\:c_\#0084b4 .bgm-link {
     color: #0084b4;
 }
@@ -5325,10 +5521,6 @@
 
   .\[\&_small\]\:fw_normal small {
     font-weight: var(--font-weights-normal);
-}
-
-  .\[\&\:\:-webkit-scrollbar\]\:d_none::-webkit-scrollbar {
-    display: none;
 }
 
   .\[\&_button\]\:c_\#f09199 button {
@@ -5471,10 +5663,6 @@
     font-size: 13px;
 }
 
-  .\[\&_\>_div\]\:d_flex > div {
-    display: flex;
-}
-
   .\[\&_\>_div\]\:flex-d_column > div {
     flex-direction: column;
 }
@@ -5505,10 +5693,6 @@
 
   .\[\&_\>_a\]\:lh_22px > a {
     line-height: 22px;
-}
-
-  .\[\&_\>_span\]\:fs_12px > span {
-    font-size: 12px;
 }
 
   .\[\&_\>_span\]\:lh_17px > span {
@@ -5583,72 +5767,12 @@
     line-height: 18px;
 }
 
-  .\[\&_label\]\:c_\#595555 label {
-    color: #595555;
-}
-
-  .\[\&_label\]\:fs_16px label {
-    font-size: 16px;
-}
-
-  .\[\&_label\]\:fw_600 label {
-    font-weight: 600;
-}
-
-  .\[\&_label\]\:lh_35px label {
-    line-height: 35px;
-}
-
-  .\[\&_label\]\:ta_right label {
-    text-align: right;
-}
-
-  .\[\&_input\]\:c_\#1f1c1c input {
-    color: #1f1c1c;
-}
-
-  .\[\&_input\]\:fs_14px input {
-    font-size: 14px;
-}
-
-  .\[\&_input\]\:bx-sh_inset_0_1px_2px_rgba\(0\,_0\,_0\,_0\.08\) input {
-    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.08);
-}
-
-  .\[\&_button\]\:d_inline-flex button {
-    display: inline-flex;
-}
-
-  .\[\&_button\]\:ai_center button {
-    align-items: center;
-}
-
-  .\[\&_button\]\:jc_center button {
-    justify-content: center;
-}
-
-  .\[\&_ul\]\:bx-sh_0_1px_5px_rgba\(50\,_46\,_46\,_0\.08\) ul {
-    box-shadow: 0 1px 5px rgba(50, 46, 46, 0.08);
-}
-
-  .\[\&_li_a\]\:d_block li a {
-    display: block;
-}
-
-  .\[\&_li_a\]\:c_\#54b5df li a {
-    color: #54b5df;
-}
-
-  .\[\&_li_a\]\:fs_13px li a {
-    font-size: 13px;
-}
-
-  .\[\&_li_a\]\:lh_18px li a {
-    line-height: 18px;
-}
-
   .\[\&\[class\]\]\:c_\#fff[class] {
     color: #fff;
+}
+
+  .\[\&_a\]\:c_\#716b6d a {
+    color: #716b6d;
 }
 
   .\[\&_select\]\:c_\#595555 select {
@@ -5657,10 +5781,6 @@
 
   .\[\&_select\]\:fs_12px select {
     font-size: 12px;
-}
-
-  .\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:fs_11px .bgm-pagination-prev,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:fs_11px .bgm-pagination-next,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:fs_11px .bgm-pagination-pager {
-    font-size: 11px;
 }
 
   .\[\&_\>_li\]\:lh_1\.4 > li {
@@ -5691,8 +5811,12 @@
     overflow-wrap: anywhere;
 }
 
-  .\[\&_\>_a\]\:c_\#54b5df > a {
-    color: #54b5df;
+  .\[\&_\>_a\]\:c_\#1f1c1c > a {
+    color: #1f1c1c;
+}
+
+  .\[\&_\>_a\]\:fw_650 > a {
+    font-weight: 650;
 }
 
   .\[\&_svg\]\:fill_\#f6a623 svg {
@@ -5703,28 +5827,12 @@
     box-sizing: border-box;
 }
 
-  .\[\&_h2\]\:c_\#9f9b9b h2 {
-    color: #9f9b9b;
-}
-
-  .\[\&_h2\]\:fs_12px h2 {
-    font-size: 12px;
-}
-
-  .\[\&_h2\]\:fw_500 h2 {
-    font-weight: 500;
-}
-
   .\[\&_a\]\:d_flex a {
     display: flex;
 }
 
   .\[\&_a\]\:flex-d_column a {
     flex-direction: column;
-}
-
-  .\[\&_a\]\:ai_center a {
-    align-items: center;
 }
 
   .\[\&_a\]\:fs_11px a {
@@ -5851,10 +5959,6 @@
     color: #9f9b9b;
 }
 
-  .\[\&_button\]\:fs_14px button {
-    font-size: 14px;
-}
-
   .\[\&_button\]\:lh_20px button {
     line-height: 20px;
 }
@@ -5897,10 +6001,6 @@
 
   .\[\&_\>_span\]\:tov_ellipsis > span {
     text-overflow: ellipsis;
-}
-
-  .\[\&_\>_span\]\:white-space_nowrap > span {
-    white-space: nowrap;
 }
 
   .\[\&_img\]\:obj-f_contain img {
@@ -6598,7 +6698,63 @@
     padding-left: 12px;
 }
 
-  .\[\&_\>_\.bgm-menu-item\]\:w_100\% > .bgm-menu-item,.\[\&_\>_\*\]\:w_100\% > * {
+  .\[\&_\>_\.bgm-menu-item\]\:w_100\% > .bgm-menu-item {
+    width: 100%;
+}
+
+  .\[\&_label\]\:w_1px label {
+    width: 1px;
+}
+
+  .\[\&_label\]\:h_1px label {
+    height: 1px;
+}
+
+  .\[\&_input\]\:min-w_0 input {
+    min-width: var(--sizes-0);
+}
+
+  .\[\&_input\]\:h_44px input,.\[\&_button\]\:h_44px button {
+    height: 44px;
+}
+
+  .\[\&_\>_div\]\:w_max-content > div {
+    width: max-content;
+}
+
+  .\[\&_\>_span\]\:mr_2px > span {
+    margin-right: 2px;
+}
+
+  .\[\&_a\]\:min-h_30px a {
+    min-height: 30px;
+}
+
+  .\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:w_32px .bgm-pagination-prev,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:w_32px .bgm-pagination-next,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:w_32px .bgm-pagination-pager {
+    width: 32px;
+}
+
+  .\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:h_32px .bgm-pagination-prev,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:h_32px .bgm-pagination-next,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:h_32px .bgm-pagination-pager {
+    height: 32px;
+}
+
+  .\[\&_\.bgm-pagination-pager_\+_\.bgm-pagination-pager\]\:ml_0 .bgm-pagination-pager + .bgm-pagination-pager {
+    margin-left: var(--spacing-0);
+}
+
+  .\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\]\:w_38px .bgm-pagination-prev,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\]\:w_38px .bgm-pagination-next {
+    width: 38px;
+}
+
+  .\[\&_\.bgm-pagination-icon\]\:w_15px .bgm-pagination-icon {
+    width: 15px;
+}
+
+  .\[\&_\.bgm-pagination-icon\]\:h_15px .bgm-pagination-icon {
+    height: 15px;
+}
+
+  .\[\&_\>_\*\]\:w_100\% > * {
     width: 100%;
 }
 
@@ -6750,48 +6906,12 @@
     min-height: 200px;
 }
 
-  .\[\&_label\]\:w_100px label {
-    width: 100px;
+  .\[\&_a\]\:min-h_34px a {
+    min-height: 34px;
 }
 
-  .\[\&_label\]\:mr_9px label {
-    margin-right: 9px;
-}
-
-  .\[\&_input\]\:w_375px input {
-    width: 375px;
-}
-
-  .\[\&_input\]\:h_34px input,.\[\&_button\]\:h_34px button {
-    height: 34px;
-}
-
-  .\[\&_select\]\:h_26px select {
-    height: 26px;
-}
-
-  .\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:w_26px .bgm-pagination-prev,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:w_26px .bgm-pagination-next,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:w_26px .bgm-pagination-pager {
-    width: 26px;
-}
-
-  .\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:h_26px .bgm-pagination-prev,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:h_26px .bgm-pagination-next,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\,_\&_\.bgm-pagination-pager\]\:h_26px .bgm-pagination-pager {
-    height: 26px;
-}
-
-  .\[\&_\.bgm-pagination-pager_\+_\.bgm-pagination-pager\]\:ml_0 .bgm-pagination-pager + .bgm-pagination-pager {
-    margin-left: var(--spacing-0);
-}
-
-  .\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\]\:w_34px .bgm-pagination-prev,.\[\&_\.bgm-pagination-prev\,_\&_\.bgm-pagination-next\]\:w_34px .bgm-pagination-next {
-    width: 34px;
-}
-
-  .\[\&_\.bgm-pagination-icon\]\:w_14px .bgm-pagination-icon {
-    width: 14px;
-}
-
-  .\[\&_\.bgm-pagination-icon\]\:h_14px .bgm-pagination-icon {
-    height: 14px;
+  .\[\&_select\]\:h_32px select {
+    height: 32px;
 }
 
   .\[\&_\>_li\]\:min-h_58px > li {
@@ -6818,16 +6938,20 @@
     height: 10px;
 }
 
-  .\[\&_\>_li\]\:min-h_126px > li {
-    min-height: 126px;
+  .\[\&_\>_li\]\:min-h_164px > li {
+    min-height: 164px;
 }
 
-  .\[\&_\>_li\]\:min-h_82px > li {
-    min-height: 82px;
+  .\[\&_\>_li\]\:min-h_94px > li {
+    min-height: 94px;
 }
 
-  .\[\&_h2\]\:pb_7px h2 {
-    padding-bottom: 7px;
+  .\[\&_img\]\:w_56px img {
+    width: 56px;
+}
+
+  .\[\&_img\]\:h_56px img {
+    height: 56px;
 }
 
   .\[\&_li_\+_li\]\:mt_8px li + li {
@@ -7278,6 +7402,10 @@
     color: #fff;
 }
 
+  .hover\:c_\#d96f79:is(:hover, [data-hover]) {
+    color: #d96f79;
+}
+
   .hover\:op_1:is(:hover, [data-hover]) {
     opacity: 1;
 }
@@ -7326,7 +7454,19 @@
     border-bottom-color: #54b5df;
 }
 
-  .\[\&_button\]\:\[\&\:hover\,_\&\:focus-visible\]\:bg_\#f09199 button:hover,.\[\&_button\]\:\[\&\:hover\,_\&\:focus-visible\]\:bg_\#f09199 button:focus-visible,.\[\&_a\]\:hover\:bg_\#f09199 a:is(:hover, [data-hover]) {
+  .\[\&_button\]\:\[\&\:hover\,_\&\:focus-visible\]\:bg_\#f09199 button:hover,.\[\&_button\]\:\[\&\:hover\,_\&\:focus-visible\]\:bg_\#f09199 button:focus-visible {
+    background: #f09199;
+}
+
+  .\[\&_button\]\:hover\:bg_\#e77f89 button:is(:hover, [data-hover]) {
+    background: #e77f89;
+}
+
+  .\[\&_a\]\:hover\:bg_\#fff a:is(:hover, [data-hover]) {
+    background: #fff;
+}
+
+  .\[\&_a\]\:\[\&\[aria-current\=\'page\'\]\]\:bg_\#f09199 a[aria-current='page'],.\[\&_a\]\:hover\:bg_\#f09199 a:is(:hover, [data-hover]) {
     background: #f09199;
 }
 
@@ -7338,12 +7478,8 @@
     padding: 6px 5px;
 }
 
-  .\[\&_button\]\:hover\:bg_\#3aa4d2 button:is(:hover, [data-hover]) {
-    background: #3aa4d2;
-}
-
-  .\[\&_li_a\]\:hover\:bg_\#fff6f7 li a:is(:hover, [data-hover]) {
-    background: #fff6f7;
+  .\[\&_a\]\:\[\&\[class\]\]\:bg_\#fff1f2 a[class] {
+    background: #fff1f2;
 }
 
   .\[\&_\>_li\]\:\[\&_p\]\:m_3px_0_0 > li p {
@@ -7352,10 +7488,6 @@
 
   .\[\&_li\]\:\[\&_\>_p\]\:m_0_0_3px li > p {
     margin: 0 0 3px;
-}
-
-  .\[\&_\>_li\]\:even\:bg_\#fafafa > li:nth-child(even) {
-    background: #fafafa;
 }
 
   .\[\&\.bgm-menu--vertical\]\:\[\&_\>_\.bgm-menu-item\]\:p_5px_0.bgm-menu--vertical > .bgm-menu-item {
@@ -7402,6 +7534,14 @@
     text-decoration: none;
 }
 
+  .\[\&_input\]\:focus\:bd-c_\#f09199 input:is(:focus, [data-focus]) {
+    border-color: #f09199;
+}
+
+  .\[\&_button\]\:focusVisible\:ring_2px_solid_\#3aa6d0 button:is(:focus-visible, [data-focus-visible]) {
+    outline: 2px solid #3aa6d0;
+}
+
   .\[\&_a\]\:\[\&\:first-child\]\:flex_0_1_auto a:first-child {
     flex: 0 1 auto;
 }
@@ -7444,10 +7584,6 @@
 
   .\[\&_li\]\:\[\&_a\]\:td_none li a {
     text-decoration: none;
-}
-
-  .\[\&_input\]\:focus\:bd-c_\#f09199 input:is(:focus, [data-focus]) {
-    border-color: #f09199;
 }
 
   .\[\&_\>_li\]\:\[\&_\>_div_\>_a\,_\&_small\]\:ov_hidden > li > div > a,.\[\&_\>_li\]\:\[\&_\>_div_\>_a\,_\&_small\]\:ov_hidden > li small,.\[\&_a\]\:\[\&_\>_span\:last-child\]\:ov_hidden a > span:last-child {
@@ -7548,6 +7684,30 @@
 
   .\[\&_div\]\:\[\&_a\]\:lh_21px div a {
     line-height: 21px;
+}
+
+  .\[\&_input\]\:focus\:bx-sh_0_0_0_3px_rgba\(240\,_145\,_153\,_0\.16\) input:is(:focus, [data-focus]) {
+    box-shadow: 0 0 0 3px rgba(240, 145, 153, 0.16);
+}
+
+  .\[\&_button\]\:focusVisible\:ring-o_2px button:is(:focus-visible, [data-focus-visible]) {
+    outline-offset: 2px;
+}
+
+  .\[\&_button\]\:\[\&_svg\]\:fill_currentcolor button svg {
+    fill: currentcolor;
+}
+
+  .\[\&_a\]\:hover\:c_\#d96f79 a:is(:hover, [data-hover]) {
+    color: #d96f79;
+}
+
+  .\[\&_a\]\:\[\&\[aria-current\=\'page\'\]\]\:c_\#fff a[aria-current='page'] {
+    color: #fff;
+}
+
+  .\[\&_a\]\:\[\&\[aria-current\=\'page\'\]\]\:fw_600 a[aria-current='page'] {
+    font-weight: 600;
 }
 
   .\[\&_a\]\:hover\:c_\#f09199 a:is(:hover, [data-hover]) {
@@ -7690,20 +7850,12 @@
     color: #fff;
 }
 
-  .\[\&_input\]\:focus\:bx-sh_0_0_0_2px_rgba\(240\,_145\,_153\,_0\.18\) input:is(:focus, [data-focus]) {
-    box-shadow: 0 0 0 2px rgba(240, 145, 153, 0.18);
+  .\[\&_a\]\:\[\&\[class\]\]\:c_\#d96f79 a[class] {
+    color: #d96f79;
 }
 
-  .\[\&_button\]\:\[\&_svg\]\:fill_currentcolor button svg {
-    fill: currentcolor;
-}
-
-  .\[\&_li_a\]\:hover\:c_\#f09199 li a:is(:hover, [data-hover]),.\[\&_a\]\:\[\&\[class\]\]\:c_\#f09199 a[class] {
-    color: #f09199;
-}
-
-  .\[\&_a\]\:\[\&\[class\]\]\:fw_600 a[class] {
-    font-weight: 600;
+  .\[\&_a\]\:\[\&\[class\]\]\:fw_650 a[class] {
+    font-weight: 650;
 }
 
   .\[\&_\>_li\]\:\[\&_\>_div_\>_a\,_\&_small\]\:d_block > li > div > a,.\[\&_\>_li\]\:\[\&_\>_div_\>_a\,_\&_small\]\:d_block > li small {
@@ -7946,6 +8098,14 @@
     margin-bottom: var(--spacing-0);
 }
 
+  .\[\&_button\]\:\[\&_svg\]\:w_17px button svg {
+    width: 17px;
+}
+
+  .\[\&_button\]\:\[\&_svg\]\:h_17px button svg {
+    height: 17px;
+}
+
   .\[\&_h2\]\:\[\&_small\]\:ml_5px h2 small {
     margin-left: 5px;
 }
@@ -7972,14 +8132,6 @@
 
   .\[\&_\>_li\]\:\[\&_\>_small\]\:h_18px > li > small {
     height: 18px;
-}
-
-  .\[\&_button\]\:\[\&_svg\]\:w_14px button svg {
-    width: 14px;
-}
-
-  .\[\&_button\]\:\[\&_svg\]\:h_14px button svg {
-    height: 14px;
 }
 
   .\[\&_li\]\:\[\&_\>_p\]\:min-h_20px li > p {
@@ -8329,18 +8481,24 @@
 }
 }
 
+  @media (max-width: 1180px) {
+    .\[\@media_\(max-width\:_1180px\)\]\:gap_28px {
+      gap: 28px;
+}
+    .\[\@media_\(max-width\:_1180px\)\]\:grid-tc_minmax\(0\,_1fr\)_240px {
+      grid-template-columns: minmax(0, 1fr) 240px;
+}
+    .\[\@media_\(max-width\:_1180px\)\]\:w_calc\(100\%_-_48px\) {
+      width: calc(100% - 48px);
+}
+}
+
   @media (max-width: 1024px) {
     .\[\@media_\(max-width\:_1024px\)\]\:grid-tc_minmax\(0\,_1fr\)_240px {
       grid-template-columns: minmax(0, 1fr) 240px;
 }
-    .\[\@media_\(max-width\:_1024px\)\]\:grid-tc_100px_minmax\(0\,_1fr\)_200px {
-      grid-template-columns: 100px minmax(0, 1fr) 200px;
-}
     .\[\@media_\(max-width\:_1024px\)\]\:grid-tc_repeat\(6\,_minmax\(0\,_1fr\)\) {
       grid-template-columns: repeat(6, minmax(0, 1fr));
-}
-    .\[\@media_\(max-width\:_1024px\)\]\:w_calc\(100\%_-_40px\) {
-      width: calc(100% - 40px);
 }
     .\[\&\.bgm-layout--alpha\]\:\[\@media_\(max-width\:_1024px\)\]\:grid-tc_minmax\(0\,_1fr\).bgm-layout--alpha {
       grid-template-columns: minmax(0, 1fr);
@@ -8377,27 +8535,27 @@
 }
 }
 
+  @media (max-width: 960px) {
+    .\[\@media_\(max-width\:_960px\)\]\:grid-tc_repeat\(4\,_minmax\(0\,_1fr\)\) {
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+}
+
+  @media (max-width: 860px) {
+    .\[\@media_\(max-width\:_860px\)\]\:grid-tc_minmax\(0\,_1fr\) {
+      grid-template-columns: minmax(0, 1fr);
+}
+}
+
   @media (max-width: 768px) {
     .\[\@media_\(max-width\:_768px\)\]\:p_24px_16px_36px {
       padding: 24px 16px 36px;
 }
-    .\[\@media_\(max-width\:_768px\)\]\:p_10px_8px_24px {
-      padding: 10px 8px 24px;
-}
-    .\[\@media_\(max-width\:_768px\)\]\:m_0 {
-      margin: var(--spacing-0);
-}
-    .\[\@media_\(max-width\:_768px\)\]\:p_3px_5px {
-      padding: 3px 5px;
-}
-    .\[\@media_\(max-width\:_768px\)\]\:bd_0 {
-      border: 0;
-}
-    .\[\@media_\(max-width\:_768px\)\]\:p_7px_3px {
-      padding: 7px 3px;
-}
     .\[\@media_\(max-width\:_768px\)\]\:p_5px_10px {
       padding: 5px 10px;
+}
+    .\[\@media_\(max-width\:_768px\)\]\:gap_0 {
+      gap: var(--spacing-0);
 }
     .\[\@media_\(max-width\:_768px\)\]\:gap_18px {
       gap: 18px;
@@ -8408,35 +8566,20 @@
     .\[\@media_\(max-width\:_768px\)\]\:flex_none {
       flex: none;
 }
-    .\[\@media_\(max-width\:_768px\)\]\:gap_12px {
-      gap: 12px;
-}
-    .\[\@media_\(max-width\:_768px\)\]\:gap_14px_10px {
-      gap: 14px 10px;
-}
-    .\[\@media_\(max-width\:_768px\)\]\:gap_10px {
-      gap: 10px;
-}
     .\[\@media_\(max-width\:_768px\)\]\:flex-b_100\% {
       flex-basis: 100%;
-}
-    .\[\@media_\(max-width\:_768px\)\]\:grid-tc_minmax\(0\,_1fr\) {
-      grid-template-columns: minmax(0, 1fr);
-}
-    .\[\@media_\(max-width\:_768px\)\]\:flex-d_column {
-      flex-direction: column;
 }
     .\[\@media_\(max-width\:_768px\)\]\:ai_stretch {
       align-items: stretch;
 }
-    .\[\@media_\(max-width\:_768px\)\]\:d_flex {
-      display: flex;
-}
-    .\[\@media_\(max-width\:_768px\)\]\:grid-tc_repeat\(3\,_minmax\(0\,_1fr\)\) {
-      grid-template-columns: repeat(3, minmax(0, 1fr));
+    .\[\@media_\(max-width\:_768px\)\]\:flex-d_column {
+      flex-direction: column;
 }
     .\[\@media_\(max-width\:_768px\)\]\:d_none {
       display: none;
+}
+    .\[\@media_\(max-width\:_768px\)\]\:grid-tc_minmax\(0\,_1fr\) {
+      grid-template-columns: minmax(0, 1fr);
 }
     .\[\@media_\(max-width\:_768px\)\]\:fs_13px {
       font-size: 13px;
@@ -8468,21 +8611,6 @@
     .\[\@media_\(max-width\:_768px\)\]\:w_100\% {
       width: 100%;
 }
-    .\[\@media_\(max-width\:_768px\)\]\:pr_16px {
-      padding-right: 16px;
-}
-    .\[\@media_\(max-width\:_768px\)\]\:pl_16px {
-      padding-left: 16px;
-}
-    .\[\@media_\(max-width\:_768px\)\]\:pr_2px {
-      padding-right: 2px;
-}
-    .\[\@media_\(max-width\:_768px\)\]\:pl_2px {
-      padding-left: 2px;
-}
-    .\[\@media_\(max-width\:_768px\)\]\:mt_14px {
-      margin-top: 14px;
-}
     .\[\@media_\(max-width\:_768px\)\]\:pr_0 {
       padding-right: var(--spacing-0);
 }
@@ -8494,12 +8622,6 @@
 }
     .\[\@media_\(max-width\:_768px\)\]\:right_3px {
       right: 3px;
-}
-    .\[\@media_\(max-width\:_768px\)\]\:min-h_116px {
-      min-height: 116px;
-}
-    .\[\@media_\(max-width\:_768px\)\]\:w_72px {
-      width: 72px;
 }
     .\[\@media_\(max-width\:_768px\)\]\:pt_16px {
       padding-top: 16px;
@@ -8519,62 +8641,14 @@
     .\[\@media_\(max-width\:_768px\)\]\:ml_80px {
       margin-left: 80px;
 }
-    .\[\@media_\(max-width\:_768px\)\]\:\[\&_ul\]\:p_4px_6px ul {
-      padding: 4px 6px;
-}
-    .\[\@media_\(max-width\:_768px\)\]\:\[\&_li_a\]\:m_0 li a {
-      margin: var(--spacing-0);
-}
-    .\[\@media_\(max-width\:_768px\)\]\:\[\&_li_a\]\:p_3px_6px li a {
-      padding: 3px 6px;
-}
-    .\[\@media_\(max-width\:_768px\)\]\:\[\&_\>_li\]\:p_7px_3px > li {
-      padding: 7px 3px;
-}
     .\[\@media_\(max-width\:_768px\)\]\:\[\&_a\]\:p_0_12px a {
       padding: 0 12px;
-}
-    .\[\@media_\(max-width\:_768px\)\]\:\[\&_input\]\:flex_1 input {
-      flex: 1 1 0%;
-}
-    .\[\@media_\(max-width\:_768px\)\]\:\[\&_ul\]\:bdr_6px ul {
-      border-radius: 6px;
-}
-    .\[\@media_\(max-width\:_768px\)\]\:\[\&_\>_li\]\:gap_12px > li {
-      gap: 12px;
-}
-    .\[\@media_\(max-width\:_768px\)\]\:\[\&_label\]\:fs_13px label {
-      font-size: 13px;
-}
-    .\[\@media_\(max-width\:_768px\)\]\:\[\&_label\]\:white-space_nowrap label {
-      white-space: nowrap;
-}
-    .\[\@media_\(max-width\:_768px\)\]\:\[\&_li\]\:d_inline-block li {
-      display: inline-block;
-}
-    .\[\@media_\(max-width\:_768px\)\]\:\[\&_li_a\]\:fs_12px li a {
-      font-size: 12px;
 }
     .\[\@media_\(max-width\:_768px\)\]\:\[\&\[class\]\]\:flex-b_64px[class] {
       flex-basis: 64px;
 }
     .\[\@media_\(max-width\:_768px\)\]\:\[\&_a\]\:fs_14px a {
       font-size: 14px;
-}
-    .\[\@media_\(max-width\:_768px\)\]\:\[\&_label\]\:w_auto label {
-      width: auto;
-}
-    .\[\@media_\(max-width\:_768px\)\]\:\[\&_label\]\:mr_4px label {
-      margin-right: 4px;
-}
-    .\[\@media_\(max-width\:_768px\)\]\:\[\&_input\]\:min-w_0 input {
-      min-width: var(--sizes-0);
-}
-    .\[\@media_\(max-width\:_768px\)\]\:\[\&_input\]\:w_auto input {
-      width: auto;
-}
-    .\[\@media_\(max-width\:_768px\)\]\:\[\&_\>_li\]\:min-h_116px > li {
-      min-height: 116px;
 }
     .\[\@media_\(max-width\:_768px\)\]\:\[\&\[class\]\]\:w_64px[class] {
       width: 64px;
@@ -8623,9 +8697,24 @@
 }
 }
 
+  @media (max-width: 700px) {
+    .\[\@media_\(max-width\:_700px\)\]\:gap_24px_12px {
+      gap: 24px 12px;
+}
+    .\[\@media_\(max-width\:_700px\)\]\:grid-tc_repeat\(3\,_minmax\(0\,_1fr\)\) {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+}
+
   @media (max-width: 640px) {
     .\[\@media_\(max-width\:_640px\)\]\:p_1px_3px {
       padding: 1px 3px;
+}
+    .\[\@media_\(max-width\:_640px\)\]\:p_14px_0_10px {
+      padding: 14px 0 10px;
+}
+    .\[\@media_\(max-width\:_640px\)\]\:p_20px_16px_42px {
+      padding: 20px 16px 42px;
 }
     .\[\@media_\(max-width\:_640px\)\]\:p_14px_15px_24px {
       padding: 14px 15px 24px;
@@ -8657,6 +8746,9 @@
     .\[\@media_\(max-width\:_640px\)\]\:p_5px_10px_0 {
       padding: 5px 10px 0;
 }
+    .\[\@media_\(max-width\:_640px\)\]\:p_14px_0 {
+      padding: 14px 0;
+}
     .\[\@media_\(max-width\:_640px\)\]\:p_10px_5px {
       padding: 10px 5px;
 }
@@ -8665,6 +8757,9 @@
 }
     .\[\@media_\(max-width\:_640px\)\]\:p_12px {
       padding: 12px;
+}
+    .\[\@media_\(max-width\:_640px\)\]\:gap_28px {
+      gap: 28px;
 }
     .\[\@media_\(max-width\:_640px\)\]\:gap_2px {
       gap: 2px;
@@ -8681,6 +8776,9 @@
     .\[\@media_\(max-width\:_640px\)\]\:flex_none {
       flex: none;
 }
+    .\[\@media_\(max-width\:_640px\)\]\:gap_13px {
+      gap: 13px;
+}
     .\[\@media_\(max-width\:_640px\)\]\:gap_10px {
       gap: 10px;
 }
@@ -8695,6 +8793,9 @@
 }
     .\[\@media_\(max-width\:_640px\)\]\:fs_11px {
       font-size: 11px;
+}
+    .\[\@media_\(max-width\:_640px\)\]\:ai_flex-end {
+      align-items: flex-end;
 }
     .\[\@media_\(max-width\:_640px\)\]\:grid-tc_minmax\(0\,_1fr\) {
       grid-template-columns: minmax(0, 1fr);
@@ -8786,6 +8887,18 @@
     .\[\@media_\(max-width\:_640px\)\]\:pl_16px {
       padding-left: 16px;
 }
+    .\[\@media_\(max-width\:_640px\)\]\:w_calc\(100\%_-_32px\) {
+      width: calc(100% - 32px);
+}
+    .\[\@media_\(max-width\:_640px\)\]\:mt_14px {
+      margin-top: 14px;
+}
+    .\[\@media_\(max-width\:_640px\)\]\:pt_11px {
+      padding-top: 11px;
+}
+    .\[\@media_\(max-width\:_640px\)\]\:w_100\% {
+      width: 100%;
+}
     .\[\@media_\(max-width\:_640px\)\]\:pb_8px {
       padding-bottom: 8px;
 }
@@ -8818,9 +8931,6 @@
 }
     .\[\@media_\(max-width\:_640px\)\]\:mt_2px {
       margin-top: 2px;
-}
-    .\[\@media_\(max-width\:_640px\)\]\:w_100\% {
-      width: 100%;
 }
     .\[\@media_\(max-width\:_640px\)\]\:ov-x_auto {
       overflow-x: auto;
@@ -8870,6 +8980,12 @@
     .\[\@media_\(max-width\:_640px\)\]\:pl_4px {
       padding-left: 4px;
 }
+    .\[\@media_\(max-width\:_640px\)\]\:min-h_134px {
+      min-height: 134px;
+}
+    .\[\@media_\(max-width\:_640px\)\]\:w_76px {
+      width: 76px;
+}
     .\[\@media_\(max-width\:_640px\)\]\:w_96px {
       width: 96px;
 }
@@ -8897,20 +9013,38 @@
     .\[\@media_\(max-width\:_640px\)\]\:min-h_0 {
       min-height: var(--sizes-0);
 }
+    .\[\@media_\(max-width\:_640px\)\]\:\[\&_button\]\:p_0 button {
+      padding: var(--spacing-0);
+}
     .\[\@media_\(max-width\:_640px\)\]\:\[\&_small\]\:m_2px_0_0 small {
       margin: 2px 0 0;
 }
-    .\[\@media_\(max-width\:_640px\)\]\:\[\&_button\]\:p_0 button {
-      padding: var(--spacing-0);
+    .\[\@media_\(max-width\:_640px\)\]\:\[\&_\>_li\]\:p_14px_0 > li {
+      padding: 14px 0;
 }
     .\[\@media_\(max-width\:_640px\)\]\:\[\&_li\]\:p_2px_8px li {
       padding: 2px 8px;
 }
+    .\[\@media_\(max-width\:_640px\)\]\:\[\&_button\]\:flex_0_0_44px button {
+      flex: 0 0 44px;
+}
+    .\[\@media_\(max-width\:_640px\)\]\:\[\&_\>_div\]\:gap_18px > div {
+      gap: 18px;
+}
     .\[\@media_\(max-width\:_640px\)\]\:\[\&_\>_li\]\:gap_8px > li {
       gap: 8px;
 }
+    .\[\@media_\(max-width\:_640px\)\]\:\[\&_\>_li\]\:gap_13px > li {
+      gap: 13px;
+}
     .\[\@media_\(max-width\:_640px\)\]\:\[\&_\.bgm-popover__content\]\:pos_fixed .bgm-popover__content {
       position: fixed;
+}
+    .\[\@media_\(max-width\:_640px\)\]\:\[\&_h2\]\:fs_17px h2 {
+      font-size: 17px;
+}
+    .\[\@media_\(max-width\:_640px\)\]\:\[\&_h2\]\:lh_23px h2 {
+      line-height: 23px;
 }
     .\[\@media_\(max-width\:_640px\)\]\:\[\&_a\,_\&_time\]\:d_inline a,.\[\@media_\(max-width\:_640px\)\]\:\[\&_a\,_\&_time\]\:d_inline time {
       display: inline;
@@ -8951,6 +9085,9 @@
     .\[\@media_\(max-width\:_640px\)\]\:\[\&_\.bgm-popover__content\]\:w_auto .bgm-popover__content {
       width: auto;
 }
+    .\[\@media_\(max-width\:_640px\)\]\:\[\&_button\]\:w_44px button {
+      width: 44px;
+}
     .\[\@media_\(max-width\:_640px\)\]\:\[\&_\>_li\]\:pr_0 > li {
       padding-right: var(--spacing-0);
 }
@@ -8960,8 +9097,8 @@
     .\[\@media_\(max-width\:_640px\)\]\:\[\&_time\]\:mt_2px time {
       margin-top: 2px;
 }
-    .\[\@media_\(max-width\:_640px\)\]\:\[\&_button\]\:w_38px button {
-      width: 38px;
+    .\[\@media_\(max-width\:_640px\)\]\:\[\&_\>_li\]\:min-h_134px > li {
+      min-height: 134px;
 }
     .\[\@media_\(max-width\:_640px\)\]\:\[\&_\.blog-comment__box\]\:ml_10px .blog-comment__box {
       margin-left: 10px;
@@ -9151,6 +9288,12 @@
 }
     .smDown\:\[\&\[aria-expanded\=\'true\'\]\]\:\[\&_span\:\:before\]\:top_0[aria-expanded='true'] span::before,.smDown\:\[\&\[aria-expanded\=\'true\'\]\]\:\[\&_span\:\:after\]\:top_0[aria-expanded='true'] span::after {
       top: var(--spacing-0);
+}
+}
+
+  @media (max-width: 420px) {
+    .\[\@media_\(max-width\:_420px\)\]\:gap_22px_10px {
+      gap: 22px 10px;
 }
 }
 }

--- a/packages/website/src/components/SearchPage/index.tsx
+++ b/packages/website/src/components/SearchPage/index.tsx
@@ -1,0 +1,359 @@
+import type { FormEvent, ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+
+import { Search } from '@bangumi/icons';
+import { css } from '@bangumi/styled-system/css';
+
+const searchArea = css({
+  borderBottom: '1px solid #e8e5e6',
+  background: '#f7f8fa',
+});
+
+const searchAreaInner = css({
+  width: '1120px',
+  margin: '0 auto',
+  padding: '18px 0 12px',
+  boxSizing: 'border-box',
+  '@media (max-width: 1180px)': {
+    width: 'calc(100% - 48px)',
+  },
+  '@media (max-width: 640px)': {
+    width: 'calc(100% - 32px)',
+    padding: '14px 0 10px',
+  },
+});
+
+const searchTop = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '18px',
+  '@media (max-width: 768px)': {
+    alignItems: 'stretch',
+    flexDirection: 'column',
+    gap: '0',
+  },
+});
+
+const searchHeading = css({
+  flex: '0 0 180px',
+  margin: '0',
+  color: '#1f1c1c',
+  fontSize: '18px',
+  fontWeight: '650',
+  lineHeight: '26px',
+  textAlign: 'center',
+  '@media (max-width: 768px)': {
+    display: 'none',
+  },
+});
+
+const searchForm = css({
+  display: 'flex',
+  flex: '1',
+  gap: '8px',
+  maxWidth: '760px',
+  '& label': {
+    position: 'absolute',
+    overflow: 'hidden',
+    width: '1px',
+    height: '1px',
+    padding: '0',
+    border: '0',
+    clip: 'rect(0, 0, 0, 0)',
+    whiteSpace: 'nowrap',
+  },
+  '& input': {
+    minWidth: '0',
+    height: '44px',
+    flex: '1',
+    padding: '0 14px',
+    border: '1px solid #d8d3d5',
+    borderRadius: '6px',
+    background: '#fff',
+    color: '#302c2d',
+    fontSize: '15px',
+    outline: 'none',
+    boxShadow: '0 1px 2px rgba(48, 44, 45, 0.04)',
+    _focus: {
+      borderColor: '#f09199',
+      boxShadow: '0 0 0 3px rgba(240, 145, 153, 0.16)',
+    },
+  },
+  '& button': {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: '7px',
+    height: '44px',
+    padding: '0 20px',
+    border: '0',
+    borderRadius: '6px',
+    background: '#f09199',
+    color: '#fff',
+    cursor: 'pointer',
+    fontSize: '14px',
+    fontWeight: '600',
+    _hover: { background: '#e77f89' },
+    _focusVisible: { outline: '2px solid #3aa6d0', outlineOffset: '2px' },
+    '& svg': {
+      width: '17px',
+      height: '17px',
+      fill: 'currentcolor',
+    },
+  },
+  '@media (max-width: 640px)': {
+    '& button': {
+      width: '44px',
+      flex: '0 0 44px',
+      padding: '0',
+      '& span': { display: 'none' },
+    },
+  },
+});
+
+const categoryNav = css({
+  overflowX: 'auto',
+  marginTop: '20px',
+  paddingTop: '14px',
+  borderTop: '1px solid #e5e1e2',
+  scrollbarWidth: 'none',
+  '&::-webkit-scrollbar': { display: 'none' },
+  '& > div': {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '24px',
+    width: 'max-content',
+  },
+  '@media (max-width: 640px)': {
+    marginTop: '14px',
+    paddingTop: '11px',
+    '& > div': { gap: '18px' },
+  },
+});
+
+const categoryGroup = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '6px',
+  '& > span': {
+    marginRight: '2px',
+    color: '#8c8587',
+    fontSize: '12px',
+    fontWeight: '600',
+    whiteSpace: 'nowrap',
+  },
+  '& a': {
+    display: 'inline-flex',
+    alignItems: 'center',
+    minHeight: '30px',
+    padding: '0 10px',
+    borderRadius: '5px',
+    color: '#5f595b',
+    fontSize: '13px',
+    textDecoration: 'none',
+    whiteSpace: 'nowrap',
+    _hover: {
+      background: '#fff',
+      color: '#d96f79',
+    },
+    "&[aria-current='page']": {
+      background: '#f09199',
+      color: '#fff',
+      fontWeight: '600',
+    },
+  },
+});
+
+export const searchPage = css({
+  width: '1120px',
+  margin: '0 auto',
+  padding: '28px 0 64px',
+  boxSizing: 'border-box',
+  '@media (max-width: 1180px)': {
+    width: 'calc(100% - 48px)',
+  },
+  '@media (max-width: 640px)': {
+    width: '100%',
+    padding: '20px 16px 42px',
+  },
+});
+
+export const searchPageWithSidebar = css({
+  display: 'grid',
+  gridTemplateColumns: 'minmax(0, 1fr) 260px',
+  gap: '36px',
+  width: '1120px',
+  margin: '0 auto',
+  padding: '28px 0 64px',
+  boxSizing: 'border-box',
+  '@media (max-width: 1180px)': {
+    width: 'calc(100% - 48px)',
+    gridTemplateColumns: 'minmax(0, 1fr) 240px',
+    gap: '28px',
+  },
+  '@media (max-width: 860px)': {
+    gridTemplateColumns: 'minmax(0, 1fr)',
+  },
+  '@media (max-width: 640px)': {
+    width: '100%',
+    gap: '28px',
+    padding: '20px 16px 42px',
+  },
+});
+
+export const searchResults = css({ minWidth: '0' });
+
+export const searchResultsHeader = css({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: '16px',
+  minHeight: '42px',
+  paddingBottom: '12px',
+  borderBottom: '1px solid #e8e5e6',
+  '& h2': {
+    margin: '0',
+    color: '#302c2d',
+    fontSize: '19px',
+    fontWeight: '650',
+    lineHeight: '26px',
+  },
+  '& p': {
+    margin: '2px 0 0',
+    color: '#8c8587',
+    fontSize: '12px',
+    lineHeight: '18px',
+  },
+  '@media (max-width: 640px)': {
+    alignItems: 'flex-end',
+    '& h2': { fontSize: '17px', lineHeight: '23px' },
+  },
+});
+
+export const searchEmpty = css({
+  minHeight: '260px',
+  margin: '0',
+  padding: '80px 20px',
+  color: '#8c8587',
+  boxSizing: 'border-box',
+  textAlign: 'center',
+});
+
+export const searchPagination = css({
+  flexWrap: 'wrap',
+  gap: '6px',
+  margin: '28px 0 0',
+  '& .bgm-pagination-prev, & .bgm-pagination-next, & .bgm-pagination-pager': {
+    width: '32px',
+    height: '32px',
+    margin: '0',
+    borderWidth: '1px',
+    borderRadius: '6px',
+    fontSize: '12px',
+  },
+  '& .bgm-pagination-pager + .bgm-pagination-pager': { marginLeft: '0' },
+  '& .bgm-pagination-prev, & .bgm-pagination-next': { width: '38px' },
+  '& .bgm-pagination-icon': { width: '15px', height: '15px' },
+});
+
+export const searchSidebar = css({
+  display: 'flex',
+  alignSelf: 'start',
+  flexDirection: 'column',
+  gap: '14px',
+});
+
+export const searchPanel = css({
+  padding: '16px',
+  border: '1px solid #e8e5e6',
+  borderRadius: '6px',
+  background: '#fff',
+  boxShadow: '0 2px 10px rgba(48, 44, 45, 0.04)',
+});
+
+export const searchPanelTitle = css({
+  margin: '0 0 14px',
+  paddingBottom: '10px',
+  borderBottom: '1px solid #eee9ea',
+  color: '#302c2d',
+  fontSize: '14px',
+  fontWeight: '650',
+  lineHeight: '20px',
+});
+
+interface SearchHeaderProps {
+  inputId: string;
+  inputLabel: string;
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  children: ReactNode;
+}
+
+export function SearchHeader({
+  inputId,
+  inputLabel,
+  value,
+  onChange,
+  onSubmit,
+  children,
+}: SearchHeaderProps) {
+  return (
+    <div className={searchArea}>
+      <div className={searchAreaInner}>
+        <div className={searchTop}>
+          <h1 className={searchHeading}>站内搜索</h1>
+          <form className={searchForm} onSubmit={onSubmit}>
+            <label htmlFor={inputId}>{inputLabel}</label>
+            <input
+              id={inputId}
+              name='search_text'
+              type='search'
+              value={value}
+              onChange={(event) => onChange(event.target.value)}
+            />
+            <button type='submit'>
+              <Search />
+              <span>搜索</span>
+            </button>
+          </form>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+interface SearchCategoryItem {
+  label: string;
+  selected?: boolean;
+  to: string;
+}
+
+interface SearchCategoryGroup {
+  label: string;
+  items: SearchCategoryItem[];
+}
+
+export function SearchCategoryNav({ groups }: { groups: SearchCategoryGroup[] }) {
+  return (
+    <nav className={categoryNav} aria-label='搜索分类'>
+      <div>
+        {groups.map((group) => (
+          <div className={categoryGroup} key={group.label}>
+            <span>{group.label}</span>
+            {group.items.map((item) => (
+              <Link
+                key={`${group.label}-${item.label}`}
+                to={item.to}
+                aria-current={item.selected ? 'page' : undefined}
+              >
+                {item.label}
+              </Link>
+            ))}
+          </div>
+        ))}
+      </div>
+    </nav>
+  );
+}

--- a/packages/website/src/pages/index/mono_search/[keyword]/MonoSearchPage.spec.tsx
+++ b/packages/website/src/pages/index/mono_search/[keyword]/MonoSearchPage.spec.tsx
@@ -47,9 +47,8 @@ describe('MonoSearchPage', () => {
 
     const links = await screen.findAllByRole('link');
     expect(links.some((el) => el.getAttribute('href') === '/character/99657')).toBe(true);
-    expect(screen.getByText('找到 40 个角色')).toBeInTheDocument();
-    // 分类侧栏：角色分类高亮
-    expect(screen.getByRole('link', { name: '虚构角色' }).className).toContain('bg_#f09199');
+    expect(screen.getByText('找到 40 个结果')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '虚构角色' })).toHaveAttribute('aria-current', 'page');
   });
 
   it('renders person results with career filter when cat=prsn', async () => {
@@ -64,7 +63,7 @@ describe('MonoSearchPage', () => {
 
     const links = await screen.findAllByRole('link');
     expect(links.some((el) => el.getAttribute('href') === '/person/49410')).toBe(true);
-    expect(screen.getByText('找到 3 个现实人物')).toBeInTheDocument();
+    expect(screen.getByText('找到 3 个结果')).toBeInTheDocument();
     expect(screen.getByRole('combobox', { name: '' })).toBeInTheDocument();
   });
 });

--- a/packages/website/src/pages/index/mono_search/[keyword]/index.tsx
+++ b/packages/website/src/pages/index/mono_search/[keyword]/index.tsx
@@ -3,165 +3,23 @@ import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 
 import type { SlimCharacter, SlimPerson } from '@bangumi/client/client';
 import { Pagination } from '@bangumi/design';
-import { Search } from '@bangumi/icons';
 import { css } from '@bangumi/styled-system/css';
 import { getCharacterLink, getLegacyPageLink, getPersonLink } from '@bangumi/utils/pages';
 import { withErrorBoundary } from '@bangumi/website/components/ErrorBoundary';
 import Helmet from '@bangumi/website/components/Helmet';
+import {
+  SearchCategoryNav,
+  searchEmpty,
+  SearchHeader,
+  searchPage,
+  searchPagination,
+  searchResults,
+  searchResultsHeader,
+} from '@bangumi/website/components/SearchPage';
 import { useCharacterSearch, usePersonSearch } from '@bangumi/website/hooks/use-mono-search';
 import { usePaginationParams } from '@bangumi/website/hooks/use-pagination';
 
 const PAGE_SIZE = 15;
-
-const searchBand = css({
-  borderBottom: '1px solid #e8e3e3',
-  background: '#fafafa',
-});
-
-const searchForm = css({
-  display: 'flex',
-  alignItems: 'center',
-  gap: '6px',
-  width: '980px',
-  margin: '0 auto',
-  padding: '10px 0',
-  boxSizing: 'border-box',
-  '& label': {
-    width: '100px',
-    marginRight: '9px',
-    color: '#595555',
-    fontSize: '16px',
-    fontWeight: '600',
-    lineHeight: '35px',
-    textAlign: 'right',
-  },
-  '& input': {
-    width: '375px',
-    height: '34px',
-    padding: '6px 10px',
-    border: '1px solid #ccc',
-    borderRadius: '4px',
-    background: '#fff',
-    color: '#1f1c1c',
-    fontSize: '14px',
-    outline: 'none',
-    boxShadow: 'inset 0 1px 2px rgba(0, 0, 0, 0.08)',
-    _focus: {
-      borderColor: '#f09199',
-      boxShadow: '0 0 0 2px rgba(240, 145, 153, 0.18)',
-    },
-  },
-  '& button': {
-    display: 'inline-flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: '5px',
-    height: '34px',
-    padding: '0 16px',
-    border: '0',
-    borderRadius: '4px',
-    background: '#54b5df',
-    color: '#fff',
-    cursor: 'pointer',
-    _hover: { background: '#3aa4d2' },
-    '& svg': {
-      width: '14px',
-      height: '14px',
-      fill: 'currentcolor',
-    },
-  },
-  '@media (max-width: 1024px)': {
-    width: 'calc(100% - 40px)',
-  },
-  '@media (max-width: 768px)': {
-    width: '100%',
-    paddingRight: '16px',
-    paddingLeft: '16px',
-    '& label': {
-      width: 'auto',
-      marginRight: '4px',
-      fontSize: '13px',
-      whiteSpace: 'nowrap',
-    },
-    '& input': {
-      minWidth: '0',
-      width: 'auto',
-      flex: '1',
-    },
-  },
-  '@media (max-width: 640px)': {
-    '& button': {
-      width: '38px',
-      padding: '0',
-      '& span': {
-        display: 'none',
-      },
-    },
-  },
-});
-
-const page = css({
-  display: 'grid',
-  gridTemplateColumns: '100px minmax(0, 655px) 200px',
-  gap: '10px',
-  width: '980px',
-  margin: '0 auto',
-  padding: '20px 0 40px',
-  boxSizing: 'border-box',
-  '@media (max-width: 1024px)': {
-    width: 'calc(100% - 40px)',
-    gridTemplateColumns: '100px minmax(0, 1fr) 200px',
-  },
-  '@media (max-width: 768px)': {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '12px',
-    width: '100%',
-    padding: '10px 8px 24px',
-  },
-});
-
-const categories = css({
-  alignSelf: 'start',
-  '& ul': {
-    overflow: 'hidden',
-    margin: '0',
-    padding: '0 2px 5px',
-    border: '1px solid #e8e3e3',
-    borderRadius: '8px',
-    background: '#fff',
-    boxShadow: '0 1px 5px rgba(50, 46, 46, 0.08)',
-    listStyle: 'none',
-  },
-  '& li a': {
-    display: 'block',
-    margin: '5px 0',
-    padding: '3px 12px',
-    borderRadius: '999px',
-    color: '#54b5df',
-    fontSize: '13px',
-    lineHeight: '18px',
-    textDecoration: 'none',
-    _hover: {
-      background: '#fff6f7',
-      color: '#f09199',
-    },
-  },
-  '@media (max-width: 768px)': {
-    '& ul': {
-      padding: '4px 6px',
-      borderRadius: '6px',
-    },
-    '& li': {
-      display: 'inline-block',
-    },
-    '& li a': {
-      margin: '0',
-      padding: '3px 6px',
-      fontSize: '12px',
-    },
-  },
-});
 
 const categorySelected = css({
   '&[class]': {
@@ -170,60 +28,25 @@ const categorySelected = css({
   },
 });
 
-const categoryRoot = css({
-  margin: '0 -2px',
-  padding: '6px 14px 5px',
-  borderBottom: '1px solid #e8e3e3',
-  color: '#9f9b9b',
-  fontSize: '12px',
-  fontWeight: '600',
-  '@media (max-width: 768px)': {
-    margin: '0',
-    padding: '3px 5px',
-    border: '0',
-  },
-});
-
-const results = css({
-  minWidth: '0',
-  '@media (max-width: 768px)': {
-    width: '100%',
-  },
-});
-
-const resultTools = css({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-  minHeight: '24px',
-  padding: '0 4px 5px',
-  color: '#9f9b9b',
-  fontSize: '12px',
-  '@media (max-width: 768px)': {
-    paddingRight: '2px',
-    paddingLeft: '2px',
-  },
-  '@media (max-width: 640px)': {
-    justifyContent: 'flex-end',
-    '& > span': {
-      display: 'none',
-    },
-  },
-});
-
 const monoTabs = css({
   display: 'flex',
-  gap: '16px',
-  padding: '10px 0 8px',
+  gap: '6px',
+  marginBottom: '18px',
   '& a': {
-    color: '#9f9b9b',
+    display: 'inline-flex',
+    alignItems: 'center',
+    minHeight: '34px',
+    padding: '0 13px',
+    borderRadius: '5px',
+    color: '#716b6d',
     fontSize: '13px',
     textDecoration: 'none',
     '&[class]': {
-      color: '#f09199',
-      fontWeight: '600',
+      background: '#fff1f2',
+      color: '#d96f79',
+      fontWeight: '650',
     },
-    _hover: { color: '#f09199' },
+    _hover: { color: '#d96f79' },
   },
 });
 
@@ -232,12 +55,16 @@ const careerFilter = css({
   flexWrap: 'wrap',
   alignItems: 'center',
   gap: '10px',
-  padding: '0 4px 8px',
+  marginBottom: '16px',
+  padding: '12px 14px',
+  border: '1px solid #eee9ea',
+  borderRadius: '6px',
+  background: '#faf9f9',
   color: '#9f9b9b',
   fontSize: '12px',
   '& select': {
-    height: '26px',
-    padding: '0 6px',
+    height: '32px',
+    padding: '0 9px',
     border: '1px solid #e8e3e3',
     borderRadius: '4px',
     background: '#fff',
@@ -249,14 +76,20 @@ const careerFilter = css({
 
 const resultsGrid = css({
   display: 'grid',
-  gridTemplateColumns: 'repeat(4, minmax(0, 1fr))',
-  gap: '18px 12px',
+  gridTemplateColumns: 'repeat(5, minmax(0, 1fr))',
+  gap: '30px 20px',
   margin: '0',
-  padding: '8px 0',
+  padding: '24px 0 4px',
   listStyle: 'none',
-  '@media (max-width: 768px)': {
+  '@media (max-width: 960px)': {
+    gridTemplateColumns: 'repeat(4, minmax(0, 1fr))',
+  },
+  '@media (max-width: 700px)': {
     gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
-    gap: '14px 10px',
+    gap: '24px 12px',
+  },
+  '@media (max-width: 420px)': {
+    gap: '22px 10px',
   },
 });
 
@@ -264,21 +97,21 @@ const cardLink = css({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
-  color: '#54b5df',
-  fontSize: '13px',
-  lineHeight: '18px',
+  color: '#1f1c1c',
+  fontSize: '14px',
+  lineHeight: '20px',
   textAlign: 'center',
   textDecoration: 'none',
-  _hover: { color: '#f09199' },
+  _hover: { color: '#d96f79' },
 });
 
 const cardCover = css({
   display: 'block',
   width: '100%',
-  aspectRatio: '1 / 1.2',
-  borderRadius: '4px',
+  aspectRatio: '4 / 5',
+  borderRadius: '6px',
   objectFit: 'cover',
-  boxShadow: '0 1px 4px rgba(0, 0, 0, 0.22)',
+  boxShadow: '0 3px 12px rgba(48, 44, 45, 0.14)',
 });
 
 const cardCoverPlaceholder = css({
@@ -286,17 +119,17 @@ const cardCoverPlaceholder = css({
   alignItems: 'center',
   justifyContent: 'center',
   width: '100%',
-  aspectRatio: '1 / 1.2',
-  borderRadius: '4px',
-  background: '#e8e3e3',
-  color: '#9f9b9b',
-  fontSize: '20px',
+  aspectRatio: '4 / 5',
+  borderRadius: '6px',
+  background: '#eee9ea',
+  color: '#8c8587',
+  fontSize: '24px',
 });
 
 const cardName = css({
   overflow: 'hidden',
   maxWidth: '100%',
-  marginTop: '6px',
+  marginTop: '10px',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
 });
@@ -304,8 +137,8 @@ const cardName = css({
 const cardSub = css({
   overflow: 'hidden',
   maxWidth: '100%',
-  color: '#9f9b9b',
-  fontSize: '11px',
+  color: '#8c8587',
+  fontSize: '12px',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
 });
@@ -313,50 +146,21 @@ const cardSub = css({
 const cardInfo = css({
   overflow: 'hidden',
   margin: '4px 0 0',
-  color: '#9f9b9b',
-  fontSize: '11px',
+  color: '#8c8587',
+  fontSize: '12px',
   lineHeight: '16px',
   textAlign: 'center',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
 });
 
-const empty = css({
-  minHeight: '240px',
-  margin: '0',
-  padding: '50px 20px',
-  borderTop: '1px solid #e8e3e3',
-  color: '#9f9b9b',
-  boxSizing: 'border-box',
-  textAlign: 'center',
-});
-
-const pagination = css({
-  flexWrap: 'wrap',
-  gap: '6px',
-  margin: '20px 0 0',
-  '& .bgm-pagination-prev, & .bgm-pagination-next, & .bgm-pagination-pager': {
-    width: '26px',
-    height: '26px',
-    margin: '0',
-    borderWidth: '1px',
-    borderRadius: '50%',
-    fontSize: '11px',
-  },
-  '& .bgm-pagination-pager + .bgm-pagination-pager': {
-    marginLeft: '0',
-  },
-  '& .bgm-pagination-prev, & .bgm-pagination-next': {
-    width: '34px',
-    borderRadius: '13px',
-  },
-  '& .bgm-pagination-icon': {
-    width: '14px',
-    height: '14px',
-  },
-  '@media (max-width: 768px)': {
-    marginTop: '14px',
-  },
+const legacyLink = css({
+  display: 'inline-block',
+  marginTop: '28px',
+  color: '#8c8587',
+  fontSize: '12px',
+  textDecoration: 'none',
+  _hover: { color: '#d96f79' },
 });
 
 /** 人物职业（旧站 PersonCareer） */
@@ -487,68 +291,52 @@ function MonoSearchPage() {
   return (
     <>
       <Helmet title={`搜索: ${routeKeyword}`} />
-      <div className={searchBand}>
-        <form className={searchForm} onSubmit={handleSearch}>
-          <label htmlFor='mono-search-input'>人物搜索</label>
-          <input
-            id='mono-search-input'
-            name='search_text'
-            type='search'
-            value={searchValue}
-            onChange={(event) => setSearchValue(event.target.value)}
-          />
-          <button type='submit'>
-            <Search />
-            <span>搜索</span>
-          </button>
-        </form>
-      </div>
+      <SearchHeader
+        inputId='mono-search-input'
+        inputLabel='人物搜索'
+        value={searchValue}
+        onChange={setSearchValue}
+        onSubmit={handleSearch}
+      >
+        <SearchCategoryNav
+          groups={[
+            {
+              label: '条目',
+              items: [
+                { label: '全部', to: `/subject_search/${keywordParam}?cat=all` },
+                { label: '动画', to: `/subject_search/${keywordParam}?cat=2` },
+                { label: '书籍', to: `/subject_search/${keywordParam}?cat=1` },
+                { label: '音乐', to: `/subject_search/${keywordParam}?cat=3` },
+                { label: '游戏', to: `/subject_search/${keywordParam}?cat=4` },
+                { label: '三次元', to: `/subject_search/${keywordParam}?cat=6` },
+              ],
+            },
+            {
+              label: '人物',
+              items: [
+                {
+                  label: '全部',
+                  selected: category === 'all',
+                  to: `/mono_search/${keywordParam}?cat=all`,
+                },
+                {
+                  label: '虚构角色',
+                  selected: category === 'crt',
+                  to: `/mono_search/${keywordParam}?cat=crt`,
+                },
+                {
+                  label: '现实人物',
+                  selected: category === 'prsn',
+                  to: `/mono_search/${keywordParam}?cat=prsn`,
+                },
+              ],
+            },
+          ]}
+        />
+      </SearchHeader>
 
-      <main className={page}>
-        <nav className={categories} aria-label='搜索分类'>
-          <ul>
-            <li className={categoryRoot}>条目</li>
-            <li>
-              <Link to={`/subject_search/${keywordParam}?cat=all`}>全部</Link>
-            </li>
-            <li>
-              <Link to={`/subject_search/${keywordParam}?cat=2`}>动画</Link>
-            </li>
-            <li>
-              <Link to={`/subject_search/${keywordParam}?cat=1`}>书籍</Link>
-            </li>
-            <li>
-              <Link to={`/subject_search/${keywordParam}?cat=4`}>游戏</Link>
-            </li>
-            <li className={categoryRoot}>人物</li>
-            <li>
-              <Link
-                className={category === 'crt' ? categorySelected : undefined}
-                to={`/mono_search/${keywordParam}?cat=crt`}
-              >
-                虚构角色
-              </Link>
-            </li>
-            <li>
-              <Link
-                className={category === 'prsn' ? categorySelected : undefined}
-                to={`/mono_search/${keywordParam}?cat=prsn`}
-              >
-                现实人物
-              </Link>
-            </li>
-            <li>
-              <Link
-                className={category === 'all' ? categorySelected : undefined}
-                to={`/mono_search/${keywordParam}?cat=all`}
-              >
-                全部
-              </Link>
-            </li>
-          </ul>
-        </nav>
-
-        <section className={results} aria-label='搜索结果'>
+      <main className={searchPage}>
+        <section className={searchResults} aria-label='搜索结果'>
           <div className={monoTabs}>
             <Link
               className={showCharacters ? categorySelected : undefined}
@@ -591,9 +379,12 @@ function MonoSearchPage() {
           )}
           {showCharacters && (
             <>
-              <div className={resultTools}>
-                <span>找到 {characterTotal} 个角色</span>
-              </div>
+              <header className={searchResultsHeader}>
+                <div>
+                  <h2>“{routeKeyword}”的角色</h2>
+                  <p>找到 {characterTotal} 个结果</p>
+                </div>
+              </header>
               {characters.length > 0 ? (
                 <ul className={resultsGrid}>
                   {characters.map((character) => (
@@ -601,15 +392,18 @@ function MonoSearchPage() {
                   ))}
                 </ul>
               ) : (
-                <p className={empty}>没有找到相关角色</p>
+                <p className={searchEmpty}>没有找到相关角色</p>
               )}
             </>
           )}
           {showPersons && (
             <>
-              <div className={resultTools}>
-                <span>找到 {personTotal} 个现实人物</span>
-              </div>
+              <header className={searchResultsHeader}>
+                <div>
+                  <h2>“{routeKeyword}”的现实人物</h2>
+                  <p>找到 {personTotal} 个结果</p>
+                </div>
+              </header>
               {persons.length > 0 ? (
                 <ul className={resultsGrid}>
                   {persons.map((person) => (
@@ -617,13 +411,13 @@ function MonoSearchPage() {
                   ))}
                 </ul>
               ) : (
-                <p className={empty}>没有找到相关现实人物</p>
+                <p className={searchEmpty}>没有找到相关现实人物</p>
               )}
             </>
           )}
           <Pagination
             key={curPage}
-            wrapperClass={pagination}
+            wrapperClass={searchPagination}
             total={category === 'prsn' ? personTotal : characterTotal}
             pageSize={PAGE_SIZE}
             currentPage={curPage}
@@ -631,16 +425,14 @@ function MonoSearchPage() {
           />
         </section>
 
-        <aside className={css({ '@media (max-width: 768px)': { display: 'none' } })}>
-          <a
-            href={getLegacyPageLink(
-              `/mono_search/${keywordParam}?cat=${category === 'prsn' ? 'prsn' : 'crt'}`,
-            )}
-            style={{ color: '#54b5df', fontSize: '12px', textDecoration: 'none' }}
-          >
-            前往旧版页面
-          </a>
-        </aside>
+        <a
+          className={legacyLink}
+          href={getLegacyPageLink(
+            `/mono_search/${keywordParam}?cat=${category === 'prsn' ? 'prsn' : 'crt'}`,
+          )}
+        >
+          前往旧版页面
+        </a>
       </main>
     </>
   );

--- a/packages/website/src/pages/index/subject_search/[keyword]/SubjectSearchPage.spec.tsx
+++ b/packages/website/src/pages/index/subject_search/[keyword]/SubjectSearchPage.spec.tsx
@@ -52,8 +52,8 @@ it('renders typed search fixtures and persists the selected view', async () => {
     'href',
     '/subject/41983',
   );
-  expect(screen.getByText('找到 62 个条目')).toBeInTheDocument();
-  expect(screen.getByRole('link', { name: '动画' }).className).toContain('bg_#f09199');
+  expect(screen.getByText('找到 62 个结果')).toBeInTheDocument();
+  expect(screen.getByRole('link', { name: '动画' })).toHaveAttribute('aria-current', 'page');
   expect(screen.getByRole('heading', { name: '相关人物' })).toBeInTheDocument();
 
   fireEvent.click(screen.getByRole('button', { name: '网格视图' }));

--- a/packages/website/src/pages/index/subject_search/[keyword]/index.tsx
+++ b/packages/website/src/pages/index/subject_search/[keyword]/index.tsx
@@ -7,239 +7,47 @@ import { ozaClient } from '@bangumi/client';
 import type { SlimCharacter, SlimPerson, SlimSubject, SubjectType } from '@bangumi/client/client';
 import { SubjectType as SubjectTypeEnum } from '@bangumi/client/client';
 import { Pagination } from '@bangumi/design';
-import { EmptyStar, FilledStar, GridView, ListView, Search } from '@bangumi/icons';
+import { EmptyStar, FilledStar, GridView, ListView } from '@bangumi/icons';
 import { css, cx } from '@bangumi/styled-system/css';
-import {
-  getCharacterLink,
-  getLegacyPageLink,
-  getPersonLink,
-  getSubjectLink,
-} from '@bangumi/utils/pages';
+import { getCharacterLink, getPersonLink, getSubjectLink } from '@bangumi/utils/pages';
 import { withErrorBoundary } from '@bangumi/website/components/ErrorBoundary';
 import Helmet from '@bangumi/website/components/Helmet';
+import {
+  SearchCategoryNav,
+  searchEmpty,
+  SearchHeader,
+  searchPageWithSidebar,
+  searchPagination,
+  searchPanel,
+  searchPanelTitle,
+  searchResults,
+  searchResultsHeader,
+  searchSidebar,
+} from '@bangumi/website/components/SearchPage';
 import { usePaginationParams } from '@bangumi/website/hooks/use-pagination';
-
-const searchBand = css({
-  borderBottom: '1px solid #e8e3e3',
-  background: '#fafafa',
-});
-
-const searchForm = css({
-  display: 'flex',
-  alignItems: 'center',
-  gap: '6px',
-  width: '980px',
-  margin: '0 auto',
-  padding: '10px 0',
-  boxSizing: 'border-box',
-  '& label': {
-    width: '100px',
-    marginRight: '9px',
-    color: '#595555',
-    fontSize: '16px',
-    fontWeight: '600',
-    lineHeight: '35px',
-    textAlign: 'right',
-  },
-  '& input': {
-    width: '375px',
-    height: '34px',
-    padding: '6px 10px',
-    border: '1px solid #ccc',
-    borderRadius: '4px',
-    background: '#fff',
-    color: '#1f1c1c',
-    fontSize: '14px',
-    outline: 'none',
-    boxShadow: 'inset 0 1px 2px rgba(0, 0, 0, 0.08)',
-    _focus: {
-      borderColor: '#f09199',
-      boxShadow: '0 0 0 2px rgba(240, 145, 153, 0.18)',
-    },
-  },
-  '& button': {
-    display: 'inline-flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: '5px',
-    height: '34px',
-    padding: '0 16px',
-    border: '0',
-    borderRadius: '4px',
-    background: '#54b5df',
-    color: '#fff',
-    cursor: 'pointer',
-    _hover: {
-      background: '#3aa4d2',
-    },
-    '& svg': {
-      width: '14px',
-      height: '14px',
-      fill: 'currentcolor',
-    },
-  },
-  '@media (max-width: 1024px)': {
-    width: 'calc(100% - 40px)',
-  },
-  '@media (max-width: 768px)': {
-    width: '100%',
-    paddingRight: '16px',
-    paddingLeft: '16px',
-    '& label': {
-      width: 'auto',
-      marginRight: '4px',
-      fontSize: '13px',
-      whiteSpace: 'nowrap',
-    },
-    '& input': {
-      minWidth: '0',
-      width: 'auto',
-      flex: '1',
-    },
-  },
-  '@media (max-width: 640px)': {
-    '& button': {
-      width: '38px',
-      padding: '0',
-      '& span': {
-        display: 'none',
-      },
-    },
-  },
-});
-
-const page = css({
-  display: 'grid',
-  gridTemplateColumns: '100px minmax(0, 655px) 200px',
-  gap: '10px',
-  width: '980px',
-  margin: '0 auto',
-  padding: '20px 0 40px',
-  boxSizing: 'border-box',
-  '@media (max-width: 1024px)': {
-    width: 'calc(100% - 40px)',
-    gridTemplateColumns: '100px minmax(0, 1fr) 200px',
-  },
-  '@media (max-width: 768px)': {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '12px',
-    width: '100%',
-    padding: '10px 8px 24px',
-  },
-});
-
-const categories = css({
-  alignSelf: 'start',
-  '& ul': {
-    overflow: 'hidden',
-    margin: '0',
-    padding: '0 2px 5px',
-    border: '1px solid #e8e3e3',
-    borderRadius: '8px',
-    background: '#fff',
-    boxShadow: '0 1px 5px rgba(50, 46, 46, 0.08)',
-    listStyle: 'none',
-  },
-  '& li a': {
-    display: 'block',
-    margin: '5px 0',
-    padding: '3px 12px',
-    borderRadius: '999px',
-    color: '#54b5df',
-    fontSize: '13px',
-    lineHeight: '18px',
-    textDecoration: 'none',
-    _hover: {
-      background: '#fff6f7',
-      color: '#f09199',
-    },
-  },
-  '@media (max-width: 768px)': {
-    '& ul': {
-      padding: '4px 6px',
-      borderRadius: '6px',
-    },
-    '& li': {
-      display: 'inline-block',
-    },
-    '& li a': {
-      margin: '0',
-      padding: '3px 6px',
-      fontSize: '12px',
-    },
-  },
-});
-
-// &[class] 提升特异性，胜过 .categories li a 的默认样式
-const categorySelected = css({
-  '&[class]': {
-    background: '#f09199',
-    color: '#fff',
-  },
-});
-
-const categoryRoot = css({
-  margin: '0 -2px',
-  padding: '6px 14px 5px',
-  borderBottom: '1px solid #e8e3e3',
-  color: '#9f9b9b',
-  fontSize: '12px',
-  fontWeight: '600',
-  '@media (max-width: 768px)': {
-    margin: '0',
-    padding: '3px 5px',
-    border: '0',
-  },
-});
-
-const results = css({
-  minWidth: '0',
-  '@media (max-width: 768px)': {
-    width: '100%',
-  },
-});
-
-const resultTools = css({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-  minHeight: '24px',
-  padding: '0 4px 5px',
-  color: '#9f9b9b',
-  fontSize: '12px',
-  '@media (max-width: 768px)': {
-    paddingRight: '2px',
-    paddingLeft: '2px',
-  },
-  '@media (max-width: 640px)': {
-    justifyContent: 'flex-end',
-    '& > span': {
-      display: 'none',
-    },
-  },
-});
 
 const viewSelector = css({
   display: 'inline-flex',
   overflow: 'hidden',
-  border: '1px solid #e8e3e3',
-  borderRadius: '4px',
+  flexShrink: '0',
+  border: '1px solid #ded9da',
+  borderRadius: '6px',
+  background: '#fff',
 });
 
 const viewButton = css({
   display: 'inline-flex',
   alignItems: 'center',
   justifyContent: 'center',
-  width: '28px',
-  height: '22px',
+  width: '34px',
+  height: '30px',
   padding: '0',
   border: '0',
-  borderRight: '1px solid #e8e3e3',
+  borderRight: '1px solid #e8e5e6',
   background: '#fff',
-  color: '#9f9b9b',
+  color: '#8c8587',
   cursor: 'pointer',
-  _hover: { color: '#54b5df' },
+  _hover: { color: '#1f1c1c' },
   '& svg': {
     width: '14px',
     height: '14px',
@@ -251,7 +59,7 @@ const viewButton = css({
 });
 
 const viewButtonActive = css({
-  background: '#54b5df',
+  background: '#f09199',
   color: '#fff',
 });
 
@@ -276,21 +84,21 @@ const coverLink = css({
 
 const cover = css({
   display: 'block',
-  width: '80px',
+  width: '96px',
   aspectRatio: '5 / 7',
-  borderRadius: '3px',
+  borderRadius: '5px',
   objectFit: 'cover',
-  boxShadow: '0 1px 4px rgba(0, 0, 0, 0.22)',
+  boxShadow: '0 3px 10px rgba(48, 44, 45, 0.16)',
 });
 
 const coverPlaceholder = css({
   display: 'block',
-  width: '80px',
+  width: '96px',
   aspectRatio: '5 / 7',
-  borderRadius: '3px',
+  borderRadius: '5px',
   objectFit: 'cover',
-  boxShadow: '0 1px 4px rgba(0, 0, 0, 0.22)',
-  background: '#e8e3e3',
+  boxShadow: '0 3px 10px rgba(48, 44, 45, 0.12)',
+  background: '#eee9ea',
 });
 
 const resultInfo = css({ minWidth: '0' });
@@ -300,13 +108,13 @@ const resultTitle = css({
   alignItems: 'baseline',
   minWidth: '0',
   margin: '0',
-  fontSize: '14px',
+  fontSize: '16px',
   fontWeight: '400',
-  lineHeight: '20px',
+  lineHeight: '22px',
   '& > a': {
     overflowWrap: 'anywhere',
-    color: '#54b5df',
-    fontWeight: '600',
+    color: '#1f1c1c',
+    fontWeight: '650',
     textDecoration: 'none',
     _hover: { color: '#f09199' },
   },
@@ -435,19 +243,16 @@ const rank = css({
 const resultsListFull = css({
   '& > li': {
     display: 'flex',
-    gap: '18px',
-    minHeight: '126px',
-    padding: '8px 5px',
+    gap: '20px',
+    minHeight: '164px',
+    padding: '18px 6px',
     boxSizing: 'border-box',
-    _even: {
-      background: '#fafafa',
-    },
   },
-  '@media (max-width: 768px)': {
+  '@media (max-width: 640px)': {
     '& > li': {
-      gap: '12px',
-      minHeight: '116px',
-      padding: '7px 3px',
+      gap: '13px',
+      minHeight: '134px',
+      padding: '14px 0',
     },
   },
 });
@@ -456,20 +261,17 @@ const resultsListCompact = css({
   '& > li': {
     display: 'flex',
     gap: '14px',
-    minHeight: '82px',
-    padding: '7px 5px',
+    minHeight: '94px',
+    padding: '12px 6px',
     boxSizing: 'border-box',
-    _even: {
-      background: '#fafafa',
-    },
   },
 });
 
 const resultsListGrid = css({
   display: 'grid',
-  gridTemplateColumns: 'repeat(auto-fill, minmax(105px, 1fr))',
-  gap: '16px 10px',
-  padding: '8px 0',
+  gridTemplateColumns: 'repeat(auto-fill, minmax(120px, 1fr))',
+  gap: '24px 14px',
+  padding: '20px 0',
   '@media (max-width: 640px)': {
     gridTemplateColumns: 'repeat(auto-fill, minmax(96px, 1fr))',
   },
@@ -478,25 +280,23 @@ const resultsListGrid = css({
 // 视图内元素样式（组合类）
 const resultItemFull = css({
   display: 'flex',
-  gap: '18px',
-  minHeight: '126px',
-  padding: '8px 5px',
+  gap: '20px',
+  minHeight: '164px',
+  padding: '18px 6px',
   boxSizing: 'border-box',
-  _even: { background: '#fafafa' },
-  '@media (max-width: 768px)': {
-    gap: '12px',
-    minHeight: '116px',
-    padding: '7px 3px',
+  '@media (max-width: 640px)': {
+    gap: '13px',
+    minHeight: '134px',
+    padding: '14px 0',
   },
 });
 
 const resultItemCompact = css({
   display: 'flex',
   gap: '14px',
-  minHeight: '82px',
-  padding: '7px 5px',
+  minHeight: '94px',
+  padding: '12px 6px',
   boxSizing: 'border-box',
-  _even: { background: '#fafafa' },
 });
 
 const resultItemGrid = css({
@@ -508,15 +308,15 @@ const resultItemGrid = css({
 });
 
 const coverFull = css({
-  '@media (max-width: 768px)': {
-    width: '72px',
+  '@media (max-width: 640px)': {
+    width: '76px',
   },
 });
 
-const coverCompact = css({ width: '48px' });
+const coverCompact = css({ width: '52px' });
 
 const coverGrid = css({
-  width: '105px',
+  width: '120px',
   '@media (max-width: 640px)': {
     width: '96px',
   },
@@ -528,7 +328,7 @@ const resultInfoList = css({
 });
 
 const resultInfoGrid = css({
-  width: '105px',
+  width: '120px',
   marginTop: '7px',
   '@media (max-width: 640px)': {
     width: '96px',
@@ -553,78 +353,14 @@ const rankGrid = css({
 
 const ratingCompact = css({ marginTop: '7px' });
 
-const empty = css({
-  minHeight: '240px',
-  margin: '0',
-  padding: '50px 20px',
-  borderTop: '1px solid #e8e3e3',
-  color: '#9f9b9b',
-  boxSizing: 'border-box',
-  textAlign: 'center',
-});
-
-const pagination = css({
-  flexWrap: 'wrap',
-  gap: '6px',
-  margin: '20px 0 0',
-  '& .bgm-pagination-prev, & .bgm-pagination-next, & .bgm-pagination-pager': {
-    width: '26px',
-    height: '26px',
-    margin: '0',
-    borderWidth: '1px',
-    borderRadius: '50%',
-    fontSize: '11px',
-  },
-  '& .bgm-pagination-pager + .bgm-pagination-pager': {
-    marginLeft: '0',
-  },
-  '& .bgm-pagination-prev, & .bgm-pagination-next': {
-    width: '34px',
-    borderRadius: '13px',
-  },
-  '& .bgm-pagination-icon': {
-    width: '14px',
-    height: '14px',
-  },
-  '@media (max-width: 768px)': {
-    marginTop: '14px',
-  },
-});
-
-const sidebar = css({
-  display: 'flex',
-  flexDirection: 'column',
-  gap: '14px',
-  '@media (max-width: 768px)': {
-    gap: '10px',
-  },
-});
-
-const sidePanel = css({
-  padding: '10px',
-  border: '1px solid #e8e3e3',
-  borderRadius: '8px',
-  background: '#fff',
-  boxShadow: '0 1px 5px rgba(50, 46, 46, 0.06)',
-  '& h2': {
-    margin: '0 0 8px',
-    paddingBottom: '7px',
-    borderBottom: '1px solid #e8e3e3',
-    color: '#9f9b9b',
-    fontSize: '12px',
-    fontWeight: '500',
-  },
-});
-
 const exactSearch = css({
-  padding: '10px',
-  border: '1px solid #e8e3e3',
-  borderRadius: '8px',
-  background: '#fff',
-  boxShadow: '0 1px 5px rgba(50, 46, 46, 0.06)',
-  fontSize: '12px',
+  padding: '14px 16px',
+  border: '1px solid #e8e5e6',
+  borderRadius: '6px',
+  background: '#fff8f8',
+  fontSize: '13px',
   '& a': {
-    color: '#54b5df',
+    color: '#1f1c1c',
     textDecoration: 'none',
     _hover: { color: '#f09199' },
   },
@@ -633,7 +369,7 @@ const exactSearch = css({
 const monoGrid = css({
   display: 'grid',
   gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
-  gap: '10px 4px',
+  gap: '14px 8px',
   margin: '0',
   padding: '0',
   listStyle: 'none',
@@ -641,7 +377,7 @@ const monoGrid = css({
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
-    color: '#54b5df',
+    color: '#1f1c1c',
     fontSize: '11px',
     lineHeight: '16px',
     textAlign: 'center',
@@ -659,8 +395,8 @@ const monoGrid = css({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    width: '48px',
-    height: '48px',
+    width: '56px',
+    height: '56px',
     borderRadius: '50%',
     objectFit: 'cover',
   },
@@ -673,8 +409,8 @@ const avatarPlaceholder = css({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  width: '48px',
-  height: '48px',
+  width: '56px',
+  height: '56px',
   borderRadius: '50%',
   objectFit: 'cover',
   background: '#e8e3e3',
@@ -895,8 +631,8 @@ function RelatedPanel({ monos }: { monos: RelatedMono[] }) {
   }
 
   return (
-    <section className={sidePanel}>
-      <h2>相关人物</h2>
+    <section className={searchPanel}>
+      <h2 className={searchPanelTitle}>相关人物</h2>
       <ul className={monoGrid}>
         {monos.map(({ kind, item }) => {
           const displayName = item.nameCN || item.name;
@@ -960,69 +696,53 @@ function SubjectSearchPage() {
   return (
     <>
       <Helmet title={`搜索: ${routeKeyword}`} />
-      <div className={searchBand}>
-        <form className={searchForm} onSubmit={handleSearch}>
-          <label htmlFor='subject-search-input'>条目搜索</label>
-          <input
-            id='subject-search-input'
-            name='search_text'
-            type='search'
-            value={searchValue}
-            onChange={(event) => setSearchValue(event.target.value)}
-          />
-          <button type='submit'>
-            <Search />
-            <span>搜索</span>
-          </button>
-        </form>
-      </div>
+      <SearchHeader
+        inputId='subject-search-input'
+        inputLabel='条目搜索'
+        value={searchValue}
+        onChange={setSearchValue}
+        onSubmit={handleSearch}
+      >
+        <SearchCategoryNav
+          groups={[
+            {
+              label: '条目',
+              items: SUBJECT_CATEGORIES.map((item) => ({
+                label: item.label,
+                selected: category === item.value,
+                to: `/subject_search/${encodeURIComponent(routeKeyword)}?cat=${item.value}`,
+              })),
+            },
+            {
+              label: '人物',
+              items: [
+                {
+                  label: '全部',
+                  to: `/mono_search/${encodeURIComponent(routeKeyword)}?cat=all`,
+                },
+                {
+                  label: '虚构角色',
+                  to: `/mono_search/${encodeURIComponent(routeKeyword)}?cat=crt`,
+                },
+                {
+                  label: '现实人物',
+                  to: `/mono_search/${encodeURIComponent(routeKeyword)}?cat=prsn`,
+                },
+              ],
+            },
+          ]}
+        />
+      </SearchHeader>
 
-      <main className={page}>
-        <nav className={categories} aria-label='搜索分类'>
-          <ul>
-            <li className={categoryRoot}>条目</li>
-            {SUBJECT_CATEGORIES.map((item) => (
-              <li key={item.value}>
-                <Link
-                  className={category === item.value ? categorySelected : undefined}
-                  to={`/subject_search/${encodeURIComponent(routeKeyword)}?cat=${item.value}`}
-                >
-                  {item.label}
-                </Link>
-              </li>
-            ))}
-            <li className={categoryRoot}>人物</li>
-            <li>
-              <a
-                href={getLegacyPageLink(`/mono_search/${encodeURIComponent(routeKeyword)}?cat=all`)}
-              >
-                全部
-              </a>
-            </li>
-            <li>
-              <a
-                href={getLegacyPageLink(`/mono_search/${encodeURIComponent(routeKeyword)}?cat=crt`)}
-              >
-                虚构角色
-              </a>
-            </li>
-            <li>
-              <a
-                href={getLegacyPageLink(
-                  `/mono_search/${encodeURIComponent(routeKeyword)}?cat=prsn`,
-                )}
-              >
-                现实人物
-              </a>
-            </li>
-          </ul>
-        </nav>
-
-        <section className={results} aria-label='搜索结果'>
-          <div className={resultTools}>
-            <span>找到 {total} 个条目</span>
+      <main className={searchPageWithSidebar}>
+        <section className={searchResults} aria-label='搜索结果'>
+          <header className={searchResultsHeader}>
+            <div>
+              <h2>“{routeKeyword}”的条目</h2>
+              <p>找到 {total} 个结果</p>
+            </div>
             <ViewSelector view={view} onChange={handleViewChange} />
-          </div>
+          </header>
           {subjects.length > 0 ? (
             <ul
               className={cx(
@@ -1037,11 +757,11 @@ function SubjectSearchPage() {
               ))}
             </ul>
           ) : (
-            <p className={empty}>没有找到相关条目</p>
+            <p className={searchEmpty}>没有找到相关条目</p>
           )}
           <Pagination
             key={curPage}
-            wrapperClass={pagination}
+            wrapperClass={searchPagination}
             total={total}
             pageSize={PAGE_SIZE}
             currentPage={curPage}
@@ -1049,15 +769,15 @@ function SubjectSearchPage() {
           />
         </section>
 
-        <aside className={sidebar}>
+        <aside className={searchSidebar}>
           <RelatedPanel monos={relatedMonos} />
           <div className={exactSearch}>
             <Link to={`/subject_search/${encodeURIComponent(exactKeyword)}?cat=${category}`}>
               显示精准匹配结果
             </Link>
           </div>
-          <section className={sidePanel}>
-            <h2>搜索提示</h2>
+          <section className={searchPanel}>
+            <h2 className={searchPanelTitle}>搜索提示</h2>
             <ul className={searchTips}>
               <li>
                 搜索时使用引号 “关键词”，如 <i>“ちょびっツ”</i> 获取精确结果


### PR DESCRIPTION
## Summary

Refactor `mono_search`（人物搜索）and `subject_search`（条目搜索）pages to share a common `SearchPage` component, unifying the search header, category navigation, result header, empty state, and pagination UI between the two pages.

## Changes

- Add shared `packages/website/src/components/SearchPage/index.tsx` with:
  - `SearchHeader` — search form band with input/button, responsive to mobile
  - `SearchCategoryNav` — horizontal category nav (条目/人物 groups) with `aria-current` selection state
  - Shared layout/pagination/empty-state/panel CSS recipes
- Rewrite `mono_search` and `subject_search` pages to consume the shared components, removing duplicated styles
- Add 音乐/三次元 subject categories to the nav
- Update spec assertions to match the new result header text and `aria-current`-based selection
- Regenerate `packages/styled-system/styles.css`

## Verification

- `pnpm type-check` ✅
- `pnpm test --run MonoSearchPage SubjectSearchPage` — 3 passed ✅
- `pnpm lint` ✅