### PR TITLE
feat(utils): add BBCode render presets and secure URL validation

### DIFF
--- a/packages/design/components/CollapsibleContent/CollapsibleContent.stories.tsx
+++ b/packages/design/components/CollapsibleContent/CollapsibleContent.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryFn } from '@storybook/react';
 import React, { useState } from 'react';
 
+import { BBCodePreset } from '@bangumi/utils/bbcode/presets';
 import { render as renderBBCode } from '@bangumi/utils/bbcode/react';
 
 import type { CollapsibleContentProps } from '.';
@@ -48,5 +49,5 @@ const description = `欢迎加入番组WIKI计划小组！
 `;
 Basic.args = {
   threshold: 192,
-  content: renderBBCode(description),
+  content: renderBBCode(description, BBCodePreset.groupDescription),
 };

--- a/packages/design/components/RichContent/RichContent.stories.tsx
+++ b/packages/design/components/RichContent/RichContent.stories.tsx
@@ -27,4 +27,5 @@ const Template: StoryFn<typeof RichContent> = (args) => {
 export const Usage = Template.bind({});
 Usage.args = {
   bbcode: input,
+  preset: 'topic',
 };

--- a/packages/design/components/RichContent/index.tsx
+++ b/packages/design/components/RichContent/index.tsx
@@ -3,10 +3,13 @@ import React from 'react';
 import closeQuote from '@bangumi/icons/assets/close-quote.svg?url';
 import openQuote from '@bangumi/icons/assets/open-quote.svg?url';
 import { css, cx } from '@bangumi/styled-system/css';
+import type { BBCodePresetName } from '@bangumi/utils/bbcode/presets';
+import { BBCodePreset } from '@bangumi/utils/bbcode/presets';
 import { render } from '@bangumi/utils/bbcode/react';
 
 export interface RichContentProps {
   bbcode: string;
+  preset: BBCodePresetName;
   classname?: string;
 }
 
@@ -58,7 +61,7 @@ const content = css({
   },
 });
 
-const RichContent: React.FC<RichContentProps> = ({ bbcode, classname }) => {
+const RichContent: React.FC<RichContentProps> = ({ bbcode, preset, classname }) => {
   return (
     <div
       className={cx('bgm-rich-content', richContent, content, classname)}
@@ -69,7 +72,7 @@ const RichContent: React.FC<RichContentProps> = ({ bbcode, classname }) => {
         } as React.CSSProperties
       }
     >
-      {render(bbcode)}
+      {render(bbcode, BBCodePreset[preset])}
     </div>
   );
 };

--- a/packages/design/components/Topic/Comment.tsx
+++ b/packages/design/components/Topic/Comment.tsx
@@ -150,7 +150,7 @@ const Link = Typography.Link;
 const RenderContent = memo(({ state, content }: { state: State; content: string }) => {
   switch (state) {
     case State.Normal:
-      return <RichContent bbcode={content} classname='bgm-comment__content' />;
+      return <RichContent bbcode={content} preset='topic' classname='bgm-comment__content' />;
     case State.Closed:
       return <div className='bgm-comment__content'>关闭了该主题</div>;
     case State.Reopen:

--- a/packages/utils/bbcode/__test__/html.test.ts
+++ b/packages/utils/bbcode/__test__/html.test.ts
@@ -191,6 +191,11 @@ describe('html render bbcode string', () => {
       '存放于其他网络服务器的图片：<br/><img src="http://chii.in/img/ico/bgm88-31.gif" class="code"/>',
     );
   });
+  test('render image as link', () => {
+    expect(render('[img]https://example.com/image.png[/img]', { images: 'link' })).toBe(
+      '<a href="https://example.com/image.png" target="_blank" rel="nofollow external noopener noreferrer" class="bgm-link">https://example.com/image.png</a>',
+    );
+  });
   test('render sticker', () => {
     const input = '(bgm38)(bgm23)(=///=)';
     expect(render(input)).toMatchSnapshot();
@@ -219,16 +224,18 @@ describe('html render bbcode string', () => {
     const input = '[code]ss[b]加粗\n换行了[/b](bgm38) [/fafa [code][/code]';
     expect(
       render(input, {
-        code: (node) => ({
-          type: 'div',
-          className: 'codeHighlight',
-          children: [
-            {
-              type: 'pre',
-              children: node.children,
-            },
-          ],
-        }),
+        converters: {
+          code: (node) => ({
+            type: 'div',
+            className: 'codeHighlight',
+            children: [
+              {
+                type: 'pre',
+                children: node.children,
+              },
+            ],
+          }),
+        },
       }),
     ).toBe(
       '<div class="codeHighlight"><pre>ss[b]加粗\n换行了[/b](bgm38) [/fafa [code]</pre></div>',

--- a/packages/utils/bbcode/__test__/parser.test.ts
+++ b/packages/utils/bbcode/__test__/parser.test.ts
@@ -1,4 +1,4 @@
-import { mergeTags, Parser } from '../parser';
+import { Parser } from '../parser';
 import type { CodeNodeTypes } from '../types';
 
 function getNodes(input: string): CodeNodeTypes[] {
@@ -263,6 +263,13 @@ describe('bbcode parser', () => {
     ];
     expect(getNodes(input)).toEqual(expect.arrayContaining(tests));
   });
+  test('reject unsafe url protocols', () => {
+    const input = '[url=javascript:alert(1)]链接[/url][img]data:text/html,unsafe[/img]';
+    expect(getNodes(input)).toEqual([
+      '[url=javascript:alert(1)]链接[/url]',
+      '[img]data:text/html,unsafe[/img]',
+    ]);
+  });
   test('invalid sticker bbcode', () => {
     const input = '(bgmab)(bgm38a';
     const tests: CodeNodeTypes[] = ['(bgm', 'ab)', '(bgm38a'];
@@ -274,7 +281,7 @@ describe('bbcode parser', () => {
   });
   test('custom bbcode', () => {
     const input = '[mybbcode]测试自定义tag[/mybbcode]';
-    const nodes = new Parser(input, ['mybbcode']).parse();
+    const nodes = new Parser(input, { additionalTags: ['mybbcode'] }).parse();
     expect(nodes).toEqual([
       {
         type: 'mybbcode',
@@ -282,43 +289,15 @@ describe('bbcode parser', () => {
       },
     ]);
   });
-  test('merge tags', () => {
-    const fn = (): boolean => true;
-    const tags = mergeTags(
-      [
-        'i',
-        'b',
-        {
-          name: 's',
-          schema: {
-            s: fn,
-          },
-        },
-      ],
-      [
-        {
-          name: 'i',
-          schema: {
-            i: fn,
-          },
-        },
-        's',
-        'mybbcode',
-      ],
-    );
-    expect(tags).toEqual(
-      expect.arrayContaining([
-        'b',
-        's',
-        'mybbcode',
-        {
-          name: 'i',
-          schema: {
-            i: fn,
-          },
-        },
-      ]),
-    );
+  test('exact tag set', () => {
+    const input = '[b]粗体[/b][i]斜体[/i]';
+    const nodes = new Parser(input, { tags: ['b'] }).parse();
+    expect(nodes).toEqual([{ type: 'b', children: ['粗体'] }, '[i]斜体[/i]']);
+  });
+  test('disable bbcode and stickers', () => {
+    const input = '[b]粗体[/b](bgm38)';
+    const nodes = new Parser(input, { bbcode: false, stickers: false }).parse();
+    expect(nodes).toEqual([input]);
   });
   test('subject bbcode', () => {
     const tests: Array<[string, CodeNodeTypes[]]> = [

--- a/packages/utils/bbcode/__test__/react.test.tsx
+++ b/packages/utils/bbcode/__test__/react.test.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import { render, renderNode } from '../react';
 import type { VNode } from '../types';
 
@@ -128,6 +130,30 @@ describe('html render bbcode string', () => {
     const input = `存放于其他网络服务器的图片：
 [img]http://chii.in/img/ico/bgm88-31.gif[/img]`;
     expect(render(input)).toMatchSnapshot();
+  });
+  test('render nested image as link', () => {
+    const output = render('[b][img]https://example.com/image.png[/img][/b]', { images: 'link' });
+    const strong = output[0];
+    expect(React.isValidElement(strong)).toBe(true);
+    if (!React.isValidElement<{ children: React.ReactElement }>(strong)) {
+      throw new Error('Expected a React element');
+    }
+    expect(strong.type).toBe('strong');
+    expect(strong.props.children).toMatchObject({
+      type: 'a',
+      props: expect.objectContaining({ href: 'https://example.com/image.png' }),
+    });
+  });
+  test('preserve stickers when disabled', () => {
+    expect(render('[b]文字[/b](bgm38)', { stickers: false })).toEqual([
+      expect.objectContaining({ type: 'strong' }),
+      '(bgm38)',
+    ]);
+  });
+  test('preserve bbcode when disabled', () => {
+    expect(render('[b]文字[/b](bgm38)', { bbcode: false, stickers: false })).toEqual([
+      '[b]文字[/b](bgm38)',
+    ]);
   });
   test('render sticker', () => {
     const input = '(bgm38)(bgm23)(=///=)';

--- a/packages/utils/bbcode/convert.ts
+++ b/packages/utils/bbcode/convert.ts
@@ -1,6 +1,15 @@
 import { UnreadableCodeError } from '../index';
 import { BGM_STICKER_START_STR, EMOJI_ARRAY, STICKER_DOMAIN_URL } from './constants';
-import type { CodeNodeTypes, CodeVNode, ConverterFn, NodeTypes, VNode } from './types';
+import type {
+  BBCodeConverterContext,
+  BBCodeOptions,
+  BBCodeRenderOptions,
+  CodeNodeTypes,
+  CodeVNode,
+  ConverterFn,
+  NodeTypes,
+  VNode,
+} from './types';
 
 const BGM_HOST_ARR = [
   'chii.in',
@@ -20,8 +29,12 @@ function isExternalLink(url: string): boolean {
   }
 }
 
-function convertImgNode(node: CodeVNode): VNode {
+function convertImgNode(node: CodeVNode, options: BBCodeOptions): VNode {
   const src = node.children![0] as string;
+  if (options.images === 'link') {
+    return convertLink(src, [src]);
+  }
+
   const vnode: VNode = {
     type: 'img',
     props: {
@@ -39,27 +52,21 @@ function convertImgNode(node: CodeVNode): VNode {
   return vnode;
 }
 
-function setVNodeChildren(vnode: VNode, node: CodeVNode): void {
+function setVNodeChildren(vnode: VNode, node: CodeVNode, context: BBCodeConverterContext): void {
   if (node.children) {
-    vnode.children = node.children.map((c) => convert(c));
+    vnode.children = node.children.map(context.convert);
   }
 }
 
-function convertUrlNode(node: CodeVNode): VNode {
-  let href = node.props?.url;
-  if (!href) {
-    href = node.children![0] as string;
-  }
+function convertLink(href: string, children: NodeTypes[]): VNode {
   const vnode: VNode = {
     type: 'a',
     props: {
       href,
     },
     className: 'bgm-link',
+    children,
   };
-  if (node.children) {
-    vnode.children = node.children.map((c) => convert(c));
-  }
   if (isExternalLink(href)) {
     vnode.props = {
       ...vnode.props,
@@ -68,6 +75,12 @@ function convertUrlNode(node: CodeVNode): VNode {
     };
   }
   return vnode;
+}
+
+function convertUrlNode(node: CodeVNode, context: BBCodeConverterContext): VNode {
+  const href = node.props?.url ?? (node.children![0] as string);
+  const children = node.children?.map(context.convert) ?? [];
+  return convertLink(href, children);
 }
 
 function convertStickerNode(node: CodeVNode): VNode | string {
@@ -152,11 +165,11 @@ function convertStickerNode(node: CodeVNode): VNode | string {
   return stickerId;
 }
 
-function convertQuote(node: CodeVNode): VNode {
+function convertQuote(node: CodeVNode, context: BBCodeConverterContext): VNode {
   const q: VNode = {
     type: 'q',
   };
-  setVNodeChildren(q, node);
+  setVNodeChildren(q, node, context);
   return {
     type: 'div',
     className: 'quote',
@@ -182,111 +195,111 @@ function convertUser(node: CodeVNode): VNode {
 function toVNode(
   node: CodeVNode,
   type: string,
+  context: BBCodeConverterContext,
   props: Pick<VNode, 'style' | 'className'> = {},
 ): VNode {
   const vnode: VNode = {
     type,
     ...props,
   };
-  setVNodeChildren(vnode, node);
+  setVNodeChildren(vnode, node, context);
   return vnode;
 }
 
 const CONVERTER_FN_MAP: Record<string, ConverterFn> = {
-  b: (node) => toVNode(node, 'strong'),
-  i: (node) => toVNode(node, 'em'),
-  u: (node) =>
-    toVNode(node, 'span', {
+  b: (node, context) => toVNode(node, 'strong', context),
+  i: (node, context) => toVNode(node, 'em', context),
+  u: (node, context) =>
+    toVNode(node, 'span', context, {
       style: {
         'text-decoration': 'underline',
       },
     }),
-  s: (node) =>
-    toVNode(node, 'span', {
+  s: (node, context) =>
+    toVNode(node, 'span', context, {
       style: {
         'text-decoration': 'line-through',
       },
     }),
-  mask: (node) =>
-    toVNode(node, 'span', {
+  mask: (node, context) =>
+    toVNode(node, 'span', context, {
       className: 'bgm-mask',
     }),
-  color: (node) =>
-    toVNode(node, 'span', {
+  color: (node, context) =>
+    toVNode(node, 'span', context, {
       style: {
         color: node.props!.color!,
       },
     }),
-  size: (node) =>
-    toVNode(node, 'span', {
+  size: (node, context) =>
+    toVNode(node, 'span', context, {
       style: {
         'font-size': node.props!.size! + 'px',
         'line-height': node.props!.size! + 'px',
       },
     }),
   url: convertUrlNode,
-  img: convertImgNode,
+  img: (node, context) => convertImgNode(node, context.options),
   sticker: convertStickerNode,
   quote: convertQuote,
   code: (node) => ({
     type: 'pre',
     children: node.children,
   }),
-  left: (node) =>
-    toVNode(node, 'p', {
+  left: (node, context) =>
+    toVNode(node, 'p', context, {
       style: {
         'text-align': 'left',
       },
     }),
-  right: (node) =>
-    toVNode(node, 'p', {
+  right: (node, context) =>
+    toVNode(node, 'p', context, {
       style: {
         'text-align': 'right',
       },
     }),
-  center: (node) =>
-    toVNode(node, 'p', {
+  center: (node, context) =>
+    toVNode(node, 'p', context, {
       style: {
         'text-align': 'center',
       },
     }),
-  indent: (node) => toVNode(node, 'blockquote', {}),
-  align: (node) =>
-    toVNode(node, 'p', {
+  indent: (node, context) => toVNode(node, 'blockquote', context),
+  align: (node, context) =>
+    toVNode(node, 'p', context, {
       style: {
         'text-align': node.props!.align!,
       },
     }),
-  float: (node) =>
-    toVNode(node, 'span', {
+  float: (node, context) =>
+    toVNode(node, 'span', context, {
       style: {
         float: node.props!.float!,
       },
     }),
-  subject: (node) =>
-    toVNode(node, 'a', {
+  subject: (node, context) =>
+    toVNode(node, 'a', context, {
       className: 'l',
     }),
   user: convertUser,
 };
 
-export function convert(
-  node: CodeNodeTypes,
-  converterMap: Record<string, ConverterFn> = {},
-): NodeTypes {
+export function convert(node: CodeNodeTypes, options: BBCodeRenderOptions = {}): NodeTypes {
   if (typeof node === 'string') {
     return node;
   }
-  let converterFn = converterMap[node.type];
-  if (!converterFn) {
-    converterFn = CONVERTER_FN_MAP[node.type];
-  }
+
+  const context: BBCodeConverterContext = {
+    options,
+    convert: (child) => convert(child, options),
+  };
+  const converterFn = options.converters?.[node.type] ?? CONVERTER_FN_MAP[node.type];
   if (converterFn) {
-    return converterFn(node);
+    return converterFn(node, context);
   }
   const vnode: VNode = {
     type: node.type,
   };
-  setVNodeChildren(vnode, node);
+  setVNodeChildren(vnode, node, context);
   return vnode;
 }

--- a/packages/utils/bbcode/html.ts
+++ b/packages/utils/bbcode/html.ts
@@ -1,7 +1,7 @@
 import { UnreadableCodeError } from '../index';
 import { convert } from './convert';
 import { Parser } from './parser';
-import type { CodeNodeTypes, ConverterFn, NodeTypes, VNode } from './types';
+import type { BBCodeRenderOptions, CodeNodeTypes, NodeTypes, VNode } from './types';
 
 const escapeHTML = (str: string): string =>
   str
@@ -83,11 +83,11 @@ export function renderNodes(nodes: NodeTypes[], parentNode?: VNode): string {
   return result;
 }
 
-export function render(rawStr: string, converterMap: Record<string, ConverterFn> = {}): string {
+export function render(rawStr: string, options: BBCodeRenderOptions = {}): string {
   let result = '';
-  const nodes: CodeNodeTypes[] = new Parser(rawStr).parse();
+  const nodes: CodeNodeTypes[] = new Parser(rawStr, options).parse();
   nodes.forEach((node) => {
-    result += renderNode(convert(node, converterMap));
+    result += renderNode(convert(node, options));
   });
   return result;
 }

--- a/packages/utils/bbcode/index.ts
+++ b/packages/utils/bbcode/index.ts
@@ -1,4 +1,6 @@
-export { render } from './react';
-export * from './parser';
 export { convert } from './convert';
+export { Parser } from './parser';
+export { BBCodePreset } from './presets';
+export type { BBCodePresetName } from './presets';
+export { render } from './react';
 export * from './types';

--- a/packages/utils/bbcode/parser.ts
+++ b/packages/utils/bbcode/parser.ts
@@ -1,21 +1,13 @@
 import { UnreadableCodeError } from '../index';
 import { BGM_STICKER_START_STR, EMOJI_ARRAY, MAX_EMOJI_LENGTH } from './constants';
-import type { CodeNodeTypes, CodeVNode } from './types';
+import type { BBCodeOptions, BBCodeTag, CodeNodeTypes, CodeVNode } from './types';
 
 const INVALID_NODE_MSG = 'invalid node';
 const INVALID_STICKER_NODE = 'invalid sticker node';
 
 type CheckCharFn = (str: string) => boolean;
-type Validator = (value: string | undefined, node: CodeVNode) => boolean;
 
-// 也许需要引入  Object schema validation
-export interface CustomTag {
-  name: string;
-  // 校验 props
-  schema: Record<string, Validator>;
-}
-
-type ITag = CustomTag | string;
+type ITag = BBCodeTag;
 
 // 只有一个 string child
 function getStringChild(node: CodeVNode): string | undefined {
@@ -31,11 +23,10 @@ function getNodeProp(node: CodeVNode, prop: string): string | undefined {
 
 function isValidUrl(str: string): boolean {
   try {
-    new URL(str);
-  } catch (e: unknown) {
+    return ['http:', 'https:'].includes(new URL(str).protocol);
+  } catch {
     return false;
   }
-  return true;
 }
 
 const DEFAULT_TAGS: ITag[] = [
@@ -122,7 +113,7 @@ const DEFAULT_TAGS: ITag[] = [
 ];
 
 // 合并 tag 配置。新的覆盖旧的
-export function mergeTags(tagList: ITag[], toMergeTags: ITag[]): ITag[] {
+function mergeTags(tagList: readonly ITag[], toMergeTags: readonly ITag[]): ITag[] {
   const results: ITag[] = [...toMergeTags];
   tagList.forEach((tag) => {
     let name = '';
@@ -151,14 +142,19 @@ export class Parser {
   private readonly ctxStack: Array<{ startIdx: number }>;
   private readonly tagStack: string[];
   private readonly validTags: ITag[];
+  private readonly parseBBCode: boolean;
+  private readonly parseStickers: boolean;
 
-  constructor(input: string, tags: ITag[] = []) {
+  constructor(input: string, options: BBCodeOptions = {}) {
     this.input = input;
     this.pos = 0;
     this.ctxStack = [];
     this.tagStack = [];
-    // 解析器支持的 tag; sticker 用来表示 Bangumi 的表情，不是 bbcode
-    this.validTags = mergeTags(DEFAULT_TAGS, tags);
+
+    const baseTags = options.tags ?? DEFAULT_TAGS;
+    this.validTags = mergeTags(baseTags, options.additionalTags ?? []);
+    this.parseBBCode = options.bbcode ?? true;
+    this.parseStickers = options.stickers ?? true;
   }
 
   parse(): CodeNodeTypes[] {
@@ -178,10 +174,10 @@ export class Parser {
     try {
       switch (this.curChar()) {
         case '(':
-          node = this.parseStickerNode();
+          node = this.parseStickers ? this.parseStickerNode() : this.parseText();
           break;
         case '[':
-          node = this.parseBBCodeNode();
+          node = this.parseBBCode ? this.parseBBCodeNode() : this.parseText();
           break;
         default:
           node = this.parseText();
@@ -296,7 +292,15 @@ export class Parser {
   }
 
   private parseText(): string {
-    return this.consumeWhile((c) => !['(', '['].includes(c));
+    return this.consumeWhile((c) => {
+      if (this.parseStickers && c === '(') {
+        return false;
+      }
+      if (this.parseBBCode && c === '[') {
+        return false;
+      }
+      return true;
+    });
   }
 
   private consumeWhile(checkFn: CheckCharFn): string {

--- a/packages/utils/bbcode/presets.ts
+++ b/packages/utils/bbcode/presets.ts
@@ -1,0 +1,38 @@
+import type { BBCodeOptions } from './types';
+
+const richContent = {
+  bbcode: true,
+  stickers: true,
+  images: 'display',
+} as const satisfies BBCodeOptions;
+
+const textDescription = {
+  bbcode: true,
+  stickers: false,
+  images: 'link',
+} as const satisfies BBCodeOptions;
+
+const textComment = {
+  bbcode: true,
+  stickers: true,
+  images: 'link',
+} as const satisfies BBCodeOptions;
+
+export const BBCodePreset = {
+  topic: richContent,
+  blog: richContent,
+  blogComment: richContent,
+  episodeComment: richContent,
+  groupDescription: textDescription,
+  userBio: textDescription,
+  indexDescription: {
+    bbcode: true,
+    stickers: false,
+    images: 'display',
+  },
+  indexComment: textComment,
+  characterComment: textComment,
+  personComment: textComment,
+} as const satisfies Record<string, BBCodeOptions>;
+
+export type BBCodePresetName = keyof typeof BBCodePreset;

--- a/packages/utils/bbcode/react.tsx
+++ b/packages/utils/bbcode/react.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { convert } from './convert';
 import { Parser } from './parser';
-import type { CodeNodeTypes, NodeTypes, VNode } from './types';
+import type { BBCodeRenderOptions, CodeNodeTypes, NodeTypes, VNode } from './types';
 
 /* eslint-disable no-useless-escape */
 const toCamelCase = (s: string) => s.replace(/(\-\w)/g, (k) => k[1]?.toUpperCase() ?? '');
@@ -66,8 +66,11 @@ export const renderNode = (node: NodeTypes, key?: React.Key): React.ReactElement
   return React.createElement(type, convertToReactProps(node, key));
 };
 
-export const render = (rawStr: string): Array<React.ReactElement | string> => {
-  const nodes: CodeNodeTypes[] = new Parser(rawStr).parse();
+export const render = (
+  rawStr: string,
+  options: BBCodeRenderOptions = {},
+): Array<React.ReactElement | string> => {
+  const nodes: CodeNodeTypes[] = new Parser(rawStr, options).parse();
 
-  return nodes.map((node, idx) => renderNode(convert(node, {}), idx));
+  return nodes.map((node, idx) => renderNode(convert(node, options), idx));
 };

--- a/packages/utils/bbcode/types.ts
+++ b/packages/utils/bbcode/types.ts
@@ -1,5 +1,33 @@
 export type TextNode = string;
 
+export type BBCodeImageMode = 'display' | 'link';
+
+export interface BBCodeOptions {
+  /** 是否解析 BBCode 标签 */
+  bbcode?: boolean;
+  /** 是否解析 Bangumi 表情代码 */
+  stickers?: boolean;
+  /** 图片标签显示为图片，或降级为链接 */
+  images?: BBCodeImageMode;
+  /** 精确指定允许的标签集合；默认使用全部内置标签 */
+  tags?: readonly BBCodeTag[];
+  /** 在允许的标签集合上追加或覆盖标签定义 */
+  additionalTags?: readonly BBCodeTag[];
+}
+
+export interface BBCodeRenderOptions extends BBCodeOptions {
+  converters?: Record<string, ConverterFn>;
+}
+
+export type BBCodeValidator = (value: string | undefined, node: CodeVNode) => boolean;
+
+export interface CustomBBCodeTag {
+  name: string;
+  schema: Record<string, BBCodeValidator>;
+}
+
+export type BBCodeTag = CustomBBCodeTag | string;
+
 export interface CodeVNode {
   type: string;
   props?: Record<string, string>;
@@ -18,4 +46,9 @@ export interface VNode {
 
 export type NodeTypes = string | VNode;
 
-export type ConverterFn = (node: CodeVNode) => NodeTypes;
+export interface BBCodeConverterContext {
+  options: BBCodeRenderOptions;
+  convert: (node: CodeNodeTypes) => NodeTypes;
+}
+
+export type ConverterFn = (node: CodeVNode, context: BBCodeConverterContext) => NodeTypes;

--- a/packages/website/src/mocks/fixtures/p1/persons/21884/comments-GET.json
+++ b/packages/website/src/mocks/fixtures/p1/persons/21884/comments-GET.json
@@ -1,1 +1,26 @@
-[]
+[
+  {
+    "id": 1,
+    "mainID": 21884,
+    "creatorID": 287622,
+    "relatedID": 0,
+    "createdAt": 1531631310,
+    "content": "[b]人物评论[/b](bgm38)\n[img]https://example.com/person-comment.png[/img]",
+    "state": 0,
+    "replies": [],
+    "user": {
+      "id": 287622,
+      "username": "trim21",
+      "nickname": "测试用户",
+      "avatar": {
+        "small": "",
+        "medium": "",
+        "large": ""
+      },
+      "group": 10,
+      "sign": "",
+      "joinedAt": 1463075630,
+      "isFriend": false
+    }
+  }
+]

--- a/packages/website/src/pages/index/blog/[id]/components/BlogCommentItem.tsx
+++ b/packages/website/src/pages/index/blog/[id]/components/BlogCommentItem.tsx
@@ -218,7 +218,11 @@ const BlogCommentItem: FC<BlogCommentItemProps> = ({
                 />
               </div>
             ) : (
-              <RichContent bbcode={comment.content} classname='blog-comment__content' />
+              <RichContent
+                bbcode={comment.content}
+                preset='blogComment'
+                classname='blog-comment__content'
+              />
             )}
             {showReplyEditor && (
               <div className={replyEditor}>

--- a/packages/website/src/pages/index/blog/[id]/index.tsx
+++ b/packages/website/src/pages/index/blog/[id]/index.tsx
@@ -148,7 +148,7 @@ const BlogEntryPage: FC = () => {
                 )}
               </header>
               <div className={entryContent}>
-                <RichContent bbcode={entry.content} />
+                <RichContent bbcode={entry.content} preset='blog' />
               </div>
               <BlogComments
                 entryId={entry.id}

--- a/packages/website/src/pages/index/character/[id]/CharacterDetail.tsx
+++ b/packages/website/src/pages/index/character/[id]/CharacterDetail.tsx
@@ -879,13 +879,21 @@ function CommentsSection({ comments }: { comments: CharacterComment[] }) {
                   {dayjs.unix(comment.createdAt).format('YYYY-M-D HH:mm')}
                 </time>
               </div>
-              <RichContent bbcode={comment.content} classname={commentContent} />
+              <RichContent
+                bbcode={comment.content}
+                preset='characterComment'
+                classname={commentContent}
+              />
               {comment.replies.length > 0 && (
                 <ul className={replyList}>
                   {comment.replies.map((reply) => (
                     <li key={reply.id}>
                       <strong>{reply.user?.nickname ?? '已注销用户'}</strong>
-                      <RichContent bbcode={reply.content} classname={replyContent} />
+                      <RichContent
+                        bbcode={reply.content}
+                        preset='characterComment'
+                        classname={replyContent}
+                      />
                     </li>
                   ))}
                 </ul>

--- a/packages/website/src/pages/index/ep/[id]/EpisodeDetail.tsx
+++ b/packages/website/src/pages/index/ep/[id]/EpisodeDetail.tsx
@@ -559,7 +559,7 @@ function CommentContent({ content, state }: { content: string; state: number }) 
   if (state === 7) {
     return <p className={deletedComment}>内容因违反社区指导原则已被删除</p>;
   }
-  return <RichContent bbcode={content} classname={commentContent} />;
+  return <RichContent bbcode={content} preset='episodeComment' classname={commentContent} />;
 }
 
 function CommentItem({

--- a/packages/website/src/pages/index/group/[name]/__tests__/fixtures/sandbox.json
+++ b/packages/website/src/pages/index/group/[name]/__tests__/fixtures/sandbox.json
@@ -13,7 +13,7 @@
   "topics": 6,
   "posts": 0,
   "members": 5,
-  "description": "[s]非[/s]官方沙盒",
+  "description": "[s]8.卖萌[/s]\n[color=red][size=25][b]不受理内容：[/b][/size]违规内容[/color]\n[user=sai]Sai[/user]\n[url=https://bgm.tv/group/topic/312100]收录范围[/url]\n(bgm38)\n[img]https://example.com/image.png[/img]",
   "accessible": true,
   "createdAt": 1531631310,
   "creator": {

--- a/packages/website/src/pages/index/group/[name]/__tests__/index.spec.tsx
+++ b/packages/website/src/pages/index/group/[name]/__tests__/index.spec.tsx
@@ -101,10 +101,29 @@ class GroupHomeTest {
   }
 }
 
-it('should match snapshot properly', async () => {
+it('renders the group description with its BBCode capabilities', async () => {
   const test = await GroupHomeTest.create('sandbox');
 
   await test.assertHeader('沙盒');
+  const deleted = test.page.getByText('8.卖萌');
+  expect(deleted).toHaveStyle({ textDecoration: 'line-through' });
+
+  const heading = test.page.getByText('不受理内容：');
+  expect(heading.tagName).toBe('STRONG');
+  expect(heading.parentElement).toHaveStyle({ fontSize: '25px' });
+  expect(heading.parentElement?.parentElement).toHaveStyle({ color: 'rgb(255, 0, 0)' });
+
+  expect(test.page.getByRole('link', { name: '@Sai' })).toHaveAttribute('href', '/user/sai');
+  expect(test.page.getByRole('link', { name: '收录范围' })).toHaveAttribute(
+    'href',
+    'https://bgm.tv/group/topic/312100',
+  );
+  expect(test.page.getByText('(bgm38)')).toBeInTheDocument();
+  expect(test.page.getByRole('link', { name: 'https://example.com/image.png' })).toHaveAttribute(
+    'href',
+    'https://example.com/image.png',
+  );
+  expect(test.page.queryByRole('img', { name: '(bgm38)' })).not.toBeInTheDocument();
 });
 
 // it('should list group members', async () => {

--- a/packages/website/src/pages/index/group/[name]/index/index.tsx
+++ b/packages/website/src/pages/index/group/[name]/index/index.tsx
@@ -5,6 +5,7 @@ import { Button, CollapsibleContent, Section } from '@bangumi/design';
 import { ArrowRightCircle } from '@bangumi/icons';
 import { css } from '@bangumi/styled-system/css';
 import { UnreadableCodeError } from '@bangumi/utils';
+import { BBCodePreset } from '@bangumi/utils/bbcode/presets';
 import { render as renderBBCode } from '@bangumi/utils/bbcode/react';
 import Helmet from '@bangumi/website/components/Helmet';
 import { useGroupTopics } from '@bangumi/website/hooks/use-group-topics';
@@ -41,7 +42,7 @@ const GroupHome: React.FC = () => {
     groupRet: { group, descriptionCollapsed, setDescriptionCollapsed },
   } = groupContext;
 
-  const parsedDescription = renderBBCode(group.description);
+  const parsedDescription = renderBBCode(group.description, BBCodePreset.groupDescription);
 
   return (
     <>

--- a/packages/website/src/pages/index/help/bbcode/index.tsx
+++ b/packages/website/src/pages/index/help/bbcode/index.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
 
 import { css } from '@bangumi/styled-system/css';
-import { render } from '@bangumi/utils';
+import { BBCodePreset } from '@bangumi/utils/bbcode/presets';
+import { render } from '@bangumi/utils/bbcode/react';
 import Helmet from '@bangumi/website/components/Helmet';
 import PageContainer from '@bangumi/website/components/PageContainer';
 
@@ -213,7 +214,7 @@ const BBCodeHelp: React.FC = () => {
               {value.trim() === '' ? (
                 <p className={previewEmpty}>输入内容后，这里会显示渲染效果。</p>
               ) : (
-                render(value)
+                render(value, BBCodePreset.topic)
               )}
             </div>
           </section>

--- a/packages/website/src/pages/index/indexes/components/IndexComments.tsx
+++ b/packages/website/src/pages/index/indexes/components/IndexComments.tsx
@@ -150,7 +150,7 @@ const CommentNode: React.FC<CommentNodeProps> = ({ comment, indexId, floor, muta
               onCancel={() => setEditing(false)}
             />
           ) : (
-            <RichContent bbcode={comment.content} classname={content} />
+            <RichContent bbcode={comment.content} preset='indexComment' classname={content} />
           )}
           {user && !isDeleted && !editing && (
             <div className={actions}>

--- a/packages/website/src/pages/index/indexes/components/IndexInfoCard.tsx
+++ b/packages/website/src/pages/index/indexes/components/IndexInfoCard.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import type { Index } from '@bangumi/client/client';
 import { Avatar, Typography } from '@bangumi/design';
 import { css } from '@bangumi/styled-system/css';
+import { BBCodePreset } from '@bangumi/utils/bbcode/presets';
 import { render as renderBBCode } from '@bangumi/utils/bbcode/react';
 import { getUserProfileLink } from '@bangumi/utils/pages';
 import { useIndexCollection } from '@bangumi/website/hooks/use-index-collection';
@@ -102,7 +103,7 @@ const IndexInfoCard: React.FC<{
   const { pending, add, remove } = useIndexCollection(index.id);
   const isCollected = index.collectedAt != null;
   const isOwner = user?.id === index.uid;
-  const parsedDescription = renderBBCode(index.desc);
+  const parsedDescription = renderBBCode(index.desc, BBCodePreset.indexDescription);
 
   const handleCollect = async () => {
     const success = isCollected ? await remove() : await add();

--- a/packages/website/src/pages/index/person/[id]/PersonDetail.spec.tsx
+++ b/packages/website/src/pages/index/person/[id]/PersonDetail.spec.tsx
@@ -111,6 +111,13 @@ describe('PersonDetail', () => {
     expect(screen.getByRole('heading', { name: /职业: 声优/ })).toBeInTheDocument();
     expect(screen.getByText(/日本の男性俳優/)).toBeInTheDocument();
 
+    // 人物评论支持 BBCode 和表情，但图片降级为链接
+    expect(screen.getByText('人物评论').tagName).toBe('STRONG');
+    expect(screen.getByRole('img', { name: '(bgm38)' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'https://example.com/person-comment.png' }),
+    ).toHaveAttribute('href', 'https://example.com/person-comment.png');
+
     // 最近演出角色
     expect(screen.getByRole('heading', { name: '最近演出角色' })).toBeInTheDocument();
     expect(screen.getAllByText('柴田').length).toBeGreaterThan(0);

--- a/packages/website/src/pages/index/person/[id]/PersonDetail.tsx
+++ b/packages/website/src/pages/index/person/[id]/PersonDetail.tsx
@@ -9,7 +9,7 @@ import type {
   PersonWork,
   SlimIndex,
 } from '@bangumi/client/client';
-import { Typography } from '@bangumi/design';
+import { RichContent, Typography } from '@bangumi/design';
 import { css, cx } from '@bangumi/styled-system/css';
 import {
   getCharacterLink,
@@ -719,7 +719,11 @@ function CommentList({ comments }: { comments: PersonHomeData['comments'] }) {
               )}{' '}
               <span>{dayjs.unix(comment.createdAt).format('YYYY-M-D HH:mm')}</span>
             </p>
-            <p className={commentContent}>{comment.content}</p>
+            <RichContent
+              bbcode={comment.content}
+              preset='personComment'
+              classname={commentContent}
+            />
           </div>
         </li>
       ))}

--- a/packages/website/src/pages/index/user/[username]/components/UserInfoCard.tsx
+++ b/packages/website/src/pages/index/user/[username]/components/UserInfoCard.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import type { User } from '@bangumi/client/client';
 import { OpenQuote } from '@bangumi/icons';
 import { css } from '@bangumi/styled-system/css';
+import { BBCodePreset } from '@bangumi/utils/bbcode/presets';
 import { render as renderBBCode } from '@bangumi/utils/bbcode/react';
 
 const card = css({
@@ -102,7 +103,7 @@ const UserInfoCard: React.FC<{ user: User }> = ({ user }) => {
       {user.bio && (
         <div className={bio}>
           <OpenQuote className={quoteIcon} />
-          <div className={bioText}>{renderBBCode(user.bio)}</div>
+          <div className={bioText}>{renderBBCode(user.bio, BBCodePreset.userBio)}</div>
         </div>
       )}
       <ul className={services}>


### PR DESCRIPTION
## Summary

Introduce a preset system for BBCode rendering so different content types get appropriate capabilities, and harden URL validation.

### BBCode package changes (`packages/utils/bbcode`)

- New `BBCodePreset` presets in `presets.ts`, covering topic/blog/comments (full features), descriptions (no stickers, images as links), and comment types (images downgraded to links).
- `Parser` now accepts `BBCodeOptions`: `tags` (exact allowed tag set), `additionalTags` (add/override tags), `bbcode`/`stickers` toggles, and `images: 'link'` to downgrade image tags to plain links.
- `convert`/`render` (html + react) accept `BBCodeRenderOptions` with a `converters` override map; custom converters now propagate to nested nodes via a converter context.
- URL protocol validation tightened to `http:`/`https:` only (rejects `javascript:`, `data:`, etc.).
- `mergeTags` and `CustomTag` made internal; new public API exported from `bbcode/index.ts`.

### Consumer migration

- `RichContent` now requires a `preset` prop; all 9 usages migrated (blog, character, ep, group, indexes, person, topic comment).
- Group description, user bio, and index description use the new description presets.
- Person comments upgraded from plain text to `RichContent` rendering.

### Tests

- bbcode: URL protocol rejection, exact tag set, disable bbcode/stickers, nested image-as-link, converters.
- Page-level assertions for group description and person comment presets; MSW fixture updated.

## Verification

- `bbcode` unit tests: 74/74 pass
- website page tests (group, person): pass
- `design` tests: 124/124 pass
- `pnpm type-check`, `pnpm lint`, Prettier: pass