### PR TITLE
fix(utils): treat unknown bbcode tags as plain text

### DIFF
--- a/packages/utils/bbcode/__test__/parser.test.ts
+++ b/packages/utils/bbcode/__test__/parser.test.ts
@@ -9,8 +9,8 @@ function getNodes(input: string): CodeNodeTypes[] {
 describe('bbcode parser', () => {
   test('text', () => {
     const input = '啊aあ\n)[bs][/bs]222';
-    const tests: CodeNodeTypes[] = ['啊aあ\n)', '[bs][/bs]', '222'];
-    expect(getNodes(input)).toEqual(expect.arrayContaining(tests));
+    // 未知标签 [bs] 不作为 bbcode 解析，整体按文本原样保留
+    expect(getNodes(input).join('')).toEqual(input);
   });
   test('bangumi sticker', () => {
     const input = '[(bgm38)[/(=A=)](=///=)(bgm01)';
@@ -292,7 +292,9 @@ describe('bbcode parser', () => {
   test('exact tag set', () => {
     const input = '[b]粗体[/b][i]斜体[/i]';
     const nodes = new Parser(input, { tags: ['b'] }).parse();
-    expect(nodes).toEqual([{ type: 'b', children: ['粗体'] }, '[i]斜体[/i]']);
+    // 只注册 b 时，[b] 正常解析，未注册的 [i] 按文本原样保留
+    expect(nodes[0]).toEqual({ type: 'b', children: ['粗体'] });
+    expect(nodes.slice(1).join('')).toEqual('[i]斜体[/i]');
   });
   test('disable bbcode and stickers', () => {
     const input = '[b]粗体[/b](bgm38)';
@@ -353,5 +355,24 @@ describe('bbcode parser', () => {
       },
     ];
     expect(getNodes(input)).toEqual(expect.arrayContaining(tests));
+  });
+  test('unknown tag inside valid tags is plain text and does not break outer tags', () => {
+    // [WIKI] 不是 bbcode 标签（帖主把标题文本前缀嵌进了链接文字），
+    // 不应让外层 [size]/[url] 因闭标签不匹配而整体回退为文本
+    const input =
+      '[size=20][url=https://bangumi.tv/group/topic/402872][WIKI] 常见编辑错误/注意事项汇总&争议讨论[/url][/size]';
+    expect(getNodes(input)).toEqual([
+      {
+        type: 'size',
+        props: { size: '20' },
+        children: [
+          {
+            type: 'url',
+            props: { url: 'https://bangumi.tv/group/topic/402872' },
+            children: ['[WIKI]', ' 常见编辑错误/注意事项汇总&争议讨论'],
+          },
+        ],
+      },
+    ]);
   });
 });

--- a/packages/utils/bbcode/parser.ts
+++ b/packages/utils/bbcode/parser.ts
@@ -234,6 +234,7 @@ export class Parser {
 
   // @TODO 暂时只支持 Bangumi 的 bbcode; 不支持 [style size="30px"]Large Text[/style]
   private parseBBCodeNode(): CodeNodeTypes {
+    const startIdx = this.pos; // 指向 '['
     let c = this.consumeChar();
     const openTag = this.parseTagName();
     c = this.consumeChar();
@@ -244,6 +245,11 @@ export class Parser {
     if (c === '=') {
       prop = this.consumeWhile((c) => c !== ']');
       c = this.consumeChar();
+    }
+    // 未知标签不是 bbcode 语法，按纯文本处理；不要进入闭标签配对，
+    // 否则不匹配的 [/xxx] 会导致外层标签连锁回退为文本
+    if (this.findTag(openTag) === -1) {
+      return this.input.slice(startIdx, this.pos);
     }
     if (openTag === 'code') {
       const codeEndTag = '[/code]';


### PR DESCRIPTION
## 问题

`group/topic/{id}` 页面中，只要正文出现一个未知标签（如 `[WIKI]`——这是维基区帖子标题的文本前缀，不是 BBCode 标签），**整段内容的 BBCode 会全部失效**，直接显示原始代码。

原因：`parseBBCodeNode` 对未知标签也会进入闭标签配对逻辑。`[WIKI]` 期望 `[/WIKI]`，但实际遇到 `[/url]` 时闭标签不匹配，回退为文本时 `pos` 不还原，`[/size]` 被当作普通文本消费，外层 `[url]`/`[size]` 找不到闭标签连锁回退，最终整个帖子渲染为纯文本。

## 修复

未知标签解析出 `openTag` 后直接按纯文本返回（`findTag(openTag) === -1` 时），不再进入闭标签配对逻辑。与老站（`ChiiCodeCore.php`）行为一致：非 BBCode 的方括号文本原样保留，相邻的有效标签正常渲染。

## 验证

- 新增回归测试：`[size=20][url=...][WIKI]...[/url][/size]` 结构正常解析
- `packages/utils` 全部 105 个测试通过
- 使用 BBCode 渲染的 website 测试 26 个通过
- eslint / prettier 通过