### PR TITLE
feat(utils): support musume/blake character stickers in BBCode

### DIFF
--- a/packages/utils/bbcode/__test__/convert.test.ts
+++ b/packages/utils/bbcode/__test__/convert.test.ts
@@ -379,6 +379,48 @@ describe('convert bbcode to html vnode', () => {
         {
           type: 'sticker',
           props: {
+            stickerId: '(musume_03)',
+          },
+        },
+        {
+          props: {
+            alt: '(musume_03)',
+            smileid: 'musume_03',
+            src: `${STICKER_DOMAIN_URL}/img/smiles/musume/musume_03.gif`,
+          },
+          style: {
+            'max-width': '55px',
+            height: 'auto',
+            'vertical-align': 'bottom',
+          },
+          type: 'img',
+        },
+      ],
+      [
+        {
+          type: 'sticker',
+          props: {
+            stickerId: '(blake_03)',
+          },
+        },
+        {
+          props: {
+            alt: '(blake_03)',
+            smileid: 'blake_03',
+            src: `${STICKER_DOMAIN_URL}/img/smiles/blake/blake_03.gif`,
+          },
+          style: {
+            'max-width': '55px',
+            height: 'auto',
+            'vertical-align': 'bottom',
+          },
+          type: 'img',
+        },
+      ],
+      [
+        {
+          type: 'sticker',
+          props: {
             stickerId: '(bgm233)',
           },
         },

--- a/packages/utils/bbcode/__test__/html.test.ts
+++ b/packages/utils/bbcode/__test__/html.test.ts
@@ -246,4 +246,12 @@ describe('html render bbcode string', () => {
     expect(render('(bgm38)')).toContain('/img/smiles/tv/15.gif');
     expect(render('(bgm11)')).toContain('/img/smiles/bgm/11.gif');
   });
+  test('should render character sticker', () => {
+    expect(render('(musume_03)')).toBe(
+      '<img src="https://lain.bgm.tv/img/smiles/musume/musume_03.gif" smileid="musume_03" alt="(musume_03)" style="max-width:55px;height:auto;vertical-align:bottom"/>',
+    );
+    expect(render('(blake_03)')).toBe(
+      '<img src="https://lain.bgm.tv/img/smiles/blake/blake_03.gif" smileid="blake_03" alt="(blake_03)" style="max-width:55px;height:auto;vertical-align:bottom"/>',
+    );
+  });
 });

--- a/packages/utils/bbcode/__test__/parser.test.ts
+++ b/packages/utils/bbcode/__test__/parser.test.ts
@@ -275,6 +275,32 @@ describe('bbcode parser', () => {
     const tests: CodeNodeTypes[] = ['(bgm', 'ab)', '(bgm38a'];
     expect(getNodes(input)).toEqual(expect.arrayContaining(tests));
   });
+  test('character sticker', () => {
+    const input = '(musume_03)(blake_03)(musume_97)(musume_118)';
+    expect(getNodes(input)).toEqual([
+      {
+        type: 'sticker',
+        props: { stickerId: '(musume_03)' },
+      },
+      {
+        type: 'sticker',
+        props: { stickerId: '(blake_03)' },
+      },
+      // musume 缺失 97、98，按文本保留（与无效 sticker 行为一致，拆为两节点）
+      '(',
+      'musume_97)',
+      {
+        type: 'sticker',
+        props: { stickerId: '(musume_118)' },
+      },
+    ]);
+  });
+  test('invalid character sticker', () => {
+    // 前导零 / 个位数编号不被识别
+    const input = '(blake_031)(musume_3)';
+    expect(getNodes(input)).toEqual(['(', 'blake_031)', '(', 'musume_3)']);
+    expect(getNodes(input).join('')).toEqual(input);
+  });
   test('invalid [code] /code] bbcode', () => {
     const input = '[code]测试中/code]';
     expect(getNodes(input).join('')).toEqual(input);

--- a/packages/utils/bbcode/constants.ts
+++ b/packages/utils/bbcode/constants.ts
@@ -22,3 +22,19 @@ export const EMOJI_ARRAY = [
 ];
 
 export const STICKER_DOMAIN_URL = 'https://lain.bgm.tv';
+
+// Bangumi 角色贴纸 (musume_XX)/(blake_XX)。id 范围与旧站 smilies_list 一致：
+// musume 缺失 97、98（这两个编号为 blake 专属）
+export const CHARACTER_STICKER_SETS = [
+  {
+    prefix: 'musume',
+    ranges: [
+      { start: 1, end: 96 },
+      { start: 99, end: 118 },
+    ],
+  },
+  {
+    prefix: 'blake',
+    ranges: [{ start: 1, end: 98 }],
+  },
+] as const;

--- a/packages/utils/bbcode/convert.ts
+++ b/packages/utils/bbcode/convert.ts
@@ -83,8 +83,34 @@ function convertUrlNode(node: CodeVNode, context: BBCodeConverterContext): VNode
   return convertLink(href, children);
 }
 
+// (musume_03)/(blake_03) 角色贴纸，图片为 240x240 大图，需限制显示宽度
+function convertCharacterStickerNode(stickerId: string): VNode {
+  const m = stickerId.match(/^\((musume|blake)_(\d+)\)$/);
+  if (!m) {
+    throw new UnreadableCodeError('BUG: unexpected sticker id', stickerId);
+  }
+  const [, prefix, id] = m;
+  const code = `${prefix}_${id}`;
+  return {
+    type: 'img',
+    props: {
+      src: `${STICKER_DOMAIN_URL}/img/smiles/${prefix}/${code}.gif`,
+      smileid: code,
+      alt: stickerId,
+    },
+    style: {
+      'max-width': '55px',
+      height: 'auto',
+      'vertical-align': 'bottom',
+    },
+  };
+}
+
 function convertStickerNode(node: CodeVNode): VNode | string {
   const stickerId = node.props!.stickerId!;
+  if (stickerId.startsWith('(musume_') || stickerId.startsWith('(blake_')) {
+    return convertCharacterStickerNode(stickerId);
+  }
   let id = -1;
   if (stickerId.startsWith(BGM_STICKER_START_STR)) {
     const m = stickerId.match(/\d+/)?.[0];

--- a/packages/utils/bbcode/parser.ts
+++ b/packages/utils/bbcode/parser.ts
@@ -1,5 +1,10 @@
 import { UnreadableCodeError } from '../index';
-import { BGM_STICKER_START_STR, EMOJI_ARRAY, MAX_EMOJI_LENGTH } from './constants';
+import {
+  BGM_STICKER_START_STR,
+  CHARACTER_STICKER_SETS,
+  EMOJI_ARRAY,
+  MAX_EMOJI_LENGTH,
+} from './constants';
 import type { BBCodeOptions, BBCodeTag, CodeNodeTypes, CodeVNode } from './types';
 
 const INVALID_NODE_MSG = 'invalid node';
@@ -201,6 +206,10 @@ export class Parser {
 
   private parseStickerNode(): CodeNodeTypes {
     if (!this.startsWith(BGM_STICKER_START_STR)) {
+      const characterSticker = this.parseCharacterStickerNode();
+      if (characterSticker !== undefined) {
+        return characterSticker;
+      }
       const target = this.input.slice(this.pos, this.pos + MAX_EMOJI_LENGTH);
       const emoji = EMOJI_ARRAY.find((s) => target.startsWith(s));
       if (!emoji) {
@@ -230,6 +239,38 @@ export class Parser {
         stickerId: `(bgm${id})`,
       },
     };
+  }
+
+  // (musume_03) 形式的角色贴纸；编号格式与旧站 %02d 一致且必须是有效 id
+  private parseCharacterStickerNode(): CodeNodeTypes | undefined {
+    for (const { prefix, ranges } of CHARACTER_STICKER_SETS) {
+      const startStr = `(${prefix}_`;
+      if (!this.startsWith(startStr)) {
+        continue;
+      }
+      const rest = this.input.slice(this.pos + startStr.length);
+      const m = rest.match(/^(\d{2,3})\)/);
+      if (!m) {
+        continue;
+      }
+      const idStr = m[1]!;
+      const id = parseInt(idStr, 10);
+      // 拒绝前导零（如 musume_031），旧站只识别 %02d 格式的编号
+      if (idStr !== String(id).padStart(2, '0')) {
+        continue;
+      }
+      if (!ranges.some(({ start, end }) => id >= start && id <= end)) {
+        continue;
+      }
+      this.pos += startStr.length + idStr.length + 1; // +1 消费 ')'
+      return {
+        type: 'sticker',
+        props: {
+          stickerId: `(${prefix}_${idStr})`,
+        },
+      };
+    }
+    return undefined;
   }
 
   // @TODO 暂时只支持 Bangumi 的 bbcode; 不支持 [style size="30px"]Large Text[/style]


### PR DESCRIPTION
## What

The BBCode parser only recognized `(bgmNN)` stickers and text emoticons like `(=A=)`, so character stickers such as `(musume_03)` and `(blake_03)` were rendered as plain text.

This PR adds support for them, matching the legacy implementation in `Bangumi/public/core/ChiiCodeCore.php` (`initCharacterSmilies`) and `public/js/editor/sets/bbcode/set.js`:

- `(musume_XX)` → `https://lain.bgm.tv/img/smiles/musume/musume_XX.gif` (valid ids: 1-96, 99-118; 97/98 are blake-only)
- `(blake_XX)` → `https://lain.bgm.tv/img/smiles/blake/blake_XX.gif` (valid ids: 1-98)

These GIFs are 240×240, so an inline `max-width: 55px` style is applied (same as the legacy `img.smile-dynamic` rule) to avoid oversized rendering.

## Changes

- `packages/utils/bbcode/constants.ts`: add `CHARACTER_STICKER_SETS` with valid id ranges per prefix
- `packages/utils/bbcode/parser.ts`: parse `(musume_XX)`/`(blake_XX)` into sticker nodes; reject leading zeros and out-of-range ids (rendered as plain text, consistent with the legacy site)
- `packages/utils/bbcode/convert.ts`: render character stickers as `<img>` with the proper URL and size constraint
- Tests for parser, converter and HTML renderer

## Verification

- `vitest run packages/utils/bbcode`: 78 tests passed
- `pnpm type-check`: passed
- ESLint & Prettier: passed